### PR TITLE
docs: the tested hardware table the README promised

### DIFF
--- a/.github/ISSUE_TEMPLATE/hardware_report.yml
+++ b/.github/ISSUE_TEMPLATE/hardware_report.yml
@@ -9,7 +9,10 @@ body:
         Monitors differ more than their spec sheets suggest, and the
         development setup has two of them. A report on a panel we have never
         seen is one of the most useful things you can send, whether or not
-        anything is broken.
+        anything is broken. The
+        [tested hardware table](https://github.com/Rydersel/Candela/blob/main/docs/HARDWARE.md)
+        lists what has been reported so far; a monitor that is already there
+        and behaves differently for you is still worth a report.
 
         Everything below is visible on the display's Diagnostics page:
         Settings, the display in the sidebar, then Diagnostics.

--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ Some features (mode switching, virtual displays, the HDR toggle, menu-bar auto-h
 
 ## Tested hardware
 
-Every release is tested on as many different displays, connections and Macs as we can get our hands on, but no two setups are alike. If something misbehaves on yours, [open an issue](https://github.com/Rydersel/Candela/issues/new/choose) with your Mac, macOS version, monitor model and how it is connected, and we will look at it as soon as we can. A working setup is worth reporting too: it goes into the verified hardware list.
+Every release is tested on as many different displays, connections and Macs as we can get our hands on, but no two setups are alike. If something misbehaves on yours, [open an issue](https://github.com/Rydersel/Candela/issues/new/choose) with your Mac, macOS version, monitor model and how it is connected, and we will look at it as soon as we can. A working setup is worth reporting too: it goes into the [tested hardware table](docs/HARDWARE.md).
 
 ## Documentation
 
 - [User guides](docs/guide/index.md): OLED care, checkup, resolutions, the Diagnostics page, and advanced settings.
 - [Advanced settings](docs/ADVANCED-SETTINGS.md): the `defaults write` keys behind the escape hatches.
+- [Tested hardware](docs/HARDWARE.md): the monitors, connections and Macs Candela has been used on, one row per report.
 - [Contributing](CONTRIBUTING.md): building from source, running the suites, and what a change is expected to state about its own verification.
 
 ## Credits

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,0 +1,26 @@
+# Tested hardware
+
+The monitors, connections and Macs Candela has been used on, one row per
+monitor and connection. Rows come from
+[hardware reports](https://github.com/Rydersel/Candela/issues/new?template=hardware_report.yml)
+and from the maintainers' own displays; the columns match what the report form
+asks for, so a report becomes a row without translation.
+
+Every row is self-reported: the person who filed it observed the behaviour on
+their own panel. Maintainers do not re-verify rows they cannot reproduce. If
+your monitor is here and behaves differently for you, that difference is
+exactly what a report is for.
+
+The capability columns say what actually changed the display, not what the
+spec sheet promises. `yes` means the control worked, `no` means it did
+nothing, `n/a` means the monitor declares that it has no such control, and
+`not tried` means nobody has checked yet. **DDC reads** is the "Reading values
+back" line on the display's Diagnostics page: a monitor that answers reads
+lets Candela confirm what it set, and one that does not is driven blind, with
+Candela remembering the last value it wrote.
+
+| Monitor | Panel | Connection | Mac | macOS | Candela | Brightness | Volume | Contrast | HDR toggle | DDC reads |
+|---|---|---|---|---|---|---|---|---|---|---|
+| MSI MAG 341CQP QD-OLED (reports as "MAG 341C OLED") | 34 inch QD-OLED, 3440 x 1440, 175 Hz | DisplayPort | MacBook Pro 14 inch (M1 Pro, 2021) | 26.6 | 1.0.0 | yes | yes | yes | yes | no |
+| MSI MAG 341CQP QD-OLED (reports as "MAG 341C OLED") | 34 inch QD-OLED, 3440 x 1440, 175 Hz | USB-C / Thunderbolt, direct | MacBook Pro 14 inch (M1 Pro, 2021) | 26.6 | 1.0.0 | yes | yes | yes | yes | no |
+| Dell U2725QE (reports as "DELL U2725QE") | 27 inch IPS Black, 3840 x 2160, 120 Hz | Thunderbolt 5, direct | MacBook Pro 14 inch (M1 Pro, 2021) | 26.6 | 1.0.0 | yes | n/a | yes | not tried | yes |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,15 @@
 # What is in `docs/`
 
-Two things. `guide/` is written for people using the app; the other is a
-reference for anyone reading or changing the code. The rest of the user-facing
-documentation is the repository README and the site.
+`guide/` and `HARDWARE.md` are written for people using the app;
+`ADVANCED-SETTINGS.md` is a reference for anyone reading or changing the code.
+The rest of the user-facing documentation is the repository README and the
+site.
 
 | path | what it is |
 |---|---|
 | `guide/` | The user guides: resolutions, OLED care, the checkup, diagnostics, and the settings that have no user interface. `guide/index.md` is the entry point, and the repository README links to it. |
 | `ADVANCED-SETTINGS.md` | Settings with no user interface, driven by `defaults write`, plus the reserved key names that deliberately do nothing yet. |
+| `HARDWARE.md` | The tested hardware table: monitors, connections and Macs, one row per hardware report, with what worked on each. |
 
 Hardware verification is not published here. Every feature is checked on real
 displays before it merges, and `CONTRIBUTING.md` says what a change is expected


### PR DESCRIPTION
The README and the hardware-report template both pointed at a verified hardware list that did not exist. `docs/HARDWARE.md` is that table, seeded with the two development panels, with the columns matching the report form so a report becomes a row without translation. The README, the docs index and the template link to it.

One cell is left as `not tried`: whether the HDR toggle works on the Dell U2725QE is not in the records. Overwrite it in review if you have checked.

Closes #4

## Hardware verification

None. Documentation only; the seed rows restate measurements already recorded on the two development panels.