### PR TITLE
site: the download button follows the appcast to the newest disk image

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -47,10 +47,11 @@ npx wrangler pages secret put ANALYTICS_SIGNING_KEY --project-name candela-site
 The signing value must be a freshly generated high-entropy secret. Production
 and preview must not share it.
 
-`RELEASE_DOWNLOAD_URL` is a committed var in `wrangler.jsonc`, because it is a
-public URL rather than a secret. It must match the current enclosure in
-`public/appcast.xml` before Download is enabled. A Pages secret of the same name
-overrides it if one is ever needed.
+`/download` needs no configuration: it reads `public/appcast.xml`, takes the
+highest version listed, and redirects to the disk image beside that item's
+enclosure (the same URL with `.dmg` in place of `.zip`). A release is live on
+the download buttons the moment its appcast item deploys. If the feed cannot
+be read, the redirect lands on the GitHub releases page instead.
 
 Apply and deploy from this `site/` directory. Running the Pages deploy from the
 repository root omits `site/functions` and silently produces a static-only
@@ -83,7 +84,7 @@ The report command requires a separate read-only token in
   byte-range responses. The appcast is the one static file routed through
   Functions, for the update-check count; its headers should match production's
   on a preview deploy before that change ships.
-- The appcast enclosure and `RELEASE_DOWNLOAD_URL` identify the same archive.
+- `curl -sI https://candela.fyi/download` redirects to the disk image of the newest appcast item, and that disk image exists on the release.
 - `curl -A 'Candela/0.0.0 Sparkle/2.9.6' https://candela.fyi/appcast.xml` returns the feed unchanged, and the report's "App update checks" count moves by one under `other` (a version the feed does not list, so the real versions stay clean). The proof that the shipped app is counted is a deployed build checking in and its version moving.
 - `/guides/` lists every guide, and `curl -H 'Accept: text/markdown' https://candela.fyi/guides/<slug>/` returns Markdown.
 - The guide placement migration has been applied (`npm run d1:migrate:remote`) before the deploy that first sends `placement=guide`.

--- a/site/functions/_middleware.ts
+++ b/site/functions/_middleware.ts
@@ -5,11 +5,7 @@ import type { AnalyticsEnv } from './lib/runtime'
 type Context = {
   request: Request
   next: () => Promise<Response>
-  env: Partial<AnalyticsEnv> & {
-    ASSETS: {
-      fetch(request: Request): Promise<Response>
-    }
-  }
+  env: Partial<AnalyticsEnv> & Pick<AnalyticsEnv, 'ASSETS'>
   waitUntil?: (promise: Promise<unknown>) => void
 }
 

--- a/site/functions/download.ts
+++ b/site/functions/download.ts
@@ -1,10 +1,9 @@
 import { recordEvent, requestCountry } from './lib/events'
 import { readAnalyticsPreference, reduceDeviceCategory } from './lib/measurement'
 import { actionMeasurement, isEligibleNavigation, redirect } from './lib/request'
+import { latestArchiveUrl } from './lib/release'
 import { externalPlacements, parsePlacement, type FunctionContext } from './lib/runtime'
 import { recordAction } from './lib/store'
-
-const releaseArchiveUrl = 'https://github.com/Rydersel/Candela/releases/download/v1.0.0/Candela-1.0.0.dmg'
 
 export const onRequestGet = async (context: FunctionContext) => {
   const placement = parsePlacement(new URL(context.request.url).searchParams.get('placement'))
@@ -27,5 +26,5 @@ export const onRequestGet = async (context: FunctionContext) => {
       // Download access is never coupled to analytics availability.
     }
   }
-  return redirect(context.env.RELEASE_DOWNLOAD_URL ?? releaseArchiveUrl)
+  return redirect(await latestArchiveUrl(context.env.ASSETS, context.request.url))
 }

