### PR TITLE
site: a Terms page, in the privacy page's voice

### DIFF
--- a/site/scripts/prerender.mjs
+++ b/site/scripts/prerender.mjs
@@ -117,6 +117,12 @@ export function privacyMetadata(html) {
   return pageMetadata(html, { title: 'Privacy | Candela', description: privacyDescription, path: '/privacy/' })
 }
 
+const termsDescription = "The terms for candela.fyi, the Candela downloads and the app's update feed, in plain words: who publishes Candela, what the MIT license covers, and what to expect from a tool that adjusts display hardware."
+
+export function termsMetadata(html) {
+  return pageMetadata(html, { title: 'Terms | Candela', description: termsDescription, path: '/terms/' })
+}
+
 const guidesIndexTitle = 'Guides | Candela'
 const guidesIndexDescription = 'Guides to looking after a display on a Mac: what wears a panel, how to check one for defects, and how to get the controls macOS leaves out.'
 
@@ -286,6 +292,11 @@ export async function prerender({ siteRoot = new URL('../', import.meta.url) } =
       path: '/privacy/',
       kind: 'page',
       html: rebaseNestedAssets(privacyMetadata(injectAppMarkup(shell, render('/privacy/', guides))), 1),
+    },
+    {
+      path: '/terms/',
+      kind: 'page',
+      html: rebaseNestedAssets(termsMetadata(injectAppMarkup(shell, render('/terms/', guides))), 1),
     },
     {
       path: '/guides/',

--- a/site/scripts/prerender.test.mjs
+++ b/site/scripts/prerender.test.mjs
@@ -13,6 +13,7 @@ import {
   pageMetadata,
   privacyMetadata,
   rebaseNestedAssets,
+  termsMetadata,
   validatePageHtml,
   validateSeoOutput,
 } from './prerender.mjs'
@@ -109,6 +110,18 @@ test('buildSitemap lists every page and dates the ones that carry a date', () =>
   assert.match(sitemap, /<url>\n    <loc>https:\/\/candela\.fyi\/guides\/oled-burn-in-mac\/<\/loc>\n    <lastmod>2026-09-03<\/lastmod>\n  <\/url>/)
   assert.doesNotMatch(sitemap, /<loc>https:\/\/candela\.fyi\/privacy\/<\/loc>\n    <lastmod>/)
   assert.match(sitemap, /<\/urlset>\n$/)
+})
+
+test('termsMetadata gives the terms page its own canonical identity', () => {
+  const shell = '<title>Landing</title><meta name="description" content="Landing description" /><link rel="canonical" href="https://candela.fyi/" /><meta property="og:url" content="https://candela.fyi/" /><meta property="og:title" content="Landing" /><meta property="og:description" content="Landing description" /><meta name="twitter:title" content="Landing" /><meta name="twitter:description" content="Landing description" />\n      <script type="application/ld+json">{"@type":"SoftwareApplication"}</script>'
+  const result = termsMetadata(shell)
+  assert.match(result, /<title>Terms \| Candela<\/title>/)
+  assert.match(result, /rel="canonical" href="https:\/\/candela\.fyi\/terms\/"/)
+  assert.match(result, /property="og:url" content="https:\/\/candela\.fyi\/terms\/"/)
+  assert.match(result, /property="og:title" content="Terms \| Candela"/)
+  assert.match(result, /content="The terms for candela\.fyi, the Candela downloads/)
+  assert.doesNotMatch(result, /SoftwareApplication/)
+  assert.doesNotMatch(result, /Landing/)
 })
 
 test('privacyMetadata gives the public disclosure its own canonical identity', () => {

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -12,6 +12,7 @@ import { Trust } from './components/Trust'
 import { Faq } from './components/Faq'
 import { Footer } from './components/Footer'
 import { PrivacyPage } from './PrivacyPage'
+import { TermsPage } from './TermsPage'
 import { GuidePage } from './GuidePage'
 import { GuidesIndexPage } from './GuidesIndexPage'
 import type { Guide } from './guides'
@@ -69,6 +70,7 @@ function LandingPage() {
 export default function App({ pathname = '/', guides = [] }: { pathname?: string; guides?: Guide[] }) {
   const path = pathname.replace(/\/+$/, '')
   if (path === '/privacy') return <PrivacyPage />
+  if (path === '/terms') return <TermsPage />
   if (path === '/guides') return <GuidesIndexPage guides={guides} />
   const guide = guides.find((entry) => `/guides/${entry.slug}` === path)
   if (guide) return <GuidePage guide={guide} guides={guides} />

--- a/site/src/TermsPage.tsx
+++ b/site/src/TermsPage.tsx
@@ -1,0 +1,85 @@
+import { Header } from './components/Header'
+import { Footer } from './components/Footer'
+import { terms } from './content/copy'
+// Shared with the privacy page; a second copy of this CSS would drift.
+import './components/Privacy.css'
+
+const repoBase = 'https://github.com/Rydersel/Candela/blob/main'
+
+export function TermsPage() {
+  return (
+    <>
+      <Header homeHref="/" faqHref="/#faq" />
+      <main id="content" className="privacy-page terms-page">
+        <article className="privacy-article">
+          <header className="privacy-intro">
+            <p className="privacy-kicker">{terms.kicker}</p>
+            <h1>{terms.h1}</h1>
+            <p className="privacy-lead">{terms.lead}</p>
+            <p className="privacy-effective">{terms.effective}</p>
+          </header>
+
+          <section className="privacy-section">
+            <h2>{terms.who.h2}</h2>
+            {terms.who.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </section>
+
+          <section className="privacy-section">
+            <h2>{terms.license.h2}</h2>
+            {terms.license.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </section>
+
+          <section className="privacy-section">
+            <h2>{terms.hardware.h2}</h2>
+            {terms.hardware.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </section>
+
+          <div className="privacy-columns">
+            <section className="privacy-section">
+              <h2>{terms.countOn.h2}</h2>
+              <ul>{terms.countOn.items.map((item) => <li key={item}>{item}</li>)}</ul>
+            </section>
+            <section className="privacy-section">
+              <h2>{terms.agreeTo.h2}</h2>
+              <ul>{terms.agreeTo.items.map((item) => <li key={item}>{item}</li>)}</ul>
+            </section>
+          </div>
+
+          <section className="privacy-section">
+            <h2>{terms.updates.h2}</h2>
+            {terms.updates.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </section>
+
+          <section className="privacy-section">
+            <h2>{terms.warranty.h2}</h2>
+            {terms.warranty.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </section>
+
+          <section className="privacy-section">
+            <h2>{terms.site.h2}</h2>
+            {terms.site.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </section>
+
+          <section className="privacy-section">
+            <h2>{terms.changes.h2}</h2>
+            {terms.changes.body.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          </section>
+
+          <section className="privacy-section privacy-source">
+            <p className="privacy-kicker">Public by design</p>
+            <h2>Read the documents these terms point to</h2>
+            <p>{terms.source}</p>
+            <ul>
+              <li><a href={`${repoBase}/LICENSE`}>MIT license</a></li>
+              <li><a href={`${repoBase}/THIRD-PARTY-LICENSES.md`}>Third-party credits</a></li>
+              <li><a href={`${repoBase}/SECURITY.md`}>Security policy</a></li>
+              <li><a href="/privacy/">Privacy page</a></li>
+              <li><a href={`${repoBase}/site/src/TermsPage.tsx`}>This Terms page</a></li>
+            </ul>
+          </section>
+        </article>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -24,6 +24,7 @@ export function Footer({ placement = 'footer' }: { placement?: 'footer' | 'guide
             {navigation.guides}
           </a>
           <a className="footer-link" href="/privacy/">Privacy</a>
+          <a className="footer-link" href="/terms/">Terms</a>
         </div>
       </div>
     </footer>

--- a/site/src/components/Privacy.css
+++ b/site/src/components/Privacy.css
@@ -40,6 +40,13 @@
   text-wrap: pretty;
 }
 
+.privacy-effective {
+  margin-top: 1rem;
+  color: var(--text-dim);
+  font-size: var(--fs-small);
+  font-variant-numeric: tabular-nums;
+}
+
 .privacy-control {
   display: flex;
   align-items: center;

--- a/site/src/content/copy.ts
+++ b/site/src/content/copy.ts
@@ -400,3 +400,76 @@ export const privacy = {
   ],
   source: "Candela is public, including the analytics implementation. The Functions, schema, retention Worker, report command and this disclosure can all be inspected in the source code.",
 }
+
+// Terms: for a stranger deciding whether to trust a download from an
+// independent developer.
+export const terms = {
+  kicker: "Candela website and app",
+  h1: "Terms, in plain words.",
+  lead: "Candela is made and published by Ryder Selikow, an independent developer. These terms cover candela.fyi, the downloads it links to, and the update feed the app checks. The app itself is open source under the MIT license, which is the document that governs copying, changing and redistributing it.",
+  effective: "Effective 2 September 2026.",
+  who: {
+    h2: "Who is behind Candela",
+    body: [
+      "Ryder Selikow, working independently, not a company. The source code, the release history and every hardware finding behind the app are public at github.com/Rydersel/Candela.",
+      "Questions, problems and requests go to ryder@candela.fyi. Security reports have their own path, described in the repository's SECURITY.md.",
+    ],
+  },
+  license: {
+    h2: "The software is MIT licensed",
+    body: [
+      "Candela is free. There is no paid tier, no account and no subscription, and nothing on this site asks you to create one. You may use, copy, modify and redistribute the app under the MIT license, whose full text ships with every download and sits in the repository as LICENSE. Portions derived from other open source projects are credited in THIRD-PARTY-LICENSES.md.",
+      "The MIT license is the legal document for the software. Where these terms and the license say different things about the software, the license wins.",
+    ],
+  },
+  hardware: {
+    h2: "Your display hardware",
+    body: [
+      "Candela changes settings on your monitor. It sends DDC/CI commands over the display cable to adjust brightness, contrast, volume, input and related controls, applies software dimming, can create virtual displays, and records how your panel is used so it can report wear. By running it, you accept that it will change what your display is doing.",
+      "Monitors implement DDC/CI inconsistently. Some ignore commands, some report values they do not honour, and some misbehave. Candela is built to verify what actually happened and to be reversible: Safe Mode exists, risky changes ask for confirmation and revert on their own, and one feature was removed before release because it could blank a panel with no recovery from inside the app. That is care, not a guarantee. Candela cannot promise how a given display will respond, and you use it with your own hardware at your own risk.",
+    ],
+  },
+  countOn: {
+    h2: "What you can count on",
+    items: [
+      "No account, no sign-in and no payment, on this site or in the app.",
+      "Display analysis runs on your Mac. The app uploads no screen content and no display-health record.",
+      "Downloads come only from the GitHub release page and the Homebrew tap, signed with a Developer ID and notarized by Apple.",
+      "The website's analytics are first-party and anonymous, and you can turn them off. The Privacy page describes exactly what is recorded.",
+    ],
+  },
+  agreeTo: {
+    h2: "What you agree to",
+    items: [
+      "You use the app and the site as they are, with your own hardware, at your own risk.",
+      "You follow the MIT license when you copy, change or redistribute the software.",
+      "You do not present a modified build as the official Candela release, and you do not use the site or the app to break the law or someone else's rights.",
+      "You do not attack, scrape or overload candela.fyi, including its analytics and update endpoints.",
+    ],
+  },
+  updates: {
+    h2: "Updates",
+    body: [
+      "The app checks candela.fyi for new versions. That request carries no account and no information about your display. Each update is signed with a key the app verifies before installing, is notarized by Apple before it is published, and the app asks before installing one.",
+    ],
+  },
+  warranty: {
+    h2: "No warranty, and the limits of liability",
+    body: [
+      "Candela and candela.fyi are provided as they are, without warranty of any kind, express or implied, including any warranty of merchantability, fitness for a particular purpose and non-infringement. To the extent the law allows, Ryder Selikow is not liable for any claim, damage or other liability arising from the software or the site, including damage to a display or other hardware, whether in contract, tort or otherwise. This restates the MIT license's disclaimer in plain words; the license text controls for the software.",
+    ],
+  },
+  site: {
+    h2: "The website",
+    body: [
+      "candela.fyi exists to describe the app, link to its downloads and host the update feed. Its pages, guides and images are written by the developer and may change or be removed at any time. The Candela name and icon identify this project and its official releases.",
+    ],
+  },
+  changes: {
+    h2: "Changes to these terms",
+    body: [
+      "This page can change. The effective date above moves when it does, and because the site lives in the public repository, every revision is in the commit history with its reason. Continuing to use the site or the app after a change means the current terms apply.",
+    ],
+  },
+  source: "This page is part of the public repository, next to the license, the third-party credits and the security policy it refers to.",
+}


### PR DESCRIPTION
## What

A Terms page at `/terms/`, pre-rendered like `/privacy/` and linked from the footer next to Privacy. It names the person behind Candela and the contact address, points at the MIT license as the document that governs the software, and says plainly that the app changes display settings over DDC/CI and what that does and does not promise. Same layout and stylesheet as the privacy page so the two legal pages read as one family.

## Why

A site that asks people to download and run software that talks to their monitor should say who stands behind it and on what terms. Privacy covered the data side; this covers the rest, and the two pages now point at each other.

## Verification

- `scripts/check-copy.sh` passes (no em dashes in site copy).
- `node --test scripts/prerender.test.mjs` passes, with a new test giving `/terms/` its own canonical identity (title, canonical, og:url, no inherited structured data).
- `npm run build` succeeds; `dist/terms/index.html` renders with its title, all nine sections, and the footer link; the sitemap lists `/terms/`.
- Rendered output checked in `vite preview`.

## Hardware verification

None required; this is a website page. Verification is the build output and the rendered page above.

## After merge

Deploy the site so `candela.fyi/terms/` goes live (the contact address on the page, ryder@candela.fyi, is already routed).