### PR TITLE
probe: the mode-apply usage names the session scope and its hazard

### DIFF
--- a/CandelaKit/Sources/CandelaProbe/main.swift
+++ b/CandelaKit/Sources/CandelaProbe/main.swift
@@ -38,7 +38,9 @@ usage: candela-probe [--display <id>] <subcommand>
   modes                                   merged mode list, marking CGS-revealed entries
   synthstops                              the synthesized-size ladder as the launch reapply computes it (needs --display)
   curated                                 what the default size picker shows, after curation
-  modeapply <ioModeID> [holdSeconds=5]    apply one mode by id at preview scope, then revert
+  modeapply <ioModeID> [holdSeconds=5] [session]
+                                          apply one mode by id at preview scope, then revert;
+                                          "session" keeps the mode after exit, and you put the display back
   identity                                EDID identity facts as the checkup reads them, as JSON
   refreshsweep                            apply every rate at the native size at preview scope, then restore
   checkup validate <file>                 verify an exported checkup report against its own hash
@@ -450,18 +452,18 @@ case "curated":
     }
   }
 case "modeapply":
-  // Applies one mode BY ID at preview scope, through the real configurator, so
-  // the revealed apply path and its post-commit verification are both exercised.
-  // Preview scope self-reverts when this process exits.
+  // Goes through the real configurator so the revealed apply path and its
+  // post-commit verification are exercised. Preview scope self-reverts on exit.
   guard arguments.count >= 2, let wanted = Int32(arguments[1]) else {
-    print("usage: candela-probe --display <id> modeapply <ioModeID> [holdSeconds=5]")
+    print("usage: candela-probe --display <id> modeapply <ioModeID> [holdSeconds=5] [session]")
+    print("  \"session\" keeps the mode after exit, and you put the display back")
     exit(2)
   }
-  let holdSeconds = arguments.count >= 3 ? UInt32(arguments[2]) ?? 5 : 5
-  // Third arg picks the scope. Session scope OUTLIVES this process, so the
-  // caller is responsible for putting the display back.
-  let applyScope: DisplayConfigScope =
-    (arguments.count >= 4 && arguments[3] == "session") ? .session : .preview
+  // Both trailing args are optional, so "session" is read wherever it lands.
+  // Session scope OUTLIVES this process; the caller puts the display back.
+  let trailing = arguments.dropFirst(2)
+  let holdSeconds = trailing.compactMap { UInt32($0) }.first ?? 5
+  let applyScope: DisplayConfigScope = trailing.contains("session") ? .session : .preview
   guard let target = displayFilter else {
     print("modeapply requires --display <id>")
     exit(2)
@@ -480,7 +482,11 @@ case "modeapply":
     print("after:  \(after.map { "\($0.logicalWidth)x\($0.logicalHeight) fb \($0.pixelWidth)x\($0.pixelHeight) id \($0.ioModeID) \(String(format: "%g", $0.refreshHz)) Hz" } ?? "unknown")")
     print("scope: \(applyScope); holding \(holdSeconds)s...")
     sleep(holdSeconds)
-    print("exiting: preview scope reverts now.")
+    print(
+      applyScope == .session
+        ? "exiting: session scope keeps the mode; put the display back."
+        : "exiting: preview scope reverts now."
+    )
   } catch {
     print("apply FAILED: \(error)")
     exit(4)


### PR DESCRIPTION
Fixes #7.

`candela-probe modeapply` accepts an optional `session` argument that switches the apply from preview scope, which reverts itself when the process exits, to session scope, which outlives the process and leaves the caller to put the display back. Neither usage text mentioned it.

Both usage strings now carry `[session]` with the hazard in the same breath: the top-level usage wraps its description onto two lines at the column the block uses, and the inline usage printed on a bad argument gains a second line saying the same thing. The exit line stops claiming a preview revert when the scope was session.

One parser change came out of writing the text: `[holdSeconds=5] [session]` reads as two independent optionals, but the scope was only read from the fourth argument, so `modeapply <id> session` silently applied at preview scope with a default hold. Both trailing arguments are now read wherever they land. The default remains preview and an unrecognised word still falls through to it. The conformance harness spawns the child without a fourth argument, so it stays at preview scope.

## Verification

`cd CandelaKit && swift build` succeeds. `swift run candela-probe` prints the new top-level line, and `candela-probe --display <id> modeapply` with no mode id prints the new inline usage. `modeapply` itself was not run: the text is the change, and the hardware verification section of the issue names none.