--- a/site/functions/lib/release.test.ts
+++ b/site/functions/lib/release.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { latestArchiveUrl, releasesPageUrl } from './release'
+
+function feed(items: string) {
+  return `<?xml version="1.0"?><rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel>${items}</channel></rss>`
+}
+
+function item(version: string, url: string) {
+  return `<item><sparkle:version>${version}</sparkle:version><enclosure\n  url="${url}"\n  length="1" type="application/octet-stream"/></item>`
+}
+
+const assets = (body: string | null) => ({
+  fetch: async () => body === null ? new Response('gone', { status: 404 }) : new Response(body),
+})
+
+describe('latestArchiveUrl', () => {
+  it('answers with the disk image beside the newest enclosure', async () => {
+    const xml = feed(
+      item('1.0.1', 'https://github.com/Rydersel/Candela/releases/download/v1.0.1/Candela-1.0.1.zip')
+      + item('1.0.0', 'https://github.com/Rydersel/Candela/releases/download/v1.0.0/Candela-1.0.0.zip'),
+    )
+    expect(await latestArchiveUrl(assets(xml), 'https://candela.fyi/download'))
+      .toBe('https://github.com/Rydersel/Candela/releases/download/v1.0.1/Candela-1.0.1.dmg')
+  })
+
+  it('picks the highest version, not the first item, and compares numerically', async () => {
+    const xml = feed(
+      item('1.9.0', 'https://example.test/v1.9.0/Candela-1.9.0.zip')
+      + item('1.10.0', 'https://example.test/v1.10.0/Candela-1.10.0.zip')
+      + item('1.2.0', 'https://example.test/v1.2.0/Candela-1.2.0.zip'),
+    )
+    expect(await latestArchiveUrl(assets(xml), 'https://candela.fyi/download'))
+      .toBe('https://example.test/v1.10.0/Candela-1.10.0.dmg')
+  })
+
+  it('keeps an enclosure that is already a disk image', async () => {
+    const xml = feed(item('2.0.0', 'https://example.test/v2.0.0/Candela-2.0.0.dmg'))
+    expect(await latestArchiveUrl(assets(xml), 'https://candela.fyi/download'))
+      .toBe('https://example.test/v2.0.0/Candela-2.0.0.dmg')
+  })
+
+  it('falls back to the releases page when the feed is missing, empty or unreadable', async () => {
+    expect(await latestArchiveUrl(assets(null), 'https://candela.fyi/download')).toBe(releasesPageUrl)
+    expect(await latestArchiveUrl(assets(feed('')), 'https://candela.fyi/download')).toBe(releasesPageUrl)
+    const throwing = { fetch: async () => { throw new Error('no assets') } }
+    expect(await latestArchiveUrl(throwing, 'https://candela.fyi/download')).toBe(releasesPageUrl)
+  })
+
+  it('reads the feed from the same origin as the request', async () => {
+    const seen: string[] = []
+    const recording = { fetch: async (request: Request) => { seen.push(request.url); return new Response(feed('')) } }
+    await latestArchiveUrl(recording, 'https://preview.candela.pages.dev/download?placement=hero')
+    expect(seen).toEqual(['https://preview.candela.pages.dev/appcast.xml'])
+  })
+})

--- a/site/functions/lib/release.ts
+++ b/site/functions/lib/release.ts
@@ -1,0 +1,37 @@
+import type { StaticAssets } from './runtime'
+
+export const releasesPageUrl = 'https://github.com/Rydersel/Candela/releases/latest'
+
+// The appcast cannot fall behind: a release that skips it is invisible to shipped apps.
+// Its enclosure is the zip Sparkle installs; the dmg sits beside it under the same name.
+export async function latestArchiveUrl(assets: StaticAssets, requestUrl: string) {
+  try {
+    const feed = await assets.fetch(new Request(new URL('/appcast.xml', requestUrl)))
+    if (!feed.ok) return releasesPageUrl
+    const newest = newestEnclosure(await feed.text())
+    return newest ? newest.replace(/\.zip$/, '.dmg') : releasesPageUrl
+  } catch {
+    return releasesPageUrl
+  }
+}
+
+function newestEnclosure(xml: string) {
+  let best: { version: number[]; url: string } | null = null
+  for (const [, item] of xml.matchAll(/<item>([\s\S]*?)<\/item>/g)) {
+    const version = item.match(/<sparkle:version>\s*([^<\s]+)\s*</)?.[1]
+    const url = item.match(/<enclosure[^>]*?\burl="([^"]+)"/)?.[1]
+    if (!version || !url) continue
+    const parts = version.split('.').map(Number)
+    if (parts.some(Number.isNaN)) continue
+    if (!best || compareVersions(parts, best.version) > 0) best = { version: parts, url }
+  }
+  return best?.url ?? null
+}
+
+function compareVersions(a: number[], b: number[]) {
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const difference = (a[i] ?? 0) - (b[i] ?? 0)
+    if (difference !== 0) return difference
+  }
+  return 0
+}

--- a/site/functions/lib/runtime.ts
+++ b/site/functions/lib/runtime.ts
@@ -27,10 +27,16 @@ export type AnalyticsEngineDataset = {
   writeDataPoint(event: { blobs?: string[]; doubles?: number[]; indexes?: string[] }): void
 }
 
+// Pages' static asset binding. It skips the Functions router, so the middleware
+// never counts an appcast read through it as an update check.
+export type StaticAssets = {
+  fetch(request: Request): Promise<Response>
+}
+
 export type AnalyticsEnv = {
+  ASSETS: StaticAssets
   ANALYTICS_DB: D1Database
   ANALYTICS_SIGNING_KEY: string
-  RELEASE_DOWNLOAD_URL?: string
   // One dataset per counted event, so the dashboard's dataset picker is the
   // chart picker.
   ANALYTICS_PAGEVIEWS?: AnalyticsEngineDataset

--- a/site/functions/routes.test.ts
+++ b/site/functions/routes.test.ts
@@ -34,26 +34,24 @@ class Database implements D1Database {
 
 const events: Record<string, unknown[]> = { pageviews: [], downloads: [], github: [] }
 
-function context(request: Request, db = new Database()): FunctionContext {
+const feed = '<?xml version="1.0"?><rss><channel>'
+  + '<item><sparkle:version>1.0.1</sparkle:version><enclosure url="https://github.com/Rydersel/Candela/releases/download/v1.0.1/Candela-1.0.1.zip" length="1" type="application/octet-stream"/></item>'
+  + '<item><sparkle:version>1.0.0</sparkle:version><enclosure url="https://github.com/Rydersel/Candela/releases/download/v1.0.0/Candela-1.0.0.zip" length="1" type="application/octet-stream"/></item>'
+  + '</channel></rss>'
+const latestDmg = 'https://github.com/Rydersel/Candela/releases/download/v1.0.1/Candela-1.0.1.dmg'
+
+function context(request: Request, db = new Database(), feedMissing = false): FunctionContext {
   return {
     request,
     env: {
+      ASSETS: { fetch: async () => feedMissing ? new Response('gone', { status: 404 }) : new Response(feed) },
       ANALYTICS_DB: db,
       ANALYTICS_SIGNING_KEY: 'a-test-secret-that-is-long-enough-for-hmac',
-      RELEASE_DOWNLOAD_URL: 'https://candela.fyi/Candela-1.0.0.dmg',
       ANALYTICS_PAGEVIEWS: { writeDataPoint: (event) => { events.pageviews.push(event) } },
       ANALYTICS_DOWNLOADS: { writeDataPoint: (event) => { events.downloads.push(event) } },
       ANALYTICS_GITHUB: { writeDataPoint: (event) => { events.github.push(event) } },
     },
   }
-}
-
-// No RELEASE_DOWNLOAD_URL, so the built-in fallback answers. It shipped
-// pointing at a release that did not exist, and nothing exercised this branch.
-function contextWithoutReleaseUrl(request: Request): FunctionContext {
-  const value = context(request)
-  delete value.env.RELEASE_DOWNLOAD_URL
-  return value
 }
 
 function post(path: string, cookie?: string) {
@@ -116,7 +114,7 @@ describe('analytics routes', () => {
       redirect: 'manual',
     }), new Database(true)))
     expect(failed.status).toBe(302)
-    expect(failed.headers.get('location')).toBe('https://candela.fyi/Candela-1.0.0.dmg')
+    expect(failed.headers.get('location')).toBe(latestDmg)
 
     const db = new Database()
     const before = events.github.length
@@ -158,14 +156,22 @@ describe('analytics routes', () => {
     expect(events.downloads.slice(before)).toContainEqual({ indexes: ['guide'], blobs: ['guide', 'unknown', 'unknown'], doubles: [1] })
   })
 
-  it('falls back to the current release archive when no download URL is configured', async () => {
-    const response = await download(contextWithoutReleaseUrl(new Request('https://candela.fyi/download', {
+  it('sends the download to the newest disk image the appcast lists', async () => {
+    const response = await download(context(new Request('https://candela.fyi/download', {
       headers: { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'navigate', 'sec-fetch-dest': 'document' },
       redirect: 'manual',
     })))
     expect(response.status).toBe(302)
-    expect(response.headers.get('location')).toBe(
-      'https://github.com/Rydersel/Candela/releases/download/v1.0.0/Candela-1.0.0.dmg',
-    )
+    expect(response.headers.get('location')).toBe(latestDmg)
+  })
+
+  // A pinned fallback URL once shipped one release behind; the releases page cannot go stale.
+  it('falls back to the releases page when the appcast cannot be read', async () => {
+    const response = await download(context(new Request('https://candela.fyi/download', {
+      headers: { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'navigate', 'sec-fetch-dest': 'document' },
+      redirect: 'manual',
+    }), new Database(), true))
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://github.com/Rydersel/Candela/releases/latest')
   })
 })

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -2,9 +2,6 @@
   "name": "candela-site",
   "compatibility_date": "2026-09-01",
   "pages_build_output_dir": "./dist",
-  "vars": {
-    "RELEASE_DOWNLOAD_URL": "https://github.com/Rydersel/Candela/releases/download/v1.0.0/Candela-1.0.0.dmg"
-  },
   "analytics_engine_datasets": [
     { "binding": "ANALYTICS_PAGEVIEWS", "dataset": "candela_site_pageviews" },
     { "binding": "ANALYTICS_DOWNLOADS", "dataset": "candela_site_downloads" },


### PR DESCRIPTION
## Why

The download route redirected to a URL pinned in `wrangler.jsonc`, with a second copy pinned in the function itself. The 1.0.1 release updated the appcast, as every release must, and touched neither, so the README's download button and the site's own download buttons kept serving the 1.0.0 disk image.

## What

- `/download` now reads `public/appcast.xml` through the static-asset binding, takes the highest version listed, and redirects to the disk image beside that item's zip enclosure (same URL, `.dmg` for `.zip`). A release is live on every download button the moment its appcast item deploys.
- If the feed cannot be read, the redirect lands on the GitHub releases page, which cannot go stale either.
- The `RELEASE_DOWNLOAD_URL` var is removed from `wrangler.jsonc`, the env type and the tests. The site README describes the new behaviour and its verification step.

## Verification

- `npm test`, `npm run lint` and `npm run build` pass in `site/`.
- New tests cover: the newest item wins by numeric version rather than position, an enclosure already ending in `.dmg` is kept, a missing, empty or throwing feed falls back to the releases page, and the feed is read from the request's own origin so previews resolve against their own appcast.
- The committed appcast resolves through the helper to `.../v1.0.1/Candela-1.0.1.dmg`, and GitHub answers that URL with a 302 to the asset.
- After deploy: `curl -sI 'https://candela.fyi/download?placement=readme'` should redirect to the 1.0.1 disk image.