### PR TITLE
site: count the app's update checks by version

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -80,8 +80,11 @@ The report command requires a separate read-only token in
 - `/privacy/` describes both analytics systems and exposes the opt-out.
 - `/github?placement=hero` redirects to the fixed repository URL.
 - Videos and hashed assets bypass Functions and preserve immutable caching and
-  byte-range responses.
+  byte-range responses. The appcast is the one static file routed through
+  Functions, for the update-check count; its headers should match production's
+  on a preview deploy before that change ships.
 - The appcast enclosure and `RELEASE_DOWNLOAD_URL` identify the same archive.
+- `curl -A 'Candela/0.0.0 Sparkle/2.9.6' https://candela.fyi/appcast.xml` returns the feed unchanged, and the report's "App update checks" count moves by one under `other` (a version the feed does not list, so the real versions stay clean). The proof that the shipped app is counted is a deployed build checking in and its version moving.
 - `/guides/` lists every guide, and `curl -H 'Accept: text/markdown' https://candela.fyi/guides/<slug>/` returns Markdown.
 - The guide placement migration has been applied (`npm run d1:migrate:remote`) before the deploy that first sends `placement=guide`.
 - A Search Console domain property for candela.fyi is verified and receiving data before the guides section is announced anywhere.

--- a/site/functions/_middleware.test.ts
+++ b/site/functions/_middleware.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
-import { onRequest } from './_middleware'
+import { readFileSync } from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { onRequest, resetFeedVersionsForTests } from './_middleware'
 
 type TestContext = Parameters<typeof onRequest>[0]
 
