### PR TITLE
readme: the header protects your displays, and names the controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Candela</h1>
 
 <p align="center">
-  <b>Candela looks after your displays.</b><br>
-  Panel health, burn-in protection, a checkup for defects and wear, and the everyday controls macOS leaves out.<br>
+  <b>Candela protects your displays from burn-in and wear.</b><br>
+  Panel health, a checkup for defects, and the monitor controls macOS leaves out (brightness, volume, HiDPI scaling).<br>
   Free and open source, for macOS.
 </p>
 


### PR DESCRIPTION
Two lines in the README header, matching the wording now used on the repository description, the AlternativeTo listing and the launch post:

- The bold line becomes "Candela protects your displays from burn-in and wear." (protects rather than looks after).
- The line under it becomes "Panel health, a checkup for defects, and the monitor controls macOS leaves out (brightness, volume, HiDPI scaling).": no longer repeats protection, and says what the controls are instead of calling them everyday.

Nothing else changes.