### PR TITLE
site: every appcast item carries its release notes and a full-history link

### DIFF
--- a/site/public/appcast.xml
+++ b/site/public/appcast.xml
@@ -3,7 +3,8 @@
      into every shipped binary and must never move; this file lives in
      site/public/ so every site deploy carries it to that path. New releases
      add their signed <item> here, newest first. Archives live on GitHub
-     Releases, never beside this file. -->
+     Releases, never beside this file. Each <description> body starts at
+     column 0 because markdown reads indentation as a code block. -->
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
   <channel>
     <title>Candela Updates</title>
@@ -16,6 +17,11 @@
       <sparkle:version>1.0.1</sparkle:version>
       <sparkle:shortVersionString>1.0.1</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <description sparkle:format="markdown"><![CDATA[
+## New
+- Menu bar: each enrolled display shows its care state under its name: whether OLED Care is on, the panel's hours, and how far its hottest area sits above the average. The figures are the Health pane's own, so the two never disagree.
+]]></description>
+      <sparkle:fullReleaseNotesLink>https://github.com/Rydersel/Candela/releases</sparkle:fullReleaseNotesLink>
       <enclosure
         url="https://github.com/Rydersel/Candela/releases/download/v1.0.1/Candela-1.0.1.zip"
         sparkle:edSignature="lurz85m4z4yBXry33x00uRo8jseRn1Wre2XFLmW+PA/bMu/1NEn9dQa2Rl3SX7Hg/8OqaV2V1VXnZn8O6mE9AQ==" length="5133690"
@@ -27,6 +33,17 @@
       <sparkle:version>1.0.0</sparkle:version>
       <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <description sparkle:format="markdown"><![CDATA[
+## New
+- Health: per-panel lit hours and an exposure heat map of where bright, static content has been, kept in the panel's own geometry. Built from a coarse 24 by 10 luminance grid, so nothing on your screen is stored.
+- Protection: one-click auto-hide for the menu bar and the Dock, dimming when you step away and while the Mac is locked, a recommended enrollment preset per display, a keep-awake toggle, and display settings that survive a replug or a reboot.
+- Checkup: a guided diagnostic for any display, with solid colour fields for dead pixels, burn-in and uneven backlight, the monitor's own claims checked against what it does, an evidence grade on every result, and a report that exports as one integrity-checked file.
+- Controls: brightness, contrast and volume over DDC/CI from the menu bar, media keys and a HUD; software dimming below the hardware floor; an HDR toggle.
+- Sizes: every resolution the panel can show, including HiDPI sizes macOS does not list on standard-density panels, plus opt-in scaled sizes in between.
+- Arrangement: arrangement, mirroring and rotation from a canvas with saved layouts, and virtual displays.
+- Setup: a guided first run.
+]]></description>
+      <sparkle:fullReleaseNotesLink>https://github.com/Rydersel/Candela/releases</sparkle:fullReleaseNotesLink>
       <enclosure
         url="https://github.com/Rydersel/Candela/releases/download/v1.0.0/Candela-1.0.0.zip"
         sparkle:edSignature="WgRy3yRf3DvAHk00y2BOC4E1BqGGPEeksTn10NlnRWVDW2zVAbscbBuhyMNn+OPkxXCHUlZ2C+qgHMBLfRoTAw==" length="5126988"


### PR DESCRIPTION
Closes #29.

## What changes

The update dialog said only that a new version exists. Every appcast item now carries two things:

- `<description sparkle:format="markdown">` with the release notes. Sparkle 2.9 (the app pins 2.9.6) renders markdown in a native text view under the version line: label colour, so both appearances work; paragraphs, headings and lists kept; links clickable; plain text if the parse fails. No page to host, no web view, no link that can go dead, which is why this went inline rather than through `sparkle:releaseNotesLink`.
- `<sparkle:fullReleaseNotesLink>` pointing at the GitHub releases page. Sparkle offers it as a Version History button from the "up to date" alert.

Neither element is required by Sparkle. An item without a description updates exactly as before.

## The release notes format

One shape from here on, for the GitHub release body and the feed item alike, written once per release:

```
## New
- Menu bar: each enrolled display shows its care state under its name.

## Changed
- Requires macOS 15 or later.

## Fixed
- Controls: the volume slider no longer greys out on a display that reports no volume control.
```

The headings New, Changed, Fixed, Removed, in that order, only those with entries, one bullet per change, nothing else. No version heading (the dialog names it), no preamble, no standing requirements (a moved macOS floor is a Changed bullet). Both shipped releases were rewritten to this shape on GitHub today, and the 1.0.0 and 1.0.1 items here carry the same text.

The release tooling that cuts an item now refuses to run without a notes file (or an explicit opt-out), refuses a file that breaks the format or the CDATA section, and the feed checker verifies the feed parses as XML and that the full-history link answers 200 as a page.

## Hardware verification

Run 2026-09-03 on the installed 1.0.1 build against a loopback feed (feed URL override in defaults, a local HTTP server, its access log as the evidence of each fetch, a control request first).

1. A 1.0.2 item carrying a description: the dialog rendered the notes under the version line, "Changed" and "Fixed" as headings with their bullets.
2. The same item with the description removed: the compact dialog as before, Install Update enabled.
3. This feed as committed, with 1.0.1 newest: "You're up to date!" with OK and Version History.

Not exercised: pressing Version History (it opens the GitHub releases page; the URL answers 200 in the feed check), and the published feed on a machine running 1.0.0, which runs once this deploys. The feed override was deleted afterwards.

## After merge

Deploy the site with `--branch main` from `site/` so the feed goes live, then re-run the feed check against the published URL.
