### PR TITLE
engine: drop the control-method enum and policy function nothing calls

### DIFF
--- a/CandelaKit/Sources/CandelaKit/Support/DisplayCardPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DisplayCardPolicy.swift
@@ -1,16 +1,5 @@
 import Foundation
 
-/// Which path is driving a display's brightness. Named for what the user sees,
-/// not the prefs behind it: `forceSw` and `avoidGamma` never reach a label.
-public enum DisplayControlMethod: Sendable, Equatable {
-  /// DDC over the data cable. `avoidGamma` is inert on this path.
-  case hardwareDDC
-  /// Software dimming through the display's color profile (gamma table).
-  case softwareGamma
-  /// Software dimming through a dark overlay window.
-  case softwareOverlay
-}
-
 /// Why no DDC command reaches a display, which is what makes the per-command
 /// tuning grid inert. Per-command reasons are deliberately absent: brightness
 /// being off leaves the volume and contrast rows live, so greying the whole grid
@@ -29,29 +18,6 @@ public enum DDCTrafficBlock: Sendable, Equatable {
 /// The Displays pane rules that are not pure bindings. Here rather than in the
 /// view because each has a wrong answer no test could catch in the app.
 public enum DisplayCardPolicy {
-  /// The card's three-way summary, derived from the engine's own path so the two
-  /// cannot disagree. nil for `.native` and `.unavailable`, which the card has no
-  /// vocabulary for; the caller renders those from the path itself.
-  ///
-  /// Do not re-add a prefs-shaped overload: the old one mirrored `applyPaths` while
-  /// ignoring HDR-native, combined mode and `unavailableDDC`, so it captioned the
-  /// wireless built-in panel "Hardware (DDC) control".
-  public static func controlMethod(for path: BrightnessPath) -> DisplayControlMethod? {
-    switch path {
-    case .native, .unavailable:
-      nil
-    // Combined is the default path and DDC carries the top of its range, so the
-    // summary calls it hardware. The split point needs a sentence, not a row.
-    case .hardware, .combined:
-      .hardwareDDC
-    // `.softwareOnly` is combined mode with its hardware half NOT running (R-A).
-    // Answering `.hardwareDDC` would caption a dead DDC wire as hardware control,
-    // the untruth this case exists to make unrepresentable.
-    case let .software(backend), let .softwareOnly(backend, _, _):
-      backend == .overlay ? .softwareOverlay : .softwareGamma
-    }
-  }
-
   /// Whether any DDC command can reach this display, and if not, why. Derived from
   /// the same `BrightnessPath` the diagnostics section renders, so one settings page
   /// cannot give two answers about one display. Do not gate on `prefs.forceSoftware`

--- a/CandelaKit/Tests/CandelaKitTests/DisplayCardPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayCardPolicyTests.swift
@@ -4,108 +4,6 @@ import Testing
 
 @Suite("Display card policy")
 struct DisplayCardPolicyTests {
-  /// `native` and `unavailable` map to nil on purpose: the card has no vocabulary
-  /// for them and diagnostics states both in full. Rendering that nil as "Hardware
-  /// (DDC) control" is the defect, and it captioned the built-in panel that way.
-  @Test func theCardHasNoWordForNativeOrForNothingAtAll() {
-    #expect(DisplayCardPolicy.controlMethod(for: .native) == nil)
-    #expect(DisplayCardPolicy.controlMethod(
-      for: .unavailable(.ddcTurnedOffWithNoSoftwareLeg)
-    ) == nil)
-  }
-
-  @Test func pureDDCAndCombinedBothReadAsHardwareControl() {
-    #expect(DisplayCardPolicy.controlMethod(for: .hardware) == .hardwareDDC)
-    // Combined is the default path and DDC carries the top of its range, so the
-    // card calls it hardware. Diagnostics has room to state the split.
-    #expect(DisplayCardPolicy.controlMethod(
-      for: .combined(switchingValue: 0.47, backend: .gamma)
-    ) == .hardwareDDC)
-    #expect(DisplayCardPolicy.controlMethod(
-      for: .combined(switchingValue: 0.47, backend: .overlay)
-    ) == .hardwareDDC)
-  }
-
-  @Test func theSoftwareLegNamesItsBackend() {
-    #expect(DisplayCardPolicy.controlMethod(for: .software(.gamma)) == .softwareGamma)
-    #expect(DisplayCardPolicy.controlMethod(for: .software(.overlay)) == .softwareOverlay)
-  }
-
-  /// Ruling R-A. `.softwareOnly` is combined mode with its hardware half stopped,
-  /// so answering `.hardwareDDC` captions a display whose DDC wire is switched off
-  /// as hardware-controlled. The type cannot catch it: that answer is well-formed.
-  @Test func aDeadDDCLegIsNeverCaptionedAsHardwareControl() {
-    for backend: SoftwareDimmingBackend in [.gamma, .overlay] {
-      let expected: DisplayControlMethod = backend == .overlay ? .softwareOverlay : .softwareGamma
-      #expect(DisplayCardPolicy.controlMethod(
-        for: .softwareOnly(backend: backend, reason: .ddcTurnedOff, dimsBelow: 0.5)
-      ) == expected)
-    }
-  }
-
-  /// The card word is a function of the path alone. A prefs-shaped overload is how
-  /// the shipped row drifted from the engine, so nothing about a display's prefs
-  /// reaches this projection except through `BrightnessPathPolicy`.
-  @Test func everyPathTheEngineCanProduceHasAnAnswer() {
-    var reached = Set<String>()
-    for path in Self.everyReachablePath() {
-      reached.insert(Self.caseTag(path))
-      // The invariant that outranks all the others: a path whose DDC leg is not
-      // running never reads as hardware control.
-      switch path {
-      case .softwareOnly:
-        #expect(DisplayCardPolicy.controlMethod(for: path) != .hardwareDDC, "\(path)")
-      case .unavailable, .native:
-        #expect(DisplayCardPolicy.controlMethod(for: path) == nil, "\(path)")
-      case .hardware, .combined:
-        #expect(DisplayCardPolicy.controlMethod(for: path) == .hardwareDDC, "\(path)")
-      case .software:
-        #expect(DisplayCardPolicy.controlMethod(for: path) != .hardwareDDC, "\(path)")
-      }
-    }
-    // Guards the sweep itself: if a future edit narrows the input product so it
-    // stops reaching a case, the assertions above quietly stop asserting it.
-    #expect(reached.count == 6, "reached \(reached.sorted())")
-  }
-
-  /// Swept over the whole input product rather than a hand-picked list, which a new
-  /// `BrightnessPath` case would silently fall out of.
-  private static func everyReachablePath() -> [BrightnessPath] {
-    var paths: [BrightnessPath] = []
-    let flags = [true, false]
-    for role in [DisplayRole.builtIn, .external] {
-      for (isHDRActive, forceSoftware) in flags.flatMap({ a in flags.map { (a, $0) } }) {
-        for (avoidGamma, disableCombined) in flags.flatMap({ a in flags.map { (a, $0) } }) {
-          for (unavailableDDC, switching) in flags.flatMap({ a in [0.0, 0.5].map { (a, $0) } }) {
-            paths.append(BrightnessPathPolicy.path(.init(
-              role: role,
-              isHDRActive: isHDRActive,
-              forceSoftware: forceSoftware,
-              avoidGamma: avoidGamma,
-              disableCombinedBrightness: disableCombined,
-              unavailableDDC: unavailableDDC,
-              switchingValue: switching
-            )))
-          }
-        }
-      }
-    }
-    return paths
-  }
-
-  private static func caseTag(_ path: BrightnessPath) -> String {
-    switch path {
-    case .native: "native"
-    case .software: "software"
-    case .hardware: "hardware"
-    case .combined: "combined"
-    case .softwareOnly: "softwareOnly"
-    case .unavailable: "unavailable"
-    }
-  }
-
-  // MARK: - DDC traffic
-
   /// The defect the projection exists to remove. `CommandTuningGrid` gated on
   /// `prefs.forceSoftware` alone, so a display in live HDR — where DDC is dead
   /// outright — presented an editable grid whose every write went nowhere.
