### PR TITLE
release: 1.0.1

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -70,7 +70,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.rydersel.Candela
-        MARKETING_VERSION: "1.0.0"
+        MARKETING_VERSION: "1.0.1"
         # One number, not two: the build number is the version. Sparkle compares
         # CFBundleVersion, so every shipped build needs its own value, and a
         # direct-download app has no reason to hide a rebuild behind an

--- a/site/public/appcast.xml
+++ b/site/public/appcast.xml
@@ -11,6 +11,17 @@
     <description>Update feed for Candela.</description>
     <language>en</language>
     <item>
+      <title>Version 1.0.1</title>
+      <pubDate>Thu, 03 Sep 2026 00:12:04 +0000</pubDate>
+      <sparkle:version>1.0.1</sparkle:version>
+      <sparkle:shortVersionString>1.0.1</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/Rydersel/Candela/releases/download/v1.0.1/Candela-1.0.1.zip"
+        sparkle:edSignature="lurz85m4z4yBXry33x00uRo8jseRn1Wre2XFLmW+PA/bMu/1NEn9dQa2Rl3SX7Hg/8OqaV2V1VXnZn8O6mE9AQ==" length="5133690"
+        type="application/octet-stream"/>
+    </item>
+    <item>
       <title>Version 1.0.0</title>
       <pubDate>Wed, 02 Sep 2026 03:14:51 +0000</pubDate>
       <sparkle:version>1.0.0</sparkle:version>


### PR DESCRIPTION
## What

- `project.yml`: version 1.0.1.
- `site/public/appcast.xml`: the signed 1.0.1 item, above 1.0.0.

## What ships

The menu bar panel's care line (#26). Nothing else has changed in the app since 1.0.0; every other commit on `main` since the tag is site or README.

## Release sequence

The Release build of this branch is notarized, stapled and Gatekeeper-accepted (Notarized Developer ID). The Sparkle zip is cut and signed with the keychain key; its length and signature are the ones in the appcast item. After this merges: the v1.0.1 GitHub release gets the zip and the disk image, the site deploy publishes the feed, the feed check runs against the live URL, and the tap cask gets its version and hash.

## Hardware verification

The build carries #26 only, which was verified on the rig in its own PR. The update path is checked after publication: a 1.0.0 install offered 1.0.1 by Sparkle and installing it.