### PR TITLE
panel: a care line under each enrolled display's name

### DIFF
--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -468,6 +468,14 @@ final class OledCareCoordinator: CheckupCareHolding {
       observationEnabled: observing)
   }
 
+  /// Loads the exposure map and per-app hours through the sampling path's own
+  /// accessors, so later samples fold into the accumulator surfaces read.
+  /// No-op once either is live.
+  private func warmHealthStores(for key: String) {
+    _ = exposureAccumulator(for: key)
+    _ = ownerHoursAccumulator(for: key)
+  }
+
   /// The raw map, live accumulator first. The health summary normalizes and drops
   /// `firstSample`, both of which the provenance record needs.
   func exposureMap(for persistenceKey: String) -> ExposureMap {
@@ -695,6 +703,11 @@ final class OledCareCoordinator: CheckupCareHolding {
         dropState(for: key)
         continue
       }
+      // The panel body reads this summary, and a key with no live accumulator
+      // decodes the stored map on menu open. Warmed here, not at the menu's own
+      // refresh, which runs on close and misses a display enrolled between one
+      // close and the next open.
+      warmHealthStores(for: key)
       let config = OledDimConfig(prefs: prefs)
       if var existing = states[key] {
         existing.engine.updateConfig(config)

--- a/Candela/Panel/PanelView.swift
+++ b/Candela/Panel/PanelView.swift
@@ -79,7 +79,8 @@ struct PanelView: View {
               // Asked of the engine that owns the pairing: a catalog refresh
               // inside an engage window answers "not engaged" with the mirror
               // already up.
-              isShowingSynthesizedSize: model.synthesis.isEngaged(displayID: state.display.id)
+              isShowingSynthesizedSize: model.synthesis.isEngaged(displayID: state.display.id),
+              careLine: Self.careLine(for: state, model: model)
             )
             DisplaySliderRow(
               controller: state.controller, displayName: name,
@@ -377,6 +378,32 @@ enum PanelMenu {
 }
 
 extension PanelView {
+  // MARK: - The care line
+
+  /// The caption under an external display's name, nil when there is nothing to
+  /// say. The Menu Bar preview calls this too, so both surfaces derive one line.
+  @MainActor
+  static func careLine(for state: AppModel.DisplayState, model: AppModel) -> String? {
+    careLine(
+      persistenceKey: state.display.persistenceKey,
+      prefs: standardPrefs(state.display.persistenceKey),
+      care: model.oledCare, safeMode: model.isSafeMode)
+  }
+
+  /// Reads the summary only when enrolled and not in Safe Mode. That leaves an
+  /// un-enrolled display's history unstated, as the Health pane does, and keeps
+  /// a store decode out of this view body.
+  @MainActor
+  static func careLine(
+    persistenceKey: String, prefs: DisplayPrefs, care: OledCareCoordinator, safeMode: Bool
+  ) -> String? {
+    let enrolled = prefs.oledCareEnrolled
+    let hours = care.hoursTracker(for: persistenceKey).totalHours
+    let summary = enrolled && !safeMode ? care.healthSummary(for: persistenceKey) : nil
+    return PanelCareLine.text(
+      enrolled: enrolled, hours: hours, summary: summary, safeMode: safeMode)
+  }
+
   /// Why the panel's HDR button cannot act, or nil when it can.
   ///
   /// Only the ENGAGE direction is refused: with HDR live the button offers the
@@ -391,12 +418,14 @@ extension PanelView {
   }
 }
 
-/// Section header for one display: name, an "HDR" state badge, and an HDR-mode
-/// toggle. All secondary-colored so the slider stays the row's only emphasis.
+/// Section header for one display, all secondary-colored so the slider stays
+/// the row's only emphasis.
 private struct DisplayHeaderRow: View {
   let controller: BrightnessController
   let displayName: String
   let isShowingSynthesizedSize: Bool
+  /// `PanelView.careLine`'s answer. Nil draws nothing, keeping the row one line tall.
+  let careLine: String?
 
   @State private var isHovering = false
 
@@ -415,23 +444,35 @@ private struct DisplayHeaderRow: View {
   }
 
   var body: some View {
-    HStack(spacing: 6) {
-      Text(displayName)
-        .font(.system(size: 13, weight: .semibold))
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
-        .accessibilityHidden(true)  // the slider carries the display name
-      if controller.isHDREngaged {
-        Text("HDR")
-          .font(.system(size: 11, weight: .medium))
+    VStack(alignment: .leading, spacing: 2) {
+      HStack(spacing: 6) {
+        Text(displayName)
+          .font(.system(size: 13, weight: .semibold))
           .foregroundStyle(.secondary)
-          .padding(.horizontal, 4)
-          .padding(.vertical, 1)
-          .background(RoundedRectangle(cornerRadius: 3, style: .continuous).fill(.quaternary))
-          .accessibilityLabel("HDR engaged")
+          .lineLimit(1)
+          .accessibilityHidden(true)  // the slider carries the display name
+        if controller.isHDREngaged {
+          Text("HDR")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(RoundedRectangle(cornerRadius: 3, style: .continuous).fill(.quaternary))
+            .accessibilityLabel("HDR engaged")
+        }
+        Spacer(minLength: 4)
+        hdrModeButton
       }
-      Spacer(minLength: 4)
-      hdrModeButton
+      if let careLine {
+        Text(verbatim: careLine)
+          .font(.system(size: 11))
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+          // The name above is hidden from VoiceOver (the slider carries it), so
+          // this line names its display and is read as one element.
+          .accessibilityLabel(Text(verbatim: "\(displayName), \(careLine)"))
+      }
     }
     // On the row, not the button: the caption draws in a leading-aligned column
     // under whatever it wraps, and the button's slot is a few characters wide.

--- a/Candela/Settings/MenuBarPreviewView.swift
+++ b/Candela/Settings/MenuBarPreviewView.swift
@@ -240,7 +240,12 @@ struct MenuBarPreviewView: View {
         )
       }
       ForEach(externals) { state in
-        displaySection(name: PanelView.title(for: state.display), rows: rows(for: state))
+        // Same derivation as the panel's header, so the preview grows a line
+        // exactly when the panel does.
+        displaySection(
+          name: PanelView.title(for: state.display),
+          careLine: PanelView.careLine(for: state, model: model),
+          rows: rows(for: state))
       }
       Divider().opacity(0.6)
       HStack {
@@ -286,13 +291,25 @@ struct MenuBarPreviewView: View {
     return rows
   }
 
-  private func displaySection(name: String, rows: [MiniRow]) -> some View {
+  private func displaySection(
+    name: String, careLine: String? = nil, rows: [MiniRow]
+  ) -> some View {
     VStack(alignment: .leading, spacing: 3) {
-      // 13 pt semibold secondary in the real panel.
-      Text(name)
-        .font(.system(size: 13 * Self.s, weight: .semibold))
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
+      VStack(alignment: .leading, spacing: 2 * Self.s) {
+        // 13 pt semibold secondary in the real panel.
+        Text(name)
+          .font(.system(size: 13 * Self.s, weight: .semibold))
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+        if let careLine {
+          // 11 pt secondary under the name in the real panel.
+          Text(verbatim: careLine)
+            .font(.system(size: 11 * Self.s))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
+      }
       ForEach(rows) { row in
         miniSlider(row)
       }

--- a/CandelaAppTests/PanelRowModelTests.swift
+++ b/CandelaAppTests/PanelRowModelTests.swift
@@ -346,6 +346,70 @@ struct PanelRowModelTests {
     #expect(!copy.contains("—"))
   }
 
+  // MARK: - The care line
+
+  /// The keys here are ones no real display has and no test writes hours to, so
+  /// the tracker answers zero.
+  @Test func anUnenrolledDisplayWithNoHoursHasNoCareLine() {
+    let domain = PrefsDomain()
+    let model = TestFixtures.appModel()
+    let line = PanelView.careLine(
+      persistenceKey: "row-model-plain", prefs: domain.prefs("row-model-plain"),
+      care: model.oledCare, safeMode: model.isSafeMode)
+    #expect(line == nil)
+  }
+
+  @Test func aFreshlyEnrolledDisplaySaysOnlyThatCareIsOn() {
+    let domain = PrefsDomain()
+    domain.edit("row-model-enrolled") { $0.oledCareEnrolled = true }
+    let model = TestFixtures.appModel()
+    let line = PanelView.careLine(
+      persistenceKey: "row-model-enrolled", prefs: domain.prefs("row-model-enrolled"),
+      care: model.oledCare, safeMode: model.isSafeMode)
+    #expect(line == PanelCareLine.enrolledSegment)
+  }
+
+  /// The care loop does not run in a Safe Mode session, so an enrolled display
+  /// with nothing counted has no line at all.
+  @Test func safeModeNeverClaimsCareIsOn() {
+    let domain = PrefsDomain()
+    domain.edit("row-model-safe") { $0.oledCareEnrolled = true }
+    let model = TestFixtures.appModel(safeMode: true)
+    let line = PanelView.careLine(
+      persistenceKey: "row-model-safe", prefs: domain.prefs("row-model-safe"),
+      care: model.oledCare, safeMode: model.isSafeMode)
+    #expect(line == nil)
+  }
+
+  /// The coordinator's counter reads the process defaults and there is no seam
+  /// to inject through, so the key is unique per run and cleaned up in a `defer`.
+  @Test func theHoursAreTheCoordinatorsOwnCounter() {
+    let key = "row-model-hours-\(UUID().uuidString)"
+    UserDefaults.standard.set(178.4 * 3600, forKey: "oledPanelSeconds.\(key)")
+    defer { UserDefaults.standard.removeObject(forKey: "oledPanelSeconds.\(key)") }
+    let domain = PrefsDomain()
+    domain.edit(key) { $0.oledCareEnrolled = true }
+    let model = TestFixtures.appModel()
+
+    let enrolled = PanelView.careLine(
+      persistenceKey: key, prefs: domain.prefs(key), care: model.oledCare, safeMode: false)
+    #expect(enrolled == "OLED Care on · 178 h")
+
+    domain.edit(key) { $0.oledCareEnrolled = false }
+    let unenrolled = PanelView.careLine(
+      persistenceKey: key, prefs: domain.prefs(key), care: model.oledCare, safeMode: false)
+    #expect(unenrolled == "178 h")
+  }
+
+  /// This form reads the app's own prefs domain, so the key is one nothing has
+  /// written to and the answer is nil.
+  @Test func theModelFormReadsTheDisplaysOwnPrefs() {
+    let model = TestFixtures.appModel()
+    let state = Self.state(
+      id: 1, name: "MAG 341C", key: "row-model-care-\(UUID().uuidString)")
+    #expect(PanelView.careLine(for: state, model: model) == nil)
+  }
+
   // MARK: - Brightness row reason
 
   /// Drives the wire until the display is demoted, or gives up. A bounded wait

--- a/CandelaKit/Sources/CandelaKit/OledCare/PanelCareLine.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/PanelCareLine.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The caption the menu-bar panel puts under an external display's name:
+///
+///     OLED Care on · 178 h · hottest area 2.5×
+///
+/// A segment is dropped, never replaced, when its condition fails; why a
+/// reading is missing belongs to the Health pane. Nil when nothing survives, so
+/// the header keeps its one-line height.
+public enum PanelCareLine {
+  /// The separator the panel's size line already uses.
+  public static let separator = " · "
+
+  public static let enrolledSegment = "OLED Care on"
+
+  /// - Parameters:
+  ///   - enrolled: `DisplayPrefs.oledCareEnrolled` for the display.
+  ///   - hours: lifetime panel hours; zero or non-finite drops the segment.
+  ///   - summary: nil where the caller had no reason to read one. The hottest
+  ///     segment needs `.measured` confidence, a figure, and enrollment, since
+  ///     the Health pane leaves an un-enrolled display's history unstated.
+  ///   - safeMode: hours only. The care loop never starts in a Safe Mode
+  ///     session, so nothing produces "on" or a present-tense reading.
+  public static func text(
+    enrolled: Bool, hours: Double, summary: PanelHealthSummary?, safeMode: Bool
+  ) -> String? {
+    let hoursSegment = PanelHealthCopy.compactHours(hours)
+    if safeMode { return hoursSegment }
+    var segments: [String] = []
+    if enrolled { segments.append(enrolledSegment) }
+    if let hoursSegment { segments.append(hoursSegment) }
+    if enrolled, let summary, summary.confidence == .measured,
+      let relative = summary.hottestRelative,
+      let multiple = PanelHealthCopy.multiple(relative)
+    {
+      // No "vs average" here: the Health card has the width for it, a panel
+      // row with two segments ahead of it does not.
+      segments.append("hottest area \(multiple)")
+    }
+    return segments.isEmpty ? nil : segments.joined(separator: separator)
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/OledCare/PanelHealthCopy.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/PanelHealthCopy.swift
@@ -32,6 +32,17 @@ public enum PanelHealthCopy {
     return whole == 1 ? "1 hour" : "\(whole) hours"
   }
 
+  /// Hours for the menu-bar panel's one-line caption, where "178 hours" does
+  /// not fit beside two more segments. Rounds to whole hours, so above ten it is
+  /// `hours(_:)`'s own number with a shorter unit; under an hour it says so
+  /// rather than switching units. Nil for an empty counter, so the caller drops
+  /// the segment instead of writing "0 h".
+  public static func compactHours(_ hours: Double) -> String? {
+    guard hours.isFinite, hours > 0 else { return nil }
+    if hours < 1 { return "under 1 h" }
+    return "\(Int(hours.rounded())) h"
+  }
+
   /// A relative exposure figure, as a multiple of the panel mean.
   ///
   /// Nil rather than a placeholder glyph when there is no number: the caller

--- a/CandelaKit/Tests/CandelaKitTests/PanelCareLineTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PanelCareLineTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import CandelaKit
+
+@Suite("Panel care line")
+struct PanelCareLineTests {
+  private func summary(
+    _ confidence: PanelHealthSummary.Confidence,
+    hottestRelative: Double? = nil,
+    sampleCount: Int = 0
+  ) -> PanelHealthSummary {
+    PanelHealthSummary(
+      confidence: confidence,
+      observationEnabled: true,
+      cells: [Double](repeating: 0, count: PanelGrid.cellCount),
+      hottestRelative: hottestRelative,
+      hottestOwner: nil,
+      sampleCount: sampleCount,
+      lastSample: nil,
+      dominantOwnerByCell: nil,
+      topOwnersByHours: [])
+  }
+
+  private func line(
+    enrolled: Bool, hours: Double, summary: PanelHealthSummary?, safeMode: Bool = false
+  ) -> String? {
+    PanelCareLine.text(enrolled: enrolled, hours: hours, summary: summary, safeMode: safeMode)
+  }
+
+  @Test func anEnrolledMeasuredDisplaySaysAllThree() {
+    let line = line(
+      enrolled: true, hours: 178.4, summary: summary(.measured, hottestRelative: 2.49))
+    #expect(line == "OLED Care on · 178 h · hottest area 2.5×")
+  }
+
+  /// Hours banked before the pref went off stay: they are a fact about the
+  /// panel. The claim goes, and so does the reading.
+  @Test func anUnenrolledDisplayKeepsItsHoursAndNothingElse() {
+    let line = line(
+      enrolled: false, hours: 178.4, summary: summary(.measured, hottestRelative: 2.49))
+    #expect(line == "178 h")
+  }
+
+  /// Absence is the signal; "off" under every display would be nagging.
+  @Test func theLineNeverSaysOff() {
+    for hours in [0.0, 0.4, 178.4] {
+      let line = line(enrolled: false, hours: hours, summary: summary(.estimated))
+      #expect(line?.localizedCaseInsensitiveContains("off") != true)
+    }
+  }
+
+  @Test func anEnrolledDisplayWithNoReadingIsOnAndItsHours() {
+    #expect(line(enrolled: true, hours: 178.4, summary: nil) == "OLED Care on · 178 h")
+    // `.measured` with no figure is reachable: an all-zero map has no hottest cell.
+    #expect(
+      line(enrolled: true, hours: 178.4, summary: summary(.measured))
+        == "OLED Care on · 178 h")
+  }
+
+  /// The Health card counts the readings toward the threshold; the panel says
+  /// nothing about them.
+  @Test func tooFewReadingsDropTheHottestSegmentWithoutCountingThem() {
+    let line = line(
+      enrolled: true, hours: 178.4,
+      summary: summary(.insufficient, hottestRelative: 2.49, sampleCount: 12))
+    #expect(line == "OLED Care on · 178 h")
+  }
+
+  /// The Health card says "brightness not measured"; the panel drops the segment.
+  @Test func anEstimatedSummaryDropsTheHottestSegmentWithoutExplaining() {
+    let line = line(
+      enrolled: true, hours: 178.4, summary: summary(.estimated, hottestRelative: 2.49))
+    #expect(line == "OLED Care on · 178 h")
+  }
+
+  /// Safe Mode first, as in the summary cards: the care loop is not running, so
+  /// nothing produces "on" or a present-tense reading.
+  @Test func safeModeIsHoursOnly() {
+    let measured = summary(.measured, hottestRelative: 2.49)
+    #expect(line(enrolled: true, hours: 178.4, summary: measured, safeMode: true) == "178 h")
+    #expect(line(enrolled: true, hours: 0, summary: measured, safeMode: true) == nil)
+  }
+
+  @Test func theFirstHourReadsUnderOneHour() {
+    #expect(line(enrolled: true, hours: 0.4, summary: nil) == "OLED Care on · under 1 h")
+  }
+
+  @Test func aFreshlyEnrolledDisplaySaysOnlyThatCareIsOn() {
+    #expect(line(enrolled: true, hours: 0, summary: summary(.insufficient)) == "OLED Care on")
+  }
+
+  /// Nil, not an empty string: the header keeps its one-line height.
+  @Test func nothingToSayIsNil() {
+    #expect(line(enrolled: false, hours: 0, summary: nil) == nil)
+    #expect(
+      line(enrolled: false, hours: 0, summary: summary(.measured, hottestRelative: 2.49)) == nil)
+    #expect(line(enrolled: false, hours: .nan, summary: nil) == nil)
+    #expect(line(enrolled: false, hours: -3, summary: nil) == nil)
+  }
+
+  /// Same formatter as the Health card, so one reading cannot round two ways
+  /// on two surfaces.
+  @Test func theFigureIsTheHealthCardsOwn() {
+    let line = line(enrolled: true, hours: 12, summary: summary(.measured, hottestRelative: 3.24))
+    #expect(line == "OLED Care on · 12 h · hottest area 3.2×")
+    #expect(line?.hasSuffix("hottest area \(PanelHealthCopy.multiple(3.24)!)") == true)
+  }
+
+  /// The same middle dot as the panel's size line, and no em dash anywhere.
+  @Test func theSeparatorIsThePanelsMiddleDot() {
+    #expect(PanelCareLine.separator == " \u{00B7} ")
+    let produced = [
+      line(enrolled: true, hours: 178.4, summary: summary(.measured, hottestRelative: 2.49)),
+      line(enrolled: true, hours: 0.4, summary: nil),
+      line(enrolled: false, hours: 5, summary: nil),
+      line(enrolled: true, hours: 5, summary: nil, safeMode: true),
+    ].compactMap { $0 }
+    #expect(produced.count == 4)
+    #expect(produced.allSatisfy { !$0.contains("—") })
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/PanelHealthCopyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PanelHealthCopyTests.swift
@@ -55,6 +55,37 @@ struct PanelHealthCopyTests {
     #expect(PanelHealthCopy.hours(10.0) == "10 hours")
   }
 
+  // MARK: - Compact hours
+
+  /// From ten hours up the number is the long form's own, rounded the same way.
+  @Test func compactHoursAgreeWithTheLongFormAboveTenHours() {
+    #expect(PanelHealthCopy.compactHours(341.6) == "342 h")
+    #expect(PanelHealthCopy.hours(341.6) == "342 hours")
+    #expect(PanelHealthCopy.compactHours(178.4) == "178 h")
+    #expect(PanelHealthCopy.compactHours(10.4) == "10 h")
+  }
+
+  @Test func compactHoursAreWholeHoursFromOneUp() {
+    #expect(PanelHealthCopy.compactHours(1.0) == "1 h")
+    #expect(PanelHealthCopy.compactHours(1.4) == "1 h")
+    #expect(PanelHealthCopy.compactHours(1.6) == "2 h")
+  }
+
+  /// A panel row has no room for minutes.
+  @Test func compactHoursUnderOneHourSaySo() {
+    #expect(PanelHealthCopy.compactHours(0.999) == "under 1 h")
+    #expect(PanelHealthCopy.compactHours(0.4) == "under 1 h")
+    #expect(PanelHealthCopy.compactHours(0.001) == "under 1 h")
+  }
+
+  /// Nil rather than "0 h": the caller drops the segment.
+  @Test func compactHoursWithNothingCountedAreNil() {
+    #expect(PanelHealthCopy.compactHours(0) == nil)
+    #expect(PanelHealthCopy.compactHours(-5) == nil)
+    #expect(PanelHealthCopy.compactHours(.nan) == nil)
+    #expect(PanelHealthCopy.compactHours(.infinity) == nil)
+  }
+
   // MARK: - Multiples
 
   @Test func aMultipleIsOneDecimalWithATimesSign() {
@@ -121,6 +152,7 @@ struct PanelHealthCopyTests {
     ]
     produced += (0..<PanelGrid.cellCount).compactMap { PanelHealthCopy.region(cell: $0) }
     produced += [1.0, 3.25, 99.9].compactMap { PanelHealthCopy.multiple($0) }
+    produced += [0.5, 1, 178.4].compactMap { PanelHealthCopy.compactHours($0) }
     #expect(produced.allSatisfy { !$0.contains("—") })
   }
 }


### PR DESCRIPTION
Closes #24.

## What

One caption under an external display's name in the menu-bar panel:

    OLED Care on · 193 h · hottest area 2.4×

- "OLED Care on" only while the display is enrolled; never "off".
- Hours from the coordinator's own tracker, the same counter the Health cards read, as whole hours ("under 1 h" below one).
- "hottest area N×" only when the exposure measurement is confirmed, using the Health card's formatter so one reading cannot round two ways on two surfaces.
- Segments whose condition fails are dropped; nothing left means no line, so the header keeps its height. Never a line for the built-in display or the All displays section. Safe Mode shows hours only.
- No permission or sample-count copy in the panel; that stays on the Health pane.

The Settings > Menu Bar preview draws the line through the same function, so it cannot disagree with the panel.

## Why

The panel is the surface people see every day and it read as a plain brightness utility; the product's own screenshot test (could a stranger tell this is not a slider app?) failed on it. This is the honest signal in the panel. The depth stays in the Heat Map window.

## How it stays cheap

The panel body makes the Health cards' reads. Those are in memory for a key with a live accumulator, so enrollment reconciliation now warms the exposure and per-app-hours stores for every enrolled key; the summary is only read for an enrolled display outside Safe Mode. No decode on menu open.

## Tests

`make check`: 2307 Kit tests in 183 suites, 508 app tests in 47 suites, all passing. New: a `PanelCareLine` suite (eleven cases pinning every segment rule and the exact strings), `compactHours` cases, and five row-model cases in the app bundle that read through the coordinator's own tracker.

## Hardware verification

Run on the dev rig with a Debug build of this branch (MAG 341C OLED and DELL U2725QE, both enrolled and measured):

1. MAG line reads "OLED Care on · 193 h · hottest area 2.4×"; the display's OLED Care page shows 193 hours in total and 2.4× as the hottest area. Match.
2. DELL line reads "OLED Care on · 94 h · hottest area 1.7×" (the un-enrolled case is covered by the row-model test; no panel in the setup is un-enrolled right now).
3. Not exercised: a display below the analysis minimum (both panels are past it); pinned by the Kit suite.
4. Not exercised: Safe Mode launch; pinned by the Kit and row-model suites.
5. Color LCD and All displays: no line.
6. Panel open time: unchanged to the eye.
7. Menu Bar preview: verification frame in a follow-up comment.