### PR TITLE
settings: a display's name fields commit on teardown; the care demo stops on cancel

### DIFF
--- a/Candela/Onboarding/OnboardingOledPages.swift
+++ b/Candela/Onboarding/OnboardingOledPages.swift
@@ -302,12 +302,17 @@ struct OnboardingCareDemo: View {
       stage = 2
       return
     }
+    // `Task.sleep` returns at once when cancelled, so re-check after each one;
+    // otherwise a cancelled task still animates the rest of the loop at teardown.
     while !Task.isCancelled {
       try? await Task.sleep(for: .seconds(1.6))
+      guard !Task.isCancelled else { return }
       withAnimation(.easeInOut(duration: 0.8)) { stage = 1 }
       try? await Task.sleep(for: .seconds(1.6))
+      guard !Task.isCancelled else { return }
       withAnimation(.easeInOut(duration: 1.2)) { stage = 2 }
       try? await Task.sleep(for: .seconds(2.2))
+      guard !Task.isCancelled else { return }
       withAnimation(.easeInOut(duration: 0.8)) { stage = 0 }
     }
   }

--- a/Candela/Settings/DisplayHubView.swift
+++ b/Candela/Settings/DisplayHubView.swift
@@ -38,12 +38,12 @@ struct DisplayHubView: View {
 
   /// Drafts, not direct pref bindings: a `TextField` bound straight to a pref
   /// would write, fan out and bump `prefsRevision` on every keystroke,
-  /// re-rendering the pane mid-edit. Committed on Return and on focus loss; on
-  /// teardown the `@State` dies with the destination and nothing is scheduled.
+  /// re-rendering the pane mid-edit. Committed on Return, on focus loss and on
+  /// teardown (the `onDisappear` on each field says why).
   ///
   /// Seeded at identity creation and re-seeded on `prefsRevision` from `onChange`
   /// modifiers ON THE FIELDS themselves, so a re-seed cannot silently stop firing
-  /// and revive a wiped name on the next focus loss.
+  /// and revive a wiped name on the next commit, teardown included.
   @State private var nameDraft: String
   @State private var audioNameDraft: String
   @FocusState private var nameFocused: Bool
@@ -129,6 +129,9 @@ struct DisplayHubView: View {
             .onChange(of: nameFocused) { _, focused in
               if !focused { commitName() }
             }
+            // Teardown moves no focus (measured), so a sidebar click would drop a
+            // pending edit. Keyed per display, so this lands on the display that was showing.
+            .onDisappear { commitName() }
             .onChange(of: model.prefsRevision) { _, _ in
               guard !nameFocused else { return } // never fight a live edit
               nameDraft = prefs.friendlyName
@@ -454,6 +457,8 @@ struct DisplayHubView: View {
               .onChange(of: audioNameFocused) { _, focused in
                 if !focused { commitAudioName() }
               }
+              // Same teardown leg as the name field above.
+              .onDisappear { commitAudioName() }
               .onChange(of: model.prefsRevision) { _, _ in
                 guard !audioNameFocused else { return } // never fight a live edit
                 audioNameDraft = prefs.audioDeviceNameOverride
@@ -859,7 +864,7 @@ struct DisplayHubView: View {
     // One shared rule, in CandelaKit under test: blank under ANY whitespace
     // means "use the name the display reports".
     let trimmed = DisplayCardPolicy.normalizedFriendlyName(nameDraft)
-    nameDraft = trimmed
+    if nameDraft != trimmed { nameDraft = trimmed }
     guard trimmed != prefs.friendlyName else { return }
     writer.write(.friendlyName) { $0.friendlyName = trimmed }
   }
@@ -884,7 +889,7 @@ struct DisplayHubView: View {
 
   private func commitAudioName() {
     let trimmed = DisplayCardPolicy.normalizedFriendlyName(audioNameDraft)
-    audioNameDraft = trimmed
+    if audioNameDraft != trimmed { audioNameDraft = trimmed }
     guard trimmed != prefs.audioDeviceNameOverride else { return }
     // Fans out to a tap re-arm: `audioDeviceNameOverride` feeds
     // `AppModel.tapConfig` through `audioMatchingDisplays`.


### PR DESCRIPTION
Fixes #12. Fixes #10.

## A display's name fields commit on teardown

The display hub's Name field and Audio device name field committed on Return and on losing focus. A plain click on another sidebar row moves no keyboard focus, so the page was re-keyed for the new display and the pending edit died with its state; the old name was back on return. Both fields now also commit in `onDisappear`, the leg the shared commit-on-blur field already carries for the same reason.

The commit lands on the display that was showing: the display root is keyed on the display's persistence key, so a selection change removes the departing subtree and the closure keeps that display's state and draft. A pushed sub-page (Advanced, Diagnostics, All Sizes) fires nothing, because the root stays mounted behind it. The two prefs fan out to a revision bump and a media-key tap config re-arm, nothing that touches a display, so a teardown-time write is as light as a focus-loss one. The drafts' doc comment is corrected to name all three commit legs, and the drafts are only reassigned when trimming changes them.

## The onboarding care demo stops on cancel

The demo's loop checked cancellation only at its `while`. `Task.sleep` returns immediately once cancelled, so leaving the page fired all three stage changes back to back on a view being torn down. Each sleep now re-checks, the idiom the OLED Care pane's poll uses. The onboarding page is re-keyed per page, so re-entering the demo starts a fresh loop.

## Verification

Hardware verification ran on this commit as a Release build installed to /Applications, on the external displays in the setup, all passing:

- Rename an external display, click another sidebar row without Return or Tab, return: the new name persists and shows in the menu bar.
- The same for the Audio device name field.
- With two externals: rename display A, click straight to B. B is unchanged, A carries the new name.
- A field left untouched, clicked away from and back: no change.
- Type a name, close the settings window with Command-W with the edit pending, reopen: the name persists.
- Onboarding: reach the care demo, let it cycle, leave mid-cycle: no burst of stage changes. Return: it cycles again.

`make check`: engine suite 2307 tests in 183 suites, app bundle 508 tests in 47 suites, all passing.
