### PR TITLE
engine: the preview countdown disarms itself when its clock fires

### DIFF
--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/PreviewCountdownDriver.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/PreviewCountdownDriver.swift
@@ -25,8 +25,15 @@ public final class PreviewCountdownDriver: Sendable {
   /// Behind a lock, not a main-actor property, so `stop()` is `nonisolated`:
   /// every coordinator cancels its clock from a nonisolated `deinit`, which a
   /// main-actor-only stop would silently drop.
-  private let task = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+  private let slot = OSAllocatedUnfairLock<Slot>(initialState: Slot())
   private let interval: Duration
+
+  /// The generation lets a clock that expires clear its own slot without
+  /// touching the one a restart put there after it.
+  private struct Slot {
+    var task: Task<Void, Never>?
+    var generation: UInt64 = 0
+  }
 
   public init(interval: Duration = .seconds(1)) {
     self.interval = interval
@@ -45,34 +52,48 @@ public final class PreviewCountdownDriver: Sendable {
     onTick: @escaping @Sendable @MainActor (Outcome?) -> Void
   ) {
     let interval = interval
-    let started = Task.detached {
-      while !Task.isCancelled {
-        try? await Task.sleep(for: interval)
-        if Task.isCancelled { return }
-        let outcome = await tick()
-        Task { @MainActor in onTick(outcome) }
-        // The countdown fires at most once; whatever it returned, it is spent.
-        if outcome != nil { return }
+    // Captured directly, not via `self`: a self-task-self cycle would keep the
+    // driver alive past the coordinator `deinit` that is its only `stop()` call.
+    let slot = slot
+    // One acquisition for cancel, bump and install, so no clock can finish and
+    // nothing can `stop()` in between; two live clocks on one session would
+    // spend it in half the time. Creating the task here is safe: a detached
+    // task never runs inline on its creating thread. The lock is not reentrant:
+    // nothing unbounded and no call into app code belongs inside this acquisition.
+    slot.withLock { state in
+      state.task?.cancel()
+      state.generation += 1
+      let generation = state.generation
+      state.task = Task.detached {
+        defer {
+          // A spent clock must not read as armed. Only its own generation is
+          // cleared: after a restart the slot belongs to the live clock.
+          slot.withLock { current in
+            if current.generation == generation { current.task = nil }
+          }
+        }
+        while !Task.isCancelled {
+          try? await Task.sleep(for: interval)
+          if Task.isCancelled { return }
+          let outcome = await tick()
+          Task { @MainActor in onTick(outcome) }
+          // The countdown fires at most once; whatever it returned, it is spent.
+          if outcome != nil { return }
+        }
       }
-    }
-    // Swapped under the lock, so a restart cannot lose the clock it replaces:
-    // two live clocks on one session would spend it in half the time.
-    task.withLock { current in
-      current?.cancel()
-      current = started
     }
   }
 
   public nonisolated func stop() {
-    task.withLock { current in
-      current?.cancel()
-      current = nil
+    slot.withLock { current in
+      current.task?.cancel()
+      current.task = nil
     }
   }
 
   /// Test seam: whether a clock is currently armed. Not used by the app, which
   /// tracks that through its own preview state.
   public nonisolated var isRunning: Bool {
-    task.withLock { $0 != nil && !($0?.isCancelled ?? true) }
+    slot.withLock { $0.task != nil && !($0.task?.isCancelled ?? true) }
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/PreviewPlumbingTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PreviewPlumbingTests.swift
@@ -87,6 +87,7 @@ struct PreviewPlumbingTests {
 
     #expect(await ticks.count == 3, "spent on the third tick and never ran again")
     #expect(seen.entries == ["nil", "nil", "reverted"])
+    #expect(driver.isRunning == false, "a spent clock is not an armed one")
   }
 
   /// The expiry is what rescues a display nobody meant to reconfigure, so
@@ -121,6 +122,7 @@ struct PreviewPlumbingTests {
     try? await Task.sleep(for: .milliseconds(80))
 
     #expect(await first.count == firstNow, "the superseded clock is dead")
+    #expect(driver.isRunning, "the dead clock's exit did not disarm the live one")
     driver.stop()
   }
 


### PR DESCRIPTION
Fixes #11.

`PreviewCountdownDriver.isRunning` answered "the slot holds an uncancelled task". A clock that expired naturally returned from its task without being cancelled or removed, so the seam read `true` after the countdown was spent. No app code reads it, but a test trusting it would have asserted the wrong thing.

The task now clears the slot in a `defer` when it exits, with the two guards the issue asked for:

- A generation counter in the lock state, captured at `start`, so a superseded clock exiting after a restart clears only its own slot and never disarms the live clock that replaced it.
- The task reaches the lock directly rather than through the driver, so a driver-to-task-to-driver cycle cannot hold a coordinator's driver past the `deinit` that is its only chance to call `stop()`.

`start` does its cancel, bump, create and install in one lock acquisition. With the bump and the install split into two, a clock finishing between them could nil the slot before the outgoing clock was cancelled, leaving that clock ticking with nothing holding it and the slot holding a finished task. Reproduced at a zero interval with a throwaway stress run: 4 orphaned clocks in 2000 restarts, and none with the single acquisition. The window is gone rather than guarded, and the same acquisition serialises `stop()` against `start()`. The generation guard is still needed: a superseded clock's `defer` runs long after the acquisition released, and without the guard it would nil the live clock.

Tests, both written before the fix and both failing without it:

- `theClockTicksUntilTheSessionReturnsAnOutcomeAndThenStops` asserts `isRunning == false` after the natural expiry. On `main` it fails with `(driver.isRunning → true) == false`.
- `startingAgainReplacesTheRunningClockRatherThanAddingOne` asserts `isRunning` is still true once the superseded clock has exited. With the generation guard removed it fails with `isRunning → false`.

Engine suite: 2307 tests in 183 suites passed. App bundle: 508 tests in 47 suites passed.

Hardware verification: none, per the issue. The driver is a timer and no display is touched.
