### PR TITLE
Five doc comments drop the spec tags they still carried

### DIFF
--- a/Candela/Settings/AdvancedPage.swift
+++ b/Candela/Settings/AdvancedPage.swift
@@ -2,7 +2,7 @@ import CandelaKit
 import SwiftUI
 
 /// One external display's Advanced sub-page (spec §6): the settings most
-/// displays never need, plus the escape hatches A1 promoted out of
+/// displays never need, plus the escape hatches promoted out of
 /// `defaults write`.
 ///
 /// `@MainActor` because a `View`'s properties other than `body` are nonisolated

--- a/Candela/Settings/CommandTuningGrid.swift
+++ b/Candela/Settings/CommandTuningGrid.swift
@@ -36,7 +36,7 @@ enum DDCCommandCopy {
 
 /// Per-command DDC tuning for one display: Enabled / Min / Max / Invert for
 /// brightness, volume and contrast. The response curve and the hex
-/// control-code remap live in the Advanced page's VCP Overrides sub-group (A1)
+/// control-code remap live in the Advanced page's VCP Overrides sub-group
 /// below, and that page owns the section header and its traffic-block
 /// explanation, so neither is drawn here.
 ///

--- a/Candela/Settings/DisplayHeroView.swift
+++ b/Candela/Settings/DisplayHeroView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// The lit opening of a display's page: the display drawn as an object,
 /// the identity block under it, and the live levels on their own card.
 ///
-/// The glyph earns its place by being functional (A4). It carries the display's
+/// The glyph earns its place by being functional. It carries the display's
 /// real shape: aspect ratio straight off the current mode, which is why a
 /// display mounted at 270° renders TALL with no rotation transform anywhere
 /// (`CGDisplayCopyDisplayMode` reports the rotated logical size, so the shape IS

--- a/CandelaKit/Tests/CandelaKitTests/ArrangementGeometryTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ArrangementGeometryTests.swift
@@ -99,7 +99,7 @@ struct CanvasTransformTests {
     CanvasTransform.fitting(arrangement.bounds, in: Self.canvas, margin: Self.margin, headroom: Self.headroom)
   }
 
-  /// A spread of fits, so R1/R2 are not pinned to one lucky scale: a real L, a small
+  /// A spread of fits, so the round trips are not pinned to one lucky scale: a real L, a small
   /// panel, a bounds far larger than any desktop (worst float error), a scale above 1.
   private var transforms: [CanvasTransform] {
     [

--- a/site/src/components/GlanceBand.css
+++ b/site/src/components/GlanceBand.css
@@ -1,6 +1,6 @@
 /* The features at a glance: six beats sitting on one continuous rail that
    runs the full viewport width, entering from one edge and leaving by the
-   other. Explicitly not cards (SR10): no boxes, no surfaces, one line and six
+   other. Explicitly not cards: no boxes, no surfaces, one line and six
    stations on it. */
 
 .glance {


### PR DESCRIPTION
## What

Removes a design-ruling number from five doc comments: two settings views, the display hero view, one geometry test and the glance band's stylesheet. Each comment now says the thing itself.

## Why

The release sweep rewrote these references out of the tree but missed these five. The numbers point at documents that are not in this repository, so to a reader here they are noise.

## Hardware verification

Comment-only change; no code or behaviour touched. No tests affected.

## Checks

- [x] `make check` unaffected (no Swift changed beyond comments)
- [x] Tests cover the new logic, or it is hardware-only and says so above
- [x] No ticket numbers in source comments, and no em dashes in user-visible text or new comments