### PR TITLE
Docs and site changes skip the macOS pipeline; the site gets its own check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,16 +24,35 @@ on:
   # PR's branch. macOS runner minutes are the expensive ones here, so a
   # duplicate run would be the costliest thing in the pipeline and would buy no
   # signal at all.
+  #
+  # paths-ignore holds only what no job below reads. Keep the push and
+  # pull_request lists identical.
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'site/**'
+      - 'LICENSE'
+      - '.github/assets/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/workflows/site.yml'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'site/**'
+      - 'LICENSE'
+      - '.github/assets/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/workflows/site.yml'
   workflow_dispatch:
 
-# No `paths:` filter, deliberately. A hand-maintained path list goes stale the
-# first time a check grows, and the engine's tests cover types the app target
-# consumes, so a filter that misses a path lets a real break through as green.
-# The suite is well under a minute, so always running it is simpler and safer.
+# `paths-ignore:`, never `paths:`. A stale allow-list hides a real break as
+# green; a stale ignore-list only costs one extra run.
 
 permissions:
   contents: read

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,53 @@
+# Split from build-and-test.yml so a site change never spends macOS runner
+# minutes; that workflow ignores site/ in return.
+name: Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/site.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  site:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      # The build is part of the check because the prerender script runs at
+      # build time and is where a broken import or a bad asset path surfaces.
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## What

`build-and-test.yml` gains a `paths-ignore` list for everything none of its jobs read: Markdown, `docs/`, `site/`, licence text, templates and the README assets. A new `site.yml` runs the landing site's lint, tests and production build on a Linux runner, triggered only by `site/` changes.

## Why

The last merge was a one-line README change and it ran the three macOS jobs four times (three pull request runs, one on main). Meanwhile the site had no CI at all: a `site/` change spent twelve macOS-runner minutes compiling Swift and never ran its own tests.

`paths-ignore` rather than `paths`, deliberately: a stale allow-list would hide a real break as green, while a stale ignore-list only costs one extra run. A comment-only Swift change still runs everything; there is no safe way to tell a comment from code without building.

Note for later: if the ruleset ever makes these checks required, a PR whose paths skip the workflow shows no check and cannot merge. The fix then is a twin workflow with the same job names that passes on the ignored paths.

## Hardware verification

Workflow-only change; no app code touched. This PR itself exercises the new site workflow (the change touches `site.yml`) and should show no macOS jobs, since only workflow files under the ignore list changed... except that `build-and-test.yml` itself is not ignored, so the Swift pipeline runs once more here as a final baseline.

## Checks

- [x] `make check` unaffected (no Swift changed)
- [x] Tests cover the new logic, or it is hardware-only and says so above
- [x] No ticket numbers in source comments, and no em dashes in user-visible text or new comments