### PR TITLE
engine: one screen clamp serves the HUD pill and the confirmation window

### DIFF
--- a/CandelaKit/Sources/CandelaKit/Support/ConfirmationPlacement.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/ConfirmationPlacement.swift
@@ -71,13 +71,10 @@ public enum ConfirmationPlacement {
     hypot(a.x - b.x, a.y - b.y)
   }
 
-  /// Keeps a window on screen. The inner `max` matters for a window taller or
-  /// wider than the space it is going into: without it the upper bound falls
-  /// below the lower one and the clamp reports a position off the top or left.
   private static func clamp(_ origin: CGPoint, size: CGSize, in frame: CGRect) -> CGPoint {
     CGPoint(
-      x: min(max(origin.x, frame.minX), max(frame.minX, frame.maxX - size.width)),
-      y: min(max(origin.y, frame.minY), max(frame.minY, frame.maxY - size.height))
+      x: ScreenClamp.clamped(origin.x, length: size.width, lower: frame.minX, upper: frame.maxX),
+      y: ScreenClamp.clamped(origin.y, length: size.height, lower: frame.minY, upper: frame.maxY)
     )
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Support/HUDPlacement.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/HUDPlacement.swift
@@ -54,17 +54,10 @@ public enum HUDPlacement {
     let y = frame.maxY - topInset - size.height - margin
     // Whole points: a centred pill on an odd-width screen otherwise starts on a
     // half point and its text renders soft.
-    return CGPoint(
-      x: clamp(x, length: size.width, lower: visibleFrame.minX, upper: visibleFrame.maxX).rounded(),
-      y: clamp(y, length: size.height, lower: frame.minY, upper: frame.maxY).rounded()
+    let clampedX = ScreenClamp.clamped(
+      x, length: size.width, lower: visibleFrame.minX, upper: visibleFrame.maxX
     )
-  }
-
-  /// The inner `max` matters for a pill larger than its screen: without it the upper
-  /// bound falls below the lower one and the clamp reports a position off-screen.
-  private static func clamp(
-    _ value: CGFloat, length: CGFloat, lower: CGFloat, upper: CGFloat
-  ) -> CGFloat {
-    min(max(value, lower), max(lower, upper - length))
+    let clampedY = ScreenClamp.clamped(y, length: size.height, lower: frame.minY, upper: frame.maxY)
+    return CGPoint(x: clampedX.rounded(), y: clampedY.rounded())
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Support/ScreenClamp.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/ScreenClamp.swift
@@ -1,0 +1,12 @@
+import CoreGraphics
+
+/// One axis of keeping something on screen. Scalar because the HUD pill clamps
+/// x against the visible frame and y against the full frame; a rect rule cannot.
+enum ScreenClamp {
+  /// Near edge of a span of `length`, held inside `lower...upper`. The inner `max`
+  /// covers a span longer than its screen: without it the upper bound drops below
+  /// the lower one and the span lands off the near edge instead of pinned to it.
+  static func clamped(_ value: CGFloat, length: CGFloat, lower: CGFloat, upper: CGFloat) -> CGFloat {
+    min(max(value, lower), max(lower, upper - length))
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/ScreenClampTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ScreenClampTests.swift
@@ -1,0 +1,19 @@
+import CoreGraphics
+import Testing
+@testable import CandelaKit
+
+@Suite("Screen clamp")
+struct ScreenClampTests {
+  @Test func aSpanThatFitsIsHeldInsideBothEnds() {
+    #expect(ScreenClamp.clamped(50, length: 100, lower: 0, upper: 400) == 50)
+    #expect(ScreenClamp.clamped(-20, length: 100, lower: 0, upper: 400) == 0)
+    #expect(ScreenClamp.clamped(350, length: 100, lower: 0, upper: 400) == 300)
+  }
+
+  /// Guards the inner `max`: a plain `min(max(...))` lands the span off the near edge.
+  @Test func aSpanLongerThanItsScreenIsPinnedToTheNearEdge() {
+    #expect(ScreenClamp.clamped(-300, length: 500, lower: 100, upper: 300) == 100)
+    #expect(ScreenClamp.clamped(250, length: 500, lower: 100, upper: 300) == 100)
+    #expect(ScreenClamp.clamped(900, length: 500, lower: 100, upper: 300) == 100)
+  }
+}


### PR DESCRIPTION
Fixes #8.

`HUDPlacement` and `ConfirmationPlacement` each carried a private clamp with the same non-obvious inner `max`, the term that keeps a pill or window larger than its screen pinned to the near edge instead of off-screen, with near-verbatim comments explaining it. Both copies were private, so nothing could notice them disagreeing.

One scalar helper, `ScreenClamp.clamped(_:length:lower:upper:)`, now lives in its own file in `Support/` and both sites call it. Scalar, because the HUD clamps x against the visible frame and y against the full frame, so a point-shaped rule could not serve it; the confirmation file keeps its two-line per-axis wrapper. One copy of the comment survives, on the helper. The arithmetic is a literal substitution of both removed bodies, and rounding still happens outside the clamp.

A small test file calls the helper directly with a span that fits and with one longer than its screen, so the inner `max` is pinned in one place rather than only through the two callers.

## Verification

`make check`: engine suite 2309 tests in 184 suites (two new), app bundle 508 tests in 47 suites, all passing. The existing oversize cases in both placement suites pass unchanged. Pure geometry; no display is touched.