@@ -139,8 +37,6 @@ struct DisplayCardPolicyTests {
     ) == nil)
   }
 
-  /// Same sweep and same reason as `everyPathTheEngineCanProduceHasAnAnswer`: over
-  /// every path the engine can produce, not a hand-picked list.
   @Test func everyPathTheEngineCanProduceHasATrafficVerdict() {
     var reached = Set<String>()
     for path in Self.everyReachablePath() {
@@ -190,5 +86,41 @@ struct DisplayCardPolicyTests {
     #expect(DisplayCardPolicy.ddcTrafficBlock(
       for: .native, isWireUnresponsive: true
     ) == .macOSDrivesBrightness)
+  }
+
+  /// The whole input product, not a hand-picked list that a new `BrightnessPath`
+  /// case would silently fall out of.
+  private static func everyReachablePath() -> [BrightnessPath] {
+    var paths: [BrightnessPath] = []
+    let flags = [true, false]
+    for role in [DisplayRole.builtIn, .external] {
+      for (isHDRActive, forceSoftware) in flags.flatMap({ a in flags.map { (a, $0) } }) {
+        for (avoidGamma, disableCombined) in flags.flatMap({ a in flags.map { (a, $0) } }) {
+          for (unavailableDDC, switching) in flags.flatMap({ a in [0.0, 0.5].map { (a, $0) } }) {
+            paths.append(BrightnessPathPolicy.path(.init(
+              role: role,
+              isHDRActive: isHDRActive,
+              forceSoftware: forceSoftware,
+              avoidGamma: avoidGamma,
+              disableCombinedBrightness: disableCombined,
+              unavailableDDC: unavailableDDC,
+              switchingValue: switching
+            )))
+          }
+        }
+      }
+    }
+    return paths
+  }
+
+  private static func caseTag(_ path: BrightnessPath) -> String {
+    switch path {
+    case .native: "native"
+    case .software: "software"
+    case .hardware: "hardware"
+    case .combined: "combined"
+    case .softwareOnly: "softwareOnly"
+    case .unavailable: "unavailable"
+    }
   }
 }


### PR DESCRIPTION
Fixes #9.

`DisplayControlMethod` and `DisplayCardPolicy.controlMethod(for:)` had no caller outside their own tests. The diagnostics report's control-method field is built from the diagnostics copy helper's brightness-path description, which switches exhaustively on the path and never touched this pair.

Both are deleted from `DisplayCardPolicy.swift`; the `DisplayCardPolicy` type stays, with the DDC traffic verdict and the friendly-name normaliser the settings views call. The five tests exercising the pair are deleted from the test file. The two private helpers the surviving traffic-verdict sweep uses, the reachable-path enumerator and the case-tag helper, are kept byte for byte and moved to the bottom of the file, and the one doc comment that cross-referenced a deleted test is reworded.

A grep across the repository finds no remaining reference to the enum or its cases. The enum had no raw values and no Codable conformance, so nothing on disk names it.

## Verification

`make check`: engine suite 2302 tests in 183 suites (five fewer), app bundle 508 tests in 47 suites, all passing. The compiler is the proof that no caller remains. Dead code removal; no display is touched.