@@ -150,5 +151,147 @@ describe('Markdown content negotiation for the guides section', () => {
       expect(fetch).not.toHaveBeenCalled()
       expect(response.headers.get('vary')).toBeNull()
     }
+  })
+})
+
+describe('update feed counting', () => {
+  type Statement = { query: string; values: unknown[]; run: () => Promise<unknown> }
+  function feedContext(userAgent: string | undefined, { method = 'GET', failing = false, feedMissing = false } = {}) {
+    const request = new Request('https://candela.fyi/appcast.xml', {
+      method,
+      headers: userAgent ? { 'user-agent': userAgent } : undefined,
+    })
+    const feed = '<?xml version="1.0"?><rss><item><sparkle:shortVersionString>1.0.1</sparkle:shortVersionString></item><item><sparkle:shortVersionString> 1.0.0 </sparkle:shortVersionString></item></rss>'
+    const next = vi.fn(async () => new Response(feed, { headers: { 'content-type': 'application/xml' } }))
+    const statements: Statement[] = []
+    const db = {
+      prepare(query: string) {
+        const statement: Statement = {
+          query,
+          values: [],
+          run: async () => { if (failing) throw new Error('d1 unavailable'); return { success: true } },
+        }
+        statements.push(statement)
+        return { bind(...values: unknown[]) { statement.values = values; return statement } }
+      },
+      batch: async () => [],
+    }
+    const points: unknown[] = []
+    const pending: Promise<unknown>[] = []
+    const context = {
+      request,
+      next,
+      env: {
+        ASSETS: { fetch: vi.fn(async () => feedMissing ? new Response('gone', { status: 404 }) : new Response(feed)) },
+        ANALYTICS_DB: db,
+        ANALYTICS_UPDATES: { writeDataPoint: (point: unknown) => { points.push(point) } },
+      },
+      waitUntil: (promise: Promise<unknown>) => { pending.push(promise) },
+    } as unknown as TestContext
+    return { context, feed, next, statements, points, pending }
+  }
+
+  // The known-version set is cached per isolate; every test starts cold.
+  beforeEach(() => { resetFeedVersionsForTests() })
+
+  it('serves the feed unchanged and counts a Sparkle check by app version', async () => {
+    const { context, feed, next, statements, points, pending } = feedContext('Candela/1.0.1 Sparkle/2.9.6')
+
+    const response = await onRequest(context)
+    await Promise.all(pending)
+
+    expect(await response.text()).toBe(feed)
+    expect(response.headers.get('content-type')).toBe('application/xml')
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(statements).toHaveLength(1)
+    expect(statements[0].query).toContain('daily_counters')
+    expect(statements[0].values.slice(1)).toEqual(['update_check', '1.0.1'])
+    expect(statements[0].values[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(points).toEqual([{ indexes: ['1.0.1'], blobs: ['1.0.1'], doubles: [1] }])
+  })
+
+  it('reads only the version out of the User-Agent', async () => {
+    const { context, statements, pending } = feedContext('Candela/1.0.1 Sparkle/2.9.6 (Macintosh; Intel Mac OS X 15_1)')
+    await onRequest(context)
+    await Promise.all(pending)
+    expect(statements[0].values.slice(1)).toEqual(['update_check', '1.0.1'])
+  })
+
+  it.each([
+    ['a browser', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 15_1) AppleWebKit/605.1.15'],
+    ['curl', 'curl/8.7.1'],
+    ['a made-up app name', 'Cendela/1.0.1 Sparkle/2.9.6'],
+    ['a version that is not a version', 'Candela/evil<script> Sparkle/2.9.6'],
+    ['a version longer than any real one', `Candela/${'9'.repeat(4000)} Sparkle/2.9.6`],
+    ['no User-Agent at all', undefined],
+  ])('does not count %s', async (_label, userAgent) => {
+    const { context, feed, next, statements, points } = feedContext(userAgent)
+
+    const response = await onRequest(context)
+
+    expect(await response.text()).toBe(feed)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(statements).toHaveLength(0)
+    expect(points).toHaveLength(0)
+  })
+
+  it.each([
+    ['a version the feed does not list', 'Candela/9.9.9 Sparkle/2.9.6'],
+    ['a spelling the feed does not list', 'Candela/01.0.1 Sparkle/2.9.6'],
+  ])('files %s under other, so the vocabulary stays closed', async (_label, userAgent) => {
+    const { context, statements, points, pending } = feedContext(userAgent)
+    await onRequest(context)
+    await Promise.all(pending)
+    expect(statements[0].values.slice(1)).toEqual(['update_check', 'other'])
+    expect(points).toEqual([{ indexes: ['other'], blobs: ['other'], doubles: [1] }])
+  })
+
+  it('files every version under other while the feed cannot be read, and retries next time', async () => {
+    const { context, statements, pending } = feedContext('Candela/1.0.1 Sparkle/2.9.6', { feedMissing: true })
+    await onRequest(context)
+    await Promise.all(pending)
+    expect(statements[0].values.slice(1)).toEqual(['update_check', 'other'])
+
+    const again = feedContext('Candela/1.0.1 Sparkle/2.9.6')
+    await onRequest(again.context)
+    await Promise.all(again.pending)
+    expect(again.statements[0].values.slice(1)).toEqual(['update_check', '1.0.1'])
+  })
+
+  it('reads the feed once per isolate, not once per check', async () => {
+    const first = feedContext('Candela/1.0.1 Sparkle/2.9.6')
+    await onRequest(first.context)
+    await Promise.all(first.pending)
+    const second = feedContext('Candela/1.0.0 Sparkle/2.9.6')
+    await onRequest(second.context)
+    await Promise.all(second.pending)
+    const fetches = (context: TestContext) => (context as unknown as { env: { ASSETS: { fetch: ReturnType<typeof vi.fn> } } }).env.ASSETS.fetch
+    expect(fetches(first.context)).toHaveBeenCalledTimes(1)
+    expect(fetches(second.context)).not.toHaveBeenCalled()
+    expect(second.statements[0].values.slice(1)).toEqual(['update_check', '1.0.0'])
+  })
+
+  it('routes the feed through Functions, or none of this runs', () => {
+    const routes = JSON.parse(readFileSync(new URL('../public/_routes.json', import.meta.url), 'utf8')) as { include: string[] }
+    expect(routes.include).toContain('/appcast.xml')
+  })
+
+  it('does not count a HEAD request, which is the publication check and not an install', async () => {
+    const { context, next, statements, points, pending } = feedContext('Candela/1.0.1 Sparkle/2.9.6', { method: 'HEAD' })
+    await onRequest(context)
+    await Promise.all(pending)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(statements).toHaveLength(0)
+    expect(points).toHaveLength(0)
+  })
+
+  it('still serves the feed when the database is down', async () => {
+    const { context, feed, next, pending } = feedContext('Candela/1.0.1 Sparkle/2.9.6', { failing: true })
+
+    const response = await onRequest(context)
+    await Promise.all(pending)
+
+    expect(await response.text()).toBe(feed)
+    expect(next).toHaveBeenCalledTimes(1)
   })
 })

--- a/site/functions/_middleware.ts
+++ b/site/functions/_middleware.ts
@@ -1,10 +1,55 @@
+import { recordUpdateCheckEvent, updateCheckVersion } from './lib/events'
+import { recordUpdateCheck } from './lib/store'
+import type { AnalyticsEnv } from './lib/runtime'
+
 type Context = {
   request: Request
   next: () => Promise<Response>
-  env: {
+  env: Partial<AnalyticsEnv> & {
     ASSETS: {
       fetch(request: Request): Promise<Response>
     }
+  }
+  waitUntil?: (promise: Promise<unknown>) => void
+}
+
+// Versions the feed lists; anything else counts as "other". Each version is a
+// primary-key row in a table nothing prunes, so a stranger must not be able to add rows.
+let feedVersions: Promise<Set<string>> | null = null
+function knownVersions(context: Context) {
+  if (!feedVersions) {
+    feedVersions = (async () => {
+      const feed = await context.env.ASSETS.fetch(new Request(new URL('/appcast.xml', context.request.url)))
+      if (!feed.ok) throw new Error('feed unavailable')
+      const xml = await feed.text()
+      return new Set([...xml.matchAll(/<sparkle:shortVersionString>\s*([^<\s]+)\s*</g)].map((match) => match[1]))
+    })().catch(() => {
+      feedVersions = null
+      return new Set<string>()
+    })
+  }
+  return feedVersions
+}
+
+export function resetFeedVersionsForTests() {
+  feedVersions = null
+}
+
+// Everything here runs after the response where the runtime allows, and
+// nothing in it can decide whether the feed is served.
+function countUpdateCheck(context: Context) {
+  try {
+    if (context.request.method !== 'GET') return
+    const version = updateCheckVersion(context.request.headers.get('user-agent'))
+    if (!version) return
+    const write = (async () => {
+      const bucket = (await knownVersions(context)).has(version) ? version : 'other'
+      recordUpdateCheckEvent(context.env, bucket)
+      if (context.env.ANALYTICS_DB) await recordUpdateCheck(context.env.ANALYTICS_DB, bucket)
+    })().catch(() => {})
+    if (context.waitUntil) context.waitUntil(write)
+  } catch {
+    // Counting is never a reason to fail the feed.
   }
 }
 
@@ -54,6 +99,10 @@ export const onRequest = async (context: Context) => {
   if (url.hostname === `www.${canonicalHost}`) {
     url.hostname = canonicalHost
     return Response.redirect(url.toString(), 301)
+  }
+  if (url.pathname === '/appcast.xml') {
+    countUpdateCheck(context)
+    return context.next()
   }
   const markdownPath = markdownAssetPath(url.pathname)
   if (!markdownPath) return context.next()

--- a/site/functions/lib/events.ts
+++ b/site/functions/lib/events.ts
@@ -33,6 +33,24 @@ export function recordEvent(env: EventEnv, event: SiteEvent) {
   }
 }
 
+// Only the version comes out of the User-Agent: a version is not an
+// identifier, and a client that is not Sparkle is not an install.
+const sparkleUserAgent = /^Candela\/(\d{1,5}(?:\.\d{1,5}){0,3}) Sparkle\//
+
+export function updateCheckVersion(userAgent: string | null) {
+  return userAgent?.match(sparkleUserAgent)?.[1] ?? null
+}
+
+// Version only, no country: the privacy page says the version is the only
+// thing read from this request, and that has to stay literally true.
+export function recordUpdateCheckEvent(env: Pick<AnalyticsEnv, 'ANALYTICS_UPDATES'>, version: string) {
+  try {
+    env.ANALYTICS_UPDATES?.writeDataPoint({ indexes: [version], blobs: [version], doubles: [1] })
+  } catch {
+    // The chart copy never affects the feed request.
+  }
+}
+
 export function requestCountry(request: Request) {
   const country = (request as Request & { cf?: { country?: string } }).cf?.country?.toUpperCase() ?? 'unknown'
   return /^[A-Z]{2}$/.test(country) ? country : 'unknown'

--- a/site/functions/lib/runtime.ts
+++ b/site/functions/lib/runtime.ts
@@ -36,6 +36,7 @@ export type AnalyticsEnv = {
   ANALYTICS_PAGEVIEWS?: AnalyticsEngineDataset
   ANALYTICS_DOWNLOADS?: AnalyticsEngineDataset
   ANALYTICS_GITHUB?: AnalyticsEngineDataset
+  ANALYTICS_UPDATES?: AnalyticsEngineDataset
 }
 
 export type FunctionContext = {

--- a/site/functions/lib/store.ts
+++ b/site/functions/lib/store.ts
@@ -78,6 +78,14 @@ export async function deleteMeasurement(db: D1Database, windowKey: string) {
   ])
 }
 
+// No window, no cookie: an install checks about once a day on its own, so a
+// day's count is near the installs on that version, and only near. Manual
+// checks and anyone with curl push it up (the request is unauthenticated); a
+// Mac asleep across the UTC day boundary, or an app not running, pushes it down.
+export async function recordUpdateCheck(db: D1Database, version: string, now = new Date()) {
+  await counter(db, now.toISOString().slice(0, 10), 'update_check', version).run()
+}
+
 export async function recordPreferenceChange(db: D1Database, metric: 'opt_out' | 'opt_in', now = new Date()) {
   await counter(db, now.toISOString().slice(0, 10), metric).run()
 }

--- a/site/public/_routes.json
+++ b/site/public/_routes.json
@@ -6,7 +6,8 @@
     "/guides/*",
     "/analytics/*",
     "/download",
-    "/github"
+    "/github",
+    "/appcast.xml"
   ],
   "exclude": []
 }

--- a/site/scripts/analytics-report.mjs
+++ b/site/scripts/analytics-report.mjs
@@ -30,11 +30,11 @@ export function dayRange(days, today = new Date()) {
   return Array.from({ length: days }, (_, offset) => dayKey(new Date(end - (days - 1 - offset) * 86_400_000)))
 }
 
-const dailyMetrics = { pageview: 'pageviews', download_attempt: 'downloads', github_attempt: 'github' }
+const dailyMetrics = { pageview: 'pageviews', download_attempt: 'downloads', github_attempt: 'github', update_check: 'updates' }
 
 // Every day in the range appears, zero-filled, so a chart never hides a quiet day by skipping it
 function dailySeries(rows, days, today) {
-  const byDay = new Map(dayRange(days, today).map((day) => [day, { day, pageviews: 0, downloads: 0, github: 0 }]))
+  const byDay = new Map(dayRange(days, today).map((day) => [day, { day, pageviews: 0, downloads: 0, github: 0, updates: 0 }]))
   for (const row of rows ?? []) {
     const point = byDay.get(row.day)
     const field = dailyMetrics[row.metric]
@@ -75,6 +75,21 @@ function dimensionMap(groups, dimensionName) {
   return result
 }
 
+// A version's count on one day is near its installs (an install checks about
+// once a day), so the split on the latest day with checks is who has updated.
+// Summing the split over the whole range would keep an abandoned version on
+// top for weeks after everyone left it.
+function latestVersionSplit(rows) {
+  let day = null
+  const versions = {}
+  for (const row of rows ?? []) {
+    if (row.metric !== 'update_check') continue
+    if (day === null || row.day > day) { day = row.day; for (const key of Object.keys(versions)) delete versions[key] }
+    if (row.day === day) versions[row.placement] = (versions[row.placement] ?? 0) + Number(row.value)
+  }
+  return { day, versions }
+}
+
 function percentage(numerator, denominator) {
   return denominator === 0 ? 0 : Math.round((numerator / denominator) * 10_000) / 100
 }
@@ -95,6 +110,9 @@ export function buildReport(data, days, today = new Date()) {
     downloadAttempts: sum(data.counters, 'download_attempt'),
     uniqueDownloadWindows,
     downloadConversion: percentage(uniqueDownloadWindows, completedWindows),
+    updateChecks: sum(data.counters, 'update_check'),
+    versionsDay: latestVersionSplit(data.daily).day,
+    versions: latestVersionSplit(data.daily).versions,
     optOuts: sum(data.counters, 'opt_out'),
     droppedWrites: sum(data.counters, 'dropped_write'),
     cleanupRuns: sum(data.counters, 'cohorts_finalized'),
@@ -122,6 +140,7 @@ const reportRows = (report) => [
   ['Download attempts', report.downloadAttempts],
   ['Unique Download browser windows', report.uniqueDownloadWindows],
   ['Download conversion (%)', report.downloadConversion],
+  ['App update checks', report.updateChecks],
   ['Opt-outs', report.optOuts],
   ['Dropped writes recorded', report.droppedWrites],
   ['Cohorts finalized', report.cleanupRuns],
@@ -140,7 +159,8 @@ export function formatTable(report) {
   const dimensions = ['country', 'device', 'referrer'].flatMap((dimension) =>
     Object.entries(report.dimensions[dimension]).map(([valueName, value]) => [`${dimension}: ${valueName}`, value]),
   )
-  const allRows = [...rows, ...placements, ...dimensions]
+  const versions = Object.entries(report.versions).map(([version, value]) => [`checking in on ${report.versionsDay} from ${version}`, value])
+  const allRows = [...rows, ...placements, ...dimensions, ...versions]
   const width = Math.max(...allRows.map(([label]) => label.length))
   return allRows.map(([label, value]) => `${label.padEnd(width)}  ${value}`).join('\n')
 }
@@ -166,9 +186,9 @@ function barChart(points, field, colour) {
 <div class="axis"><span>${escapeHtml(first)}</span><span>peak ${max}</span><span>${escapeHtml(last)}</span></div>`
 }
 
-function breakdownTable(title, entries, colour) {
+function breakdownTable(title, entries, colour, empty = 'No completed windows yet.') {
   const rows = Object.entries(entries).sort((a, b) => b[1] - a[1])
-  if (rows.length === 0) return `<section><h2>${escapeHtml(title)}</h2><p class="empty">No completed windows yet.</p></section>`
+  if (rows.length === 0) return `<section><h2>${escapeHtml(title)}</h2><p class="empty">${escapeHtml(empty)}</p></section>`
   const max = Math.max(1, ...rows.map(([, value]) => value))
   const body = rows.map(([label, value]) => `<tr><th scope="row">${escapeHtml(label)}</th><td>${value}</td><td><div class="bar" style="width:${Math.round((value / max) * 100)}%;background:${colour}"></div></td></tr>`)
   return `<section><h2>${escapeHtml(title)}</h2><table>${body.join('')}</table></section>`
@@ -181,6 +201,7 @@ export function formatHtml(report, generatedAt = new Date()) {
     tile('Download attempts', report.downloadAttempts, `${report.uniqueDownloadWindows} unique windows, ${report.downloadConversion}% of completed`),
     tile('GitHub attempts', report.githubAttempts, `${report.uniqueGithubWindows} unique windows, ${report.githubConversion}% of completed`),
     tile('Completed windows', report.completedWindows, `${report.provisionalWindows} still provisional`),
+    tile('App update checks', report.updateChecks, report.versionsDay ? `${Object.keys(report.versions).length} version(s) checking in on ${report.versionsDay}` : 'none yet'),
     tile('Opt-outs', report.optOuts),
     tile('Dropped writes', report.droppedWrites, `${report.cleanupRuns} cohort rollups`),
   ]
@@ -188,8 +209,10 @@ export function formatHtml(report, generatedAt = new Date()) {
     ['Pageviews per day', 'pageviews', '#f2b544'],
     ['Download attempts per day', 'downloads', '#ff8a4c'],
     ['GitHub attempts per day', 'github', '#8fb3ff'],
+    ['App update checks per day', 'updates', '#9fd6a4'],
   ].map(([title, field, colour]) => `<section><h2>${title}</h2>${barChart(report.daily, field, colour)}</section>`)
   const breakdowns = [
+    breakdownTable(report.versionsDay ? `Checking in on ${report.versionsDay}, by version` : 'Checking in by version', report.versions, '#9fd6a4', 'No update checks yet.'),
     breakdownTable('Unique downloads by placement', report.placements.download, '#ff8a4c'),
     breakdownTable('Unique GitHub clicks by placement', report.placements.github, '#8fb3ff'),
     breakdownTable('Completed windows by country', report.dimensions.country, '#f2b544'),
@@ -284,7 +307,7 @@ export async function loadData(days, query = d1Query) {
       WHERE cohort_day >= '${cutoff}' AND expires_at <= ${now} GROUP BY referrer_host
     `),
     query(`SELECT COUNT(*) AS value FROM measurement_windows WHERE cohort_day >= '${cutoff}' AND expires_at > ${now}`),
-    query(`SELECT day, metric, SUM(value) AS value FROM daily_counters WHERE day >= '${cutoff}' AND metric IN ('pageview', 'download_attempt', 'github_attempt') GROUP BY day, metric ORDER BY day`),
+    query(`SELECT day, metric, placement, SUM(value) AS value FROM daily_counters WHERE day >= '${cutoff}' AND metric IN ('pageview', 'download_attempt', 'github_attempt', 'update_check') GROUP BY day, metric, placement ORDER BY day`),
   ])
   return {
     counters,

--- a/site/scripts/analytics-report.test.mjs
+++ b/site/scripts/analytics-report.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import * as reportModule from './analytics-report.mjs'
 
-const { buildReport, dayRange, formatCsv, formatHtml, parseArgs } = reportModule
+const { buildReport, dayRange, formatCsv, formatHtml, formatTable, parseArgs } = reportModule
 
 test('parseArgs accepts supported windows and CSV output', () => {
   assert.deepEqual(parseArgs(['--days', '7']), { days: 7, format: 'table', open: false })
@@ -30,9 +30,9 @@ test('buildReport zero-fills the per-day series across the whole range', () => {
 
   assert.deepEqual(dayRange(7, today), ['2026-08-27', '2026-08-28', '2026-08-29', '2026-08-30', '2026-08-31', '2026-09-01', '2026-09-02'])
   assert.equal(report.daily.length, 7)
-  assert.deepEqual(report.daily[4], { day: '2026-08-31', pageviews: 5, downloads: 2, github: 0 })
-  assert.deepEqual(report.daily[5], { day: '2026-09-01', pageviews: 0, downloads: 0, github: 0 })
-  assert.deepEqual(report.daily[6], { day: '2026-09-02', pageviews: 0, downloads: 0, github: 1 })
+  assert.deepEqual(report.daily[4], { day: '2026-08-31', pageviews: 5, downloads: 2, github: 0, updates: 0 })
+  assert.deepEqual(report.daily[5], { day: '2026-09-01', pageviews: 0, downloads: 0, github: 0, updates: 0 })
+  assert.deepEqual(report.daily[6], { day: '2026-09-02', pageviews: 0, downloads: 0, github: 1, updates: 0 })
   assert.equal(report.daily.reduce((sum, point) => sum + point.pageviews, 0), 5)
 })
 
@@ -48,14 +48,17 @@ test('formatHtml is self-contained and escapes values that come from the databas
     downloadAttempts: 5,
     uniqueDownloadWindows: 3,
     downloadConversion: 75,
+    updateChecks: 0,
+    versionsDay: null,
+    versions: {},
     optOuts: 0,
     droppedWrites: 0,
     cleanupRuns: 1,
     placements: { github: { hero: 2 }, download: { hero: 2, header: 1 } },
     dimensions: { country: { US: 3, unknown: 1 }, device: {}, referrer: { '<script>alert(1)</script>': 1 } },
     daily: [
-      { day: '2026-09-01', pageviews: 7, downloads: 3, github: 1 },
-      { day: '2026-09-02', pageviews: 5, downloads: 2, github: 2 },
+      { day: '2026-09-01', pageviews: 7, downloads: 3, github: 1, updates: 0 },
+      { day: '2026-09-02', pageviews: 5, downloads: 2, github: 2, updates: 0 },
     ],
   }, new Date('2026-09-02T10:30:00Z'))
 
@@ -64,7 +67,7 @@ test('formatHtml is self-contained and escapes values that come from the databas
   assert.doesNotMatch(html, /<script>alert/)
   assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/)
   assert.doesNotMatch(html, /<script|src="http|href="http/)
-  assert.equal((html.match(/<svg /g) ?? []).length, 3)
+  assert.equal((html.match(/<svg /g) ?? []).length, 4)
   assert.match(html, /<title>2026-09-01: 7<\/title>/)
   assert.match(html, /No completed windows yet\./)
   assert.match(html, /75% of completed/)
@@ -164,4 +167,42 @@ test('loadData keeps live aggregation queries within the D1 compound-select limi
     { metric: 'unique_windows', dimension_name: 'country', dimension_value: 'US', value: 4 },
   ])
   assert.equal(data.provisionalWindows, 2)
+})
+
+test('buildReport splits the app update checks by version on the latest day only', () => {
+  const today = new Date('2026-09-04T15:00:00Z')
+  const report = buildReport({
+    counters: [
+      { metric: 'update_check', placement: '1.0.0', value: 24 },
+      { metric: 'update_check', placement: '1.0.1', value: 12 },
+      { metric: 'pageview', placement: 'all', value: 3 },
+    ],
+    rollups: [],
+    liveCompleted: [],
+    provisionalWindows: 0,
+    daily: [
+      { day: '2026-09-03', metric: 'update_check', placement: '1.0.0', value: 20 },
+      { day: '2026-09-03', metric: 'update_check', placement: '1.0.1', value: 1 },
+      { day: '2026-09-04', metric: 'update_check', placement: '1.0.0', value: 4 },
+      { day: '2026-09-04', metric: 'update_check', placement: '1.0.1', value: 11 },
+      { day: '2026-09-04', metric: 'pageview', placement: 'all', value: 3 },
+    ],
+  }, 7, today)
+
+  assert.equal(report.updateChecks, 36)
+  assert.equal(report.versionsDay, '2026-09-04')
+  assert.deepEqual(report.versions, { '1.0.0': 4, '1.0.1': 11 })
+  assert.equal(report.daily[5].updates, 21)
+  assert.equal(report.daily[6].updates, 15)
+  assert.match(formatCsv(report), /"App update checks",36/)
+  assert.match(formatTable(report), /checking in on 2026-09-04 from 1\.0\.1\s+11/)
+  assert.match(formatHtml(report), /Checking in on 2026-09-04, by version/)
+})
+
+test('a report with no update checks yet says so instead of borrowing the windows copy', () => {
+  const report = buildReport({ counters: [], rollups: [], liveCompleted: [], provisionalWindows: 0, daily: [] }, 7, new Date('2026-09-04T15:00:00Z'))
+  assert.equal(report.versionsDay, null)
+  assert.deepEqual(report.versions, {})
+  assert.match(formatHtml(report), /No update checks yet\./)
+  assert.match(formatHtml(report), /none yet/)
 })

--- a/site/src/PrivacyPage.tsx
+++ b/site/src/PrivacyPage.tsx
@@ -82,6 +82,8 @@ export function PrivacyPage() {
             <ul>
               <li><a href={`${sourceBase}/functions/analytics/visit.ts`}>Visit and cookie Function</a></li>
               <li><a href={`${sourceBase}/functions/analytics/opt-out.ts`}>Opt-out Function</a></li>
+              <li><a href={`${sourceBase}/functions/_middleware.ts`}>Update feed counter</a></li>
+              <li><a href={`${sourceBase}/functions/lib/events.ts`}>Event fields, including the update check's</a></li>
               <li><a href={`${sourceBase}/migrations/0001_analytics.sql`}>D1 schema</a></li>
               <li><a href={`${sourceBase}/analytics-worker/src/index.ts`}>Retention and rollup Worker</a></li>
               <li><a href={`${sourceBase}/scripts/analytics-report.mjs`}>Analytics report command</a></li>

--- a/site/src/content/copy.ts
+++ b/site/src/content/copy.ts
@@ -377,13 +377,14 @@ export const privacy = {
   h1: "Privacy, without the vague parts.",
   lead: "Candela's website analytics are anonymous to Candela and first-party only. A random, short-lived cookie distinguishes one browser for 24 hours so we can count visits and whether that browser chooses Download or GitHub. There are no cross-site cookies.",
   control: "Website analytics are enabled by default. Opting out stops both Candela's first-party funnel and Cloudflare Web Analytics in this browser. You can opt back in at any time.",
-  app: "The Candela app performs display analysis locally. It requires no account, sends no screen samples to Candela, and uploads no display-health record. Website analytics are separate from the app.",
+  app: "The Candela app performs display analysis locally. It requires no account, sends no screen samples to Candela, and uploads no display-health record. Its one request to candela.fyi is the update check, which names the app's version and nothing about you or your display. The site counts those checks by app version and day, keeps no address and sets no cookie. The browser opt-out above does not reach the app. Turning off automatic checks in the app's About pane stops the scheduled request; pressing Check for Updates still fetches the feed, and that check is counted too.",
   does: [
     "Counts pageviews and anonymous 24-hour browser windows.",
+    "Counts the app's update checks by app version and day. That is the request Sparkle already makes for the update feed; nothing is added to it, and the version is the only thing read from it.",
     "Counts Download attempts and GitHub clicks, including which header, hero, footer or guide link was used, or whether the download came from the GitHub README's button.",
     "Records coarse country, device category and external referrer hostname.",
     "Produces anonymous daily statistics and operational counts.",
-    "Keeps a charting copy of the same counts (event, placement, country, device category) in Cloudflare's Workers Analytics Engine, which expires on its own after about 90 days.",
+    "Keeps a charting copy of the same counts (event, placement, country and device category for the website; app version alone for update checks) in Cloudflare's Workers Analytics Engine, which expires on its own after about 90 days.",
     "Uses one host-only measurement cookie restricted to candela.fyi.",
   ],
   doesNot: [
@@ -397,6 +398,7 @@ export const privacy = {
     "The random measurement cookie expires after 24 hours. It contains no name, account, email, IP address, fingerprint or advertising identifier, and it is never sent to another website.",
     "A one-way derived browser-window key is retained for seven days so completed visit-to-action cohorts can be counted. The raw random cookie value is never stored in the database. After seven days, linkable rows are deleted and only thresholded anonymous totals remain. Groups smaller than ten browser windows are folded into other.",
     "A 24-hour browser window is not a person. Two browsers on one Mac count separately, and a returning browser receives a new random window after the prior one expires. Anonymous totals already produced cannot be traced back to a browser and cannot be selectively removed.",
+    "The app's update checks are daily totals by version and nothing else: no address, no cookie, no browser-window key, so nothing in them points back to a particular install. The charting copy expires after about 90 days; the daily totals are anonymous and are kept.",
   ],
   source: "Candela is public, including the analytics implementation. The Functions, schema, retention Worker, report command and this disclosure can all be inspected in the source code.",
 }
@@ -450,7 +452,7 @@ export const terms = {
   updates: {
     h2: "Updates",
     body: [
-      "The app checks candela.fyi for new versions. That request carries no account and no information about your display. Each update is signed with a key the app verifies before installing, is notarized by Apple before it is published, and the app asks before installing one.",
+      "The app checks candela.fyi for new versions. That request carries no account and no information about your display. The site counts those checks by app version and day so it can see which versions are still in use; the Privacy page describes it in full. Each update is signed with a key the app verifies before installing, is notarized by Apple before it is published, and the app asks before installing one.",
     ],
   },
   warranty: {

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -8,7 +8,8 @@
   "analytics_engine_datasets": [
     { "binding": "ANALYTICS_PAGEVIEWS", "dataset": "candela_site_pageviews" },
     { "binding": "ANALYTICS_DOWNLOADS", "dataset": "candela_site_downloads" },
-    { "binding": "ANALYTICS_GITHUB", "dataset": "candela_site_github" }
+    { "binding": "ANALYTICS_GITHUB", "dataset": "candela_site_github" },
+    { "binding": "ANALYTICS_UPDATES", "dataset": "candela_site_updates" }
   ],
   "d1_databases": [
     {


### PR DESCRIPTION
## What changes

The app's update check is the one request it makes to candela.fyi, and Sparkle names the app and its version in that request's User-Agent (measured on the installed 1.0.1: `Candela/1.0.1 Sparkle/2.9.6`). The site now counts feed fetches by app version and day. That answers two questions the GitHub download counter cannot: how many installs check in each day, and how many are on which version, which after a release is who has updated.

- `/appcast.xml` joins the Functions routes. The middleware counts a GET whose User-Agent has Sparkle's shape, then serves the file exactly as before. A failed write never affects the response; the write runs after it where the runtime allows.
- Only the version is read from the request. A browser, curl, a HEAD publication check or a User-Agent that is not Sparkle's shape is not counted. No cookie, no address, no country, no window.
- Only a version the feed itself lists gets a row of its own; every other Sparkle-shaped request lands in one `other` bucket. A counted version is a primary-key row in a table nothing prunes, so the vocabulary stays closed against a stranger with curl. The feed's version list is read once per isolate through the asset binding.
- The count lives in the existing daily counters (metric `update_check`, keyed by version), with a charting copy in a new Analytics Engine dataset. No schema migration.
- The report gains an "App update checks" total, a daily chart, and the version split on the latest day with checks, which is who has updated. Summed over the range it would keep an abandoned version on top for weeks.
- The privacy page says what the app's one request is, that only its version is read and counted, that a manual check counts too, that the browser opt-out cannot reach the app and the About pane's automatic-check switch stops the scheduled request, and how long the counts live. The Terms sentence on updates names the count. The counter and the file that chooses its fields are linked from the page's source list.

## Verification

- Middleware tests cover: a Sparkle check is counted by version and the feed body passes through unchanged; a User-Agent with trailing platform text still yields only the version; a browser, curl, a wrong app name, a non-version, a 4000-digit version, and no User-Agent are not counted; a version the feed does not list, or spells differently, files under `other`; an unreadable feed files everything under `other` and is retried; the feed is read once per isolate; HEAD is not counted; a failing database still serves the feed; the routes file carries the path.
- Measured on a preview deployment: the feed's header set is identical to production apart from the `noindex` Pages adds to previews, same ETag, cache-control, length and body, `If-None-Match` answers 304, HEAD answers 200.
- Report tests cover the version split, the CSV row, the HTML breakdown and the daily series.
- Full site suite, lint, type check and build pass.

## After merge

Deploy the site with `--branch main` from `site/` (the new dataset binding rides `wrangler.jsonc`; no D1 migration). Then `curl -A 'Candela/0.0.0 Sparkle/2.9.6' https://candela.fyi/appcast.xml` should return the feed and add one under `other` in the report. Installs start counting under their real versions on their next daily check.
