### PR TITLE
Fixes across the panel, Settings, Health, Checkup, Setup and the engine

### DIFF
--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -427,7 +427,11 @@ final class AppModel {
     // that outlived it would stand until quit with every control that knew about
     // it already rebuilt. The engine's table is stale for the rest of the session
     // either way, so the log line is what a later report has to explain it by.
-    if await synthesis.disengageAllForReset() == false {
+    //
+    // `force` for the same reason, one step earlier: a gate claim held by
+    // another feature does not get to leave a set standing through a reset that
+    // is about to rebuild the controller which would have taken it down.
+    if await synthesis.disengageAllForReset(force: true) == false {
       log.error("reset: the synthesis engine refused its teardown; the virtual displays go down without it")
     }
     let host = virtualDisplays

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -428,11 +428,9 @@ final class AppModel {
     // it already rebuilt. The engine's table is stale for the rest of the session
     // either way, so the log line is what a later report has to explain it by.
     //
-    // `force` for the same reason, one step earlier: a gate claim held by
-    // another feature does not get to leave a set standing through a reset that
-    // is about to rebuild the controller which would have taken it down. It
-    // WAITS for that claim rather than barging past it, and only proceeds
-    // unclaimed once the wait runs out.
+    // `force`: a claim held by another feature must not leave a set standing
+    // through a reset that rebuilds the controller which would take it down. It
+    // waits for the claim and only goes on unclaimed once the wait runs out.
     if await synthesis.disengageAllForReset(force: true) == false {
       log.error("reset: the synthesis engine refused its teardown; the virtual displays go down without it")
     }

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -237,7 +237,7 @@ final class AppModel {
   /// other two it persists nothing, since a rotation is already system state the
   /// instant it applies.
   @ObservationIgnored private(set) lazy var rotation = RotationCoordinator(
-    gate: reconfigurationGate
+    gate: reconfigurationGate, topologyStore: mirrorTopology
   )
 
   /// The display arrangement, its preview countdown, and the layout on screen.
@@ -430,7 +430,9 @@ final class AppModel {
     //
     // `force` for the same reason, one step earlier: a gate claim held by
     // another feature does not get to leave a set standing through a reset that
-    // is about to rebuild the controller which would have taken it down.
+    // is about to rebuild the controller which would have taken it down. It
+    // WAITS for that claim rather than barging past it, and only proceeds
+    // unclaimed once the wait runs out.
     if await synthesis.disengageAllForReset(force: true) == false {
       log.error("reset: the synthesis engine refused its teardown; the virtual displays go down without it")
     }

--- a/Candela/App/DebugPanelDump.swift
+++ b/Candela/App/DebugPanelDump.swift
@@ -95,6 +95,14 @@
         ("brightness", value(controller.brightness)),
         ("hdrEngaged", yesNo(controller.isHDREngaged)),
         ("hdrSupported", yesNo(controller.supportsHDR)),
+        ("hdrProbed", yesNo(controller.hdrCapabilityProbed)),
+        // The caption the greyed HDR button carries, from the same pure helper
+        // the row calls, so a rig leg can read the reason without a hover.
+        ("hdrRefusal", quoted(PanelView.hdrRefusalReason(
+          isShowingSynthesizedSize: model.synthesis.isEngaged(displayID: state.display.id),
+          isHDREngaged: controller.isHDREngaged,
+          supportsHDR: controller.supportsHDR,
+          capabilityProbed: controller.hdrCapabilityProbed) ?? "none")),
         ("hdrMode", controller.hdrMode == .off ? "off" : "alwaysOn"),
         // The verdict and the caption, from the same accessors the row's body
         // calls: the only way a rig leg can assert a degraded panel says so.

--- a/Candela/App/DebugPanelDump.swift
+++ b/Candela/App/DebugPanelDump.swift
@@ -96,8 +96,8 @@
         ("hdrEngaged", yesNo(controller.isHDREngaged)),
         ("hdrSupported", yesNo(controller.supportsHDR)),
         ("hdrProbed", yesNo(controller.hdrCapabilityProbed)),
-        // The caption the greyed HDR button carries, from the same pure helper
-        // the row calls, so a rig leg can read the reason without a hover.
+        // From the same helper the row calls, so a rig leg can read the reason
+        // without a hover.
         ("hdrRefusal", quoted(PanelView.hdrRefusalReason(
           isShowingSynthesizedSize: model.synthesis.isEngaged(displayID: state.display.id),
           isHDREngaged: controller.isHDREngaged,

--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -1308,6 +1308,11 @@ final class DisplayModeCoordinator {
     }
     switch await session.begin(mode: mode, on: displayID) {
     case .success:
+      // Cancelled BEFORE the await, not after `startCountdown()`: the previous
+      // preview's driver is still looping, and a tick landing during `adopt`
+      // knocks seconds off the fresh preview. This narrows the window rather
+      // than closing it.
+      stopCountdown()
       await adopt(.clear)
       startCountdown()
     case let .failure(error):
@@ -1427,6 +1432,11 @@ final class DisplayModeCoordinator {
       size, onPhysical: displayID, identityKey: display.identity.key
     ) {
     case .success:
+      // Cancelled BEFORE the await, not after the start below: the previous
+      // preview's driver is still looping, and a tick landing during `adopt`
+      // knocks seconds off the fresh preview. This narrows the window rather
+      // than closing it.
+      stopCountdown()
       await adopt(.clear, synthesis: .clear)
       // Guarded on a preview actually standing, which a successful engage does
       // not guarantee: the engage runs its own departure sweep when it lands, and

--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -1308,10 +1308,8 @@ final class DisplayModeCoordinator {
     }
     switch await session.begin(mode: mode, on: displayID) {
     case .success:
-      // Cancelled BEFORE the await, not after `startCountdown()`: the previous
-      // preview's driver is still looping, and a tick landing during `adopt`
-      // knocks seconds off the fresh preview. This narrows the window rather
-      // than closing it.
+      // Before the await: a tick from the previous driver landing during `adopt`
+      // knocks seconds off the fresh preview. Narrows the window, does not close it.
       stopCountdown()
       await adopt(.clear)
       startCountdown()
@@ -1432,10 +1430,8 @@ final class DisplayModeCoordinator {
       size, onPhysical: displayID, identityKey: display.identity.key
     ) {
     case .success:
-      // Cancelled BEFORE the await, not after the start below: the previous
-      // preview's driver is still looping, and a tick landing during `adopt`
-      // knocks seconds off the fresh preview. This narrows the window rather
-      // than closing it.
+      // Before the await: a tick from the previous driver landing during `adopt`
+      // knocks seconds off the fresh preview. Narrows the window, does not close it.
       stopCountdown()
       await adopt(.clear, synthesis: .clear)
       // Guarded on a preview actually standing, which a successful engage does

--- a/Candela/App/RotationCoordinator.swift
+++ b/Candela/App/RotationCoordinator.swift
@@ -47,6 +47,10 @@ final class RotationCoordinator {
   /// outstanding. Not defaulted: a per-coordinator default would compile, run,
   /// and exclude nobody.
   @ObservationIgnored private let gate: DisplayReconfigurationGate
+  /// The pairing sample the synthesis carve-out reads. The raw mirroring flag on
+  /// `ConfiguredDisplay` cannot tell a size this app renders from a mirror the
+  /// user set up, and the two get different refusals.
+  @ObservationIgnored private let topologyStore: any MirrorTopologyProviding
   @ObservationIgnored private let session: RotationPreviewSession
   @ObservationIgnored private let queue = PreviewQueue()
   @ObservationIgnored private let countdown = PreviewCountdownDriver()
@@ -62,10 +66,12 @@ final class RotationCoordinator {
 
   init(
     gate: DisplayReconfigurationGate,
+    topologyStore: any MirrorTopologyProviding,
     configurator: any DisplayConfiguring = CoreGraphicsDisplayConfigurator(),
     timeoutSeconds: Int = 30
   ) {
     self.gate = gate
+    self.topologyStore = topologyStore
     self.configurator = configurator
     session = RotationPreviewSession(configurator: configurator, timeoutSeconds: timeoutSeconds)
     // A rotation fires this notification itself, so besides departures this is
@@ -107,6 +113,13 @@ final class RotationCoordinator {
   /// cannot work.
   var canRotate: Bool { configurator.canRotate }
 
+  /// Whether this display is showing a size the app renders for it. The row
+  /// reads this rather than sampling a topology of its own, so the caption it
+  /// shows and the refusal the policy would return cannot disagree.
+  func isSynthesizedSize(_ displayID: CGDirectDisplayID) -> Bool {
+    MirroringPredicates.isSynthesized(topologyStore.topology(), displayID: displayID)
+  }
+
   func rotation(of displayID: CGDirectDisplayID) -> DisplayRotation? {
     configurator.rotation(of: displayID)
   }
@@ -127,7 +140,8 @@ final class RotationCoordinator {
       to: requested,
       in: configurator.displays(),
       currentRotation: configurator.rotation(of: displayID),
-      isSupported: configurator.canRotate
+      isSupported: configurator.canRotate,
+      isSynthesizedSize: isSynthesizedSize(displayID)
     )
     switch decision {
     case let .refused(refusal):

--- a/Candela/App/RotationCoordinator.swift
+++ b/Candela/App/RotationCoordinator.swift
@@ -47,9 +47,8 @@ final class RotationCoordinator {
   /// outstanding. Not defaulted: a per-coordinator default would compile, run,
   /// and exclude nobody.
   @ObservationIgnored private let gate: DisplayReconfigurationGate
-  /// The pairing sample the synthesis carve-out reads. The raw mirroring flag on
-  /// `ConfiguredDisplay` cannot tell a size this app renders from a mirror the
-  /// user set up, and the two get different refusals.
+  /// The raw mirroring flag cannot tell a rendered size from a user's mirror,
+  /// and the two get different refusals.
   @ObservationIgnored private let topologyStore: any MirrorTopologyProviding
   @ObservationIgnored private let session: RotationPreviewSession
   @ObservationIgnored private let queue = PreviewQueue()
@@ -113,9 +112,7 @@ final class RotationCoordinator {
   /// cannot work.
   var canRotate: Bool { configurator.canRotate }
 
-  /// Whether this display is showing a size the app renders for it. The row
-  /// reads this rather than sampling a topology of its own, so the caption it
-  /// shows and the refusal the policy would return cannot disagree.
+  /// The flag `rotate` hands `RotationPolicy`, read off the coordinator's own store.
   func isSynthesizedSize(_ displayID: CGDirectDisplayID) -> Bool {
     MirroringPredicates.isSynthesized(topologyStore.topology(), displayID: displayID)
   }

--- a/Candela/App/RotationCopy.swift
+++ b/Candela/App/RotationCopy.swift
@@ -60,6 +60,7 @@ enum RotationCopy {
     case .unreadable: "This display reports an orientation Candela does not recognize, so it will not offer to change it."
     case .unchanged: "That display is already in this orientation."
     case .mirrored: "This display is showing another display's image. \(AppInfo.productName) will not rotate it."
+    case .synthesizedSize: "Turn off the size \(AppInfo.productName) renders to rotate this display."
     }
   }
 

--- a/Candela/App/RotationCopy.swift
+++ b/Candela/App/RotationCopy.swift
@@ -59,6 +59,7 @@ enum RotationCopy {
     case .displayGone: "That display disconnected before the change could be made."
     case .unreadable: "This display reports an orientation Candela does not recognize, so it will not offer to change it."
     case .unchanged: "That display is already in this orientation."
+    case .mirrored: "This display is showing another display's image. \(AppInfo.productName) will not rotate it."
     }
   }
 

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -679,11 +679,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // hung teardown fall through to mach-port reclaim.
       let finished = DispatchSemaphore(value: 0)
       // The ceiling is derived from the work it bounds, not chosen next to it: a
-      // second literal drifts from the departure timeout it is meant to cover,
-      // and the old one held main for 4 s over a poll that could not run that
-      // long. One poll per live slot, plus a margin for the teardown itself.
+      // second literal drifts from the departure timeout it is meant to cover.
+      // Each slot costs a poll PLUS a full CG configuration transaction, since
+      // `destroy` breaks the mirrors this display masters before it polls, so
+      // the per-slot budget carries a margin for that transaction. Floored at
+      // the 4 s the old literal gave, which no teardown may come in under.
       let departureTimeout: TimeInterval = 1.5
-      let ceiling = departureTimeout * Double(max(1, virtualDisplayHost.live().count)) + 0.25
+      let ceiling = max(4, (departureTimeout + 0.75) * Double(max(1, virtualDisplayHost.live().count)))
       DispatchQueue.global(qos: .userInitiated).async {
         virtualDisplayHost.destroyAll(departureTimeout: departureTimeout)
         finished.signal()
@@ -960,6 +962,15 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // combined-mode dimming at quit, and safe mode never installed any, so
     // skipping it leaves the monitor where the user last put it.
     guard !isSafeMode else { return }
+    // Whether either leg actually SUBMITTED anything, read off the submission
+    // counter rather than inferred: `restoreFullRangeDDC` returns early on the
+    // native path, under forced software, and on a display whose DDC brightness
+    // is turned off, so a display list is no evidence that a write exists.
+    // Marked BEFORE the lock-dim release, not between the two: on an HDR
+    // display the release submits through the native leg and the restore below
+    // returns at its own native guard, so a mark taken after it would see no
+    // movement and skip the settle nap over a write still in flight.
+    let marks = model.displays.map { ($0, $0.controller.submissionMark()) }
     // AFTER the gamma reset and shade removal, which tear the software surfaces
     // down unconditionally, so the restore below leaves the user's value on a
     // clean surface. BEFORE the full-range restore: quitting while a display is
@@ -967,16 +978,11 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // `restoreFullRangeDDC` returns early on the native path, which is exactly
     // where an HDR display's lock dim lives.
     model.oledCare.endAllLockDims()
-    // Whether the restore actually SUBMITTED anything, read off the submission
-    // counter rather than inferred: `restoreFullRangeDDC` returns early on the
-    // native path, under forced software, and on a display whose DDC brightness
-    // is turned off, so a display list is no evidence that a write exists.
     var submittedRestore = false
-    for state in model.displays {
+    for (state, mark) in marks {
       // Quitting while DisplayManager is suspended (mid-reconfigure or asleep)
       // silently drops this at the epoch gate. Best-effort is the
       // restore-choreography contract.
-      let mark = state.controller.submissionMark()
       state.controller.restoreFullRangeDDC()
       submittedRestore = submittedRestore || state.controller.submissionMark() != mark
     }

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -678,12 +678,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // and DDC traffic on a process that is going away. The bounded wait lets a
       // hung teardown fall through to mach-port reclaim.
       let finished = DispatchSemaphore(value: 0)
-      // The ceiling is derived from the work it bounds, not chosen next to it: a
-      // second literal drifts from the departure timeout it is meant to cover.
-      // Each slot costs a poll PLUS a full CG configuration transaction, since
-      // `destroy` breaks the mirrors this display masters before it polls, so
-      // the per-slot budget carries a margin for that transaction. Floored at
-      // the 4 s the old literal gave, which no teardown may come in under.
+      // Per slot: the departure poll plus a CG transaction, since `destroy`
+      // breaks the mirrors it masters before polling. Floored at 4 s.
       let departureTimeout: TimeInterval = 1.5
       let ceiling = max(4, (departureTimeout + 0.75) * Double(max(1, virtualDisplayHost.live().count)))
       DispatchQueue.global(qos: .userInitiated).async {
@@ -962,14 +958,9 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // combined-mode dimming at quit, and safe mode never installed any, so
     // skipping it leaves the monitor where the user last put it.
     guard !isSafeMode else { return }
-    // Whether either leg actually SUBMITTED anything, read off the submission
-    // counter rather than inferred: `restoreFullRangeDDC` returns early on the
-    // native path, under forced software, and on a display whose DDC brightness
-    // is turned off, so a display list is no evidence that a write exists.
-    // Marked BEFORE the lock-dim release, not between the two: on an HDR
-    // display the release submits through the native leg and the restore below
-    // returns at its own native guard, so a mark taken after it would see no
-    // movement and skip the settle nap over a write still in flight.
+    // Submission counters, not the display list: `restoreFullRangeDDC` returns
+    // early on several paths, so a display is no evidence of a write. Marked
+    // before the lock-dim release, whose native-leg write the mark must cover.
     let marks = model.displays.map { ($0, $0.controller.submissionMark()) }
     // AFTER the gamma reset and shade removal, which tear the software surfaces
     // down unconditionally, so the restore below leaves the user's value on a
@@ -1244,12 +1235,9 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // that follows cannot observe a stale ON.
     try? await SMAppService.mainApp.unregister()
 
-    // ---- 3b. Sparkle keeps its settings in OUR defaults domain under its own
-    //          schema (`SUEnableAutomaticChecks` and friends), so the wipe below
-    //          takes the update preference with it. The button clears Candela's
-    //          settings; whether the app checks for updates is not one of the
-    //          things it offers to change, so it is read here and written back
-    //          after.
+    // ---- 3b. Sparkle stores its keys in our defaults domain, so the wipe would
+    //          take the update preference, which this button does not offer to
+    //          change. Read here, written back after.
     let automaticUpdateChecks = updaterModel.automaticallyChecksForUpdates
 
     // ---- 4. The wipe itself.
@@ -1274,9 +1262,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       prefs.muted = true
     }
 
-    // ---- 4c. The update preference back, through Sparkle rather than by
-    //          writing its key: the updater is the store, and a key written
-    //          behind it would not reach the running scheduler.
+    // ---- 4c. Through Sparkle, not its key: a key written behind the updater
+    //          never reaches the running scheduler.
     updaterModel.automaticallyChecksForUpdates = automaticUpdateChecks
 
     // ---- 5. Rebuild, do NOT merely refresh. `refresh()` would reuse every
@@ -1349,8 +1336,7 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     settingsActions.rearmTap()
     updateStatusItemVisibility()
     model.notePrefsChanged()
-    // The About pane's toggle and its "Last checked" line are mirrors of
-    // Sparkle's own state, and the wipe moved that state underneath them.
+    // The About pane mirrors Sparkle's state, which the wipe just moved.
     updaterModel.refreshFromUpdater()
     // Post-reset state IS first-run state: prefsSchemaVersion is gone, so
     // onboarding re-runs.
@@ -1448,13 +1434,9 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     model.noteTapArmed(config)
   }
 
-  /// The bar glyph, filled while a keep-awake assertion is held. Keep Display
-  /// Awake defeats a power setting the user chose and suppresses OLED care's
-  /// idle dim, blackout and unfocused dim for the session, so a hold that is
-  /// only visible with the panel open is a hold nobody remembers taking.
-  ///
-  /// A refused assertion leaves `isOn` false and the glyph idle, which is the
-  /// honest reading: nothing is held.
+  /// Filled while a keep-awake assertion is held: it suppresses every OLED care
+  /// dim for the session, so a hold visible only inside the panel is one nobody
+  /// remembers taking. A refused assertion leaves `isOn` false and the glyph idle.
   private func updateStatusItemImage() {
     guard let statusItem else { return }
     let isHeld = model.keepAwake.isOn
@@ -1463,9 +1445,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       accessibilityDescription: isHeld ? "Candela, keeping the display awake" : "Candela")
   }
 
-  /// Re-arms after every change, the pattern `OnboardingLiveApplier` uses:
-  /// `withObservationTracking` fires its `onChange` once, before the write
-  /// lands, so the new value is read on the hop rather than in the callback.
+  /// `withObservationTracking` fires once, before the write lands, so the value
+  /// is read on the hop and the tracking re-armed there.
   private func trackKeepAwake() {
     withObservationTracking {
       _ = model.keepAwake.isOn

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -2,6 +2,7 @@ import AppKit
 // @preconcurrency: same mutable-C-global import quirk as AccessibilityPermission.
 @preconcurrency import ApplicationServices
 import CandelaKit
+import Observation
 import os
 import ServiceManagement
 import SwiftUI
@@ -186,11 +187,12 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     menu.addItem(panelItem)
 
     let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    item.button?.image = NSImage(systemSymbolName: "sun.max", accessibilityDescription: "Candela")
     item.menu = menu
     // Fork parity: the icon can be ⌘-dragged off the bar, and we persist that.
     item.behavior = .removalAllowed
     statusItem = item
+    updateStatusItemImage()
+    trackKeepAwake()
 
     // Panel controls that have to end this tracking session reach it through
     // here: the gear button (a window cannot take focus while it runs) and
@@ -676,11 +678,17 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // and DDC traffic on a process that is going away. The bounded wait lets a
       // hung teardown fall through to mach-port reclaim.
       let finished = DispatchSemaphore(value: 0)
+      // The ceiling is derived from the work it bounds, not chosen next to it: a
+      // second literal drifts from the departure timeout it is meant to cover,
+      // and the old one held main for 4 s over a poll that could not run that
+      // long. One poll per live slot, plus a margin for the teardown itself.
+      let departureTimeout: TimeInterval = 1.5
+      let ceiling = departureTimeout * Double(max(1, virtualDisplayHost.live().count)) + 0.25
       DispatchQueue.global(qos: .userInitiated).async {
-        virtualDisplayHost.destroyAll(departureTimeout: 1.5)
+        virtualDisplayHost.destroyAll(departureTimeout: departureTimeout)
         finished.signal()
       }
-      _ = finished.wait(timeout: .now() + 4)
+      _ = finished.wait(timeout: .now() + ceiling)
     }
 
     // Nobody else calls this. A no-op while the version key is absent (first
@@ -959,17 +967,24 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // `restoreFullRangeDDC` returns early on the native path, which is exactly
     // where an HDR display's lock dim lives.
     model.oledCare.endAllLockDims()
+    // Whether the restore actually SUBMITTED anything, read off the submission
+    // counter rather than inferred: `restoreFullRangeDDC` returns early on the
+    // native path, under forced software, and on a display whose DDC brightness
+    // is turned off, so a display list is no evidence that a write exists.
+    var submittedRestore = false
     for state in model.displays {
       // Quitting while DisplayManager is suspended (mid-reconfigure or asleep)
       // silently drops this at the epoch gate. Best-effort is the
       // restore-choreography contract.
+      let mark = state.controller.submissionMark()
       state.controller.restoreFullRangeDDC()
+      submittedRestore = submittedRestore || state.controller.submissionMark() != mark
     }
     // Best-effort barrier: the coalescer drains on the global executor, so a
     // short main-thread nap gives the ~20 ms/display DDC transactions time to
     // land before exit. Awaiting the main-actor waiters here would deadlock,
     // since terminate is synchronous on main.
-    if !model.displays.isEmpty {
+    if submittedRestore {
       Thread.sleep(forTimeInterval: 0.25)
     }
   }
@@ -1220,6 +1235,14 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // that follows cannot observe a stale ON.
     try? await SMAppService.mainApp.unregister()
 
+    // ---- 3b. Sparkle keeps its settings in OUR defaults domain under its own
+    //          schema (`SUEnableAutomaticChecks` and friends), so the wipe below
+    //          takes the update preference with it. The button clears Candela's
+    //          settings; whether the app checks for updates is not one of the
+    //          things it offers to change, so it is read here and written back
+    //          after.
+    let automaticUpdateChecks = updaterModel.automaticallyChecksForUpdates
+
     // ---- 4. The wipe itself.
     UserDefaults.standard.removePersistentDomain(
       forName: Bundle.main.bundleIdentifier ?? "com.rydersel.Candela"
@@ -1241,6 +1264,11 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       prefs.enableMuteUnmute = usedMuteCommand
       prefs.muted = true
     }
+
+    // ---- 4c. The update preference back, through Sparkle rather than by
+    //          writing its key: the updater is the store, and a key written
+    //          behind it would not reach the running scheduler.
+    updaterModel.automaticallyChecksForUpdates = automaticUpdateChecks
 
     // ---- 5. Rebuild, do NOT merely refresh. `refresh()` would reuse every
     //         controller for a still-connected display and leave it holding
@@ -1312,6 +1340,9 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     settingsActions.rearmTap()
     updateStatusItemVisibility()
     model.notePrefsChanged()
+    // The About pane's toggle and its "Last checked" line are mirrors of
+    // Sparkle's own state, and the wipe moved that state underneath them.
+    updaterModel.refreshFromUpdater()
     // Post-reset state IS first-run state: prefsSchemaVersion is gone, so
     // onboarding re-runs.
     settingsActions.postReset()
@@ -1406,6 +1437,36 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     let config = model.tapConfig
     mediaKeyTap.update(config: config)
     model.noteTapArmed(config)
+  }
+
+  /// The bar glyph, filled while a keep-awake assertion is held. Keep Display
+  /// Awake defeats a power setting the user chose and suppresses OLED care's
+  /// idle dim, blackout and unfocused dim for the session, so a hold that is
+  /// only visible with the panel open is a hold nobody remembers taking.
+  ///
+  /// A refused assertion leaves `isOn` false and the glyph idle, which is the
+  /// honest reading: nothing is held.
+  private func updateStatusItemImage() {
+    guard let statusItem else { return }
+    let isHeld = model.keepAwake.isOn
+    statusItem.button?.image = NSImage(
+      systemSymbolName: isHeld ? "sun.max.fill" : "sun.max",
+      accessibilityDescription: isHeld ? "Candela, keeping the display awake" : "Candela")
+  }
+
+  /// Re-arms after every change, the pattern `OnboardingLiveApplier` uses:
+  /// `withObservationTracking` fires its `onChange` once, before the write
+  /// lands, so the new value is read on the hop rather than in the callback.
+  private func trackKeepAwake() {
+    withObservationTracking {
+      _ = model.keepAwake.isOn
+    } onChange: { [weak self] in
+      Task { @MainActor in
+        guard let self else { return }
+        self.updateStatusItemImage()
+        self.trackKeepAwake()
+      }
+    }
   }
 
   /// Applies the `menuIcon` mode to the status item. Called at launch, after

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -1199,9 +1199,12 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
           )
         }
         if !unmuteLanded {
-          log.error(
-            "reset: display \(state.display.persistenceKey, privacy: .public) could not be confirmed unmuted, so its mute state and strategy are kept across the wipe"
-          )
+          log.error("""
+            reset: display \
+            \(DisplayLogging.tag(for: state.display.persistenceKey), privacy: .public) \
+            could not be confirmed unmuted, so its mute state and strategy are kept \
+            across the wipe
+            """)
           // The STRATEGY AS IT STANDS, not a fixed value: restoring the wrong one
           // changes which wire a later unmute writes. Both are kept, because both
           // leave a panel silent: the dedicated command has no sender left once

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -784,7 +784,7 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // bar, where it aims at the top edge the bar slides out of. Pointing beats
     // auto-opening the panel (tried first): with the bar hidden, a programmatic
     // performClick shows a disembodied menu that teaches nothing.
-    controller.onFinishedByButton = { [weak self] in
+    controller.onFirstRunClosed = { [weak self] in
       Task { @MainActor in
         try? await Task.sleep(for: .milliseconds(400))
         self?.showSetupLandingCallout()

--- a/Candela/App/SynthesisCoordinator.swift
+++ b/Candela/App/SynthesisCoordinator.swift
@@ -481,12 +481,31 @@ final class SynthesisCoordinator {
   /// down": the pairing table is empty for the whole of an engage, so a caller
   /// that reads the table to judge the teardown has to read this first.
   ///
-  /// `force` belongs to the whole-app reset alone: it presses on through a
-  /// refused gate claim because it is wiping the domain and rebuilding anyway,
-  /// so a set left standing would outlive everything that knows about it. Every
-  /// other caller takes the refusal, the hotkey's unwind included.
+  /// `force` belongs to the whole-app reset alone, and it is a bounded WAIT
+  /// rather than a barge: a teardown staged behind a live configuration is the
+  /// interleaving that produces a success nobody achieved, so the reset retries
+  /// the claim for `forcedClaimWait` before it gives up on it. Only then does it
+  /// go on without one, naming the holder at `.error`, because the reset is
+  /// wiping the domain and rebuilding anyway and a set left standing would
+  /// outlive everything that knows about it. Every other caller takes the
+  /// refusal outright, the hotkey's unwind included.
+  ///
+  /// **The wait covers mirroring, rotation and arrangement, and those only.**
+  /// The gate is re-entrant per claimant and synthesis claims `.displayModes`,
+  /// the same claimant the mode coordinator uses, so a mode preview or apply is
+  /// granted here rather than refused and nothing is ever waited out for it.
+  /// `isWorking` is the check that answers for those, and it is re-checked after
+  /// the claim as well as before it: the top-of-function reading is older by the
+  /// preview stand-down, the claim's actor hop and, when forced, the wait.
+  ///
+  /// The window and the retry delay are parameters so a test can collapse them;
+  /// nothing in the app passes them.
   @discardableResult
-  func disengageAllForReset(force: Bool = false) async -> Bool {
+  func disengageAllForReset(
+    force: Bool = false,
+    forcedClaimWait: Duration = .seconds(2),
+    forcedClaimRetryDelay: Duration = .milliseconds(100)
+  ) async -> Bool {
     // Checked FIRST: the snapshot below is empty for the whole multi-second
     // engage, so it answers "nothing is engaged" about a machine that is about
     // to have a synthesis set on it.
@@ -501,13 +520,41 @@ final class SynthesisCoordinator {
     // with nothing left that knows about it. The disengage below is the
     // teardown that matters.
     _ = await endOutstandingPreview()
-    let claimed = await gate.claim(.displayModes).refusedBy == nil
+    var refusedBy = await gate.claim(.displayModes).refusedBy
     // A refused claim means another feature is mid-reconfiguration, and a
     // teardown staged behind its back is the raw change every other path here
     // refuses. `disengageForOptOut` returns false on the same answer.
+    //
+    // The reset waits it out instead. Most holders are a preview or a mode
+    // apply, both of which clear in well under the window.
+    if refusedBy != nil, force {
+      let deadline = ContinuousClock.now.advanced(by: forcedClaimWait)
+      while refusedBy != nil, ContinuousClock.now < deadline {
+        try? await Task.sleep(for: forcedClaimRetryDelay)
+        refusedBy = await gate.claim(.displayModes).refusedBy
+      }
+    }
+    // The top-of-function reading is stale by the stand-down, the claim's hop and
+    // any forced wait, and the gate cannot stand in for it: a mode preview or
+    // apply claims `.displayModes` too, so it is granted alongside this teardown
+    // instead of refusing it.
+    //
+    // Nothing is handed back on this path on purpose. The sequence now running
+    // shares the claimant, so a release here would take the gate out from under
+    // it; it comes back through the funnel when that sequence finishes.
+    guard !isWorking else {
+      log.error("synthesis: a hardware sequence started before the teardown could begin; nothing was taken down")
+      return false
+    }
+    let claimed = refusedBy == nil
     guard claimed || force else {
       log.error("synthesis: the reconfiguration gate refused the teardown claim; nothing was taken down")
       return false
+    }
+    if let holder = refusedBy {
+      // Unclaimed and going ahead regardless, so the log line is the only record
+      // that this teardown overlapped someone else's configuration.
+      log.error("synthesis reset: \(holder.rawValue, privacy: .public) still held the reconfiguration gate after the wait; the teardown goes ahead without the claim")
     }
     let engaged = pairings
     // Through the driver, so the panel comes back on the mode the user chose

--- a/Candela/App/SynthesisCoordinator.swift
+++ b/Candela/App/SynthesisCoordinator.swift
@@ -258,6 +258,14 @@ final class SynthesisCoordinator {
     guard offersSyntheticSizes(displayID: display.id) else { return .notOffered }
     if isInUserMirrorSet(display) { return .alreadyMirrored }
     if isHDREngaged(display.id) { return .hdrEngaged }
+    // Last, where `SynthesisReapplyPolicy` puts it. An ENGAGED display is never
+    // refused for it: `ModeSynthesisEngine.engage` takes that display's own
+    // pairing down before it allocates, so the slot is free by the time it asks.
+    //
+    // `.engine(.noFreeSlot)` rather than a reason of its own: the engine already
+    // answers this at the allocation, and one fact told two ways would need a
+    // second sentence saying the same thing.
+    if freeSlots == 0, !isEngaged(displayID: display.id) { return .engine(.noFreeSlot) }
     return nil
   }
 
@@ -472,8 +480,13 @@ final class SynthesisCoordinator {
   /// Returns false when it REFUSED, which is not the same as "nothing came
   /// down": the pairing table is empty for the whole of an engage, so a caller
   /// that reads the table to judge the teardown has to read this first.
+  ///
+  /// `force` belongs to the whole-app reset alone: it presses on through a
+  /// refused gate claim because it is wiping the domain and rebuilding anyway,
+  /// so a set left standing would outlive everything that knows about it. Every
+  /// other caller takes the refusal, the hotkey's unwind included.
   @discardableResult
-  func disengageAllForReset() async -> Bool {
+  func disengageAllForReset(force: Bool = false) async -> Bool {
     // Checked FIRST: the snapshot below is empty for the whole multi-second
     // engage, so it answers "nothing is engaged" about a machine that is about
     // to have a synthesis set on it.
@@ -489,6 +502,13 @@ final class SynthesisCoordinator {
     // teardown that matters.
     _ = await endOutstandingPreview()
     let claimed = await gate.claim(.displayModes).refusedBy == nil
+    // A refused claim means another feature is mid-reconfiguration, and a
+    // teardown staged behind its back is the raw change every other path here
+    // refuses. `disengageForOptOut` returns false on the same answer.
+    guard claimed || force else {
+      log.error("synthesis: the reconfiguration gate refused the teardown claim; nothing was taken down")
+      return false
+    }
     let engaged = pairings
     // Through the driver, so the panel comes back on the mode the user chose
     // rather than the HiDPI twin the engage tail re-timed it onto; the driver

--- a/Candela/App/SynthesisCoordinator.swift
+++ b/Candela/App/SynthesisCoordinator.swift
@@ -258,13 +258,8 @@ final class SynthesisCoordinator {
     guard offersSyntheticSizes(displayID: display.id) else { return .notOffered }
     if isInUserMirrorSet(display) { return .alreadyMirrored }
     if isHDREngaged(display.id) { return .hdrEngaged }
-    // Last, where `SynthesisReapplyPolicy` puts it. An ENGAGED display is never
-    // refused for it: `ModeSynthesisEngine.engage` takes that display's own
-    // pairing down before it allocates, so the slot is free by the time it asks.
-    //
-    // `.engine(.noFreeSlot)` rather than a reason of its own: the engine already
-    // answers this at the allocation, and one fact told two ways would need a
-    // second sentence saying the same thing.
+    // An engaged display is exempt: `engage` frees its own slot before it
+    // allocates. Reuses the engine's reason rather than minting a twin.
     if freeSlots == 0, !isEngaged(displayID: display.id) { return .engine(.noFreeSlot) }
     return nil
   }
@@ -481,25 +476,18 @@ final class SynthesisCoordinator {
   /// down": the pairing table is empty for the whole of an engage, so a caller
   /// that reads the table to judge the teardown has to read this first.
   ///
-  /// `force` belongs to the whole-app reset alone, and it is a bounded WAIT
-  /// rather than a barge: a teardown staged behind a live configuration is the
-  /// interleaving that produces a success nobody achieved, so the reset retries
-  /// the claim for `forcedClaimWait` before it gives up on it. Only then does it
-  /// go on without one, naming the holder at `.error`, because the reset is
-  /// wiping the domain and rebuilding anyway and a set left standing would
-  /// outlive everything that knows about it. Every other caller takes the
-  /// refusal outright, the hotkey's unwind included.
+  /// `force` is for the whole-app reset only. It waits up to `forcedClaimWait`
+  /// for a refused gate rather than barging: a teardown staged behind a live
+  /// configuration produces a success nobody achieved. Past the wait it goes on
+  /// unclaimed, logging the holder, because the reset wipes and rebuilds anyway
+  /// and a set left standing would outlive everything that knows about it.
   ///
-  /// **The wait covers mirroring, rotation and arrangement, and those only.**
-  /// The gate is re-entrant per claimant and synthesis claims `.displayModes`,
-  /// the same claimant the mode coordinator uses, so a mode preview or apply is
-  /// granted here rather than refused and nothing is ever waited out for it.
-  /// `isWorking` is the check that answers for those, and it is re-checked after
-  /// the claim as well as before it: the top-of-function reading is older by the
-  /// preview stand-down, the claim's actor hop and, when forced, the wait.
+  /// The wait covers mirroring, rotation and arrangement only: synthesis and the
+  /// mode coordinator share the `.displayModes` claimant, so a mode preview or
+  /// apply is granted here, not refused. `isWorking` answers for those, re-read
+  /// after the claim because the first reading predates the awaits.
   ///
-  /// The window and the retry delay are parameters so a test can collapse them;
-  /// nothing in the app passes them.
+  /// The window and retry delay are parameters only so a test can collapse them.
   @discardableResult
   func disengageAllForReset(
     force: Bool = false,
@@ -521,12 +509,8 @@ final class SynthesisCoordinator {
     // teardown that matters.
     _ = await endOutstandingPreview()
     var refusedBy = await gate.claim(.displayModes).refusedBy
-    // A refused claim means another feature is mid-reconfiguration, and a
-    // teardown staged behind its back is the raw change every other path here
-    // refuses. `disengageForOptOut` returns false on the same answer.
-    //
-    // The reset waits it out instead. Most holders are a preview or a mode
-    // apply, both of which clear in well under the window.
+    // Another feature is mid-reconfiguration. Every other path refuses here;
+    // the reset waits, since holders usually clear well inside the window.
     if refusedBy != nil, force {
       let deadline = ContinuousClock.now.advanced(by: forcedClaimWait)
       while refusedBy != nil, ContinuousClock.now < deadline {
@@ -534,14 +518,12 @@ final class SynthesisCoordinator {
         refusedBy = await gate.claim(.displayModes).refusedBy
       }
     }
-    // The top-of-function reading is stale by the stand-down, the claim's hop and
-    // any forced wait, and the gate cannot stand in for it: a mode preview or
-    // apply claims `.displayModes` too, so it is granted alongside this teardown
-    // instead of refusing it.
+    // Re-read: the first reading predates the stand-down, the claim hop and any
+    // wait, and the gate cannot cover this, since a mode preview or apply shares
+    // the `.displayModes` claimant and is granted alongside us.
     //
-    // Nothing is handed back on this path on purpose. The sequence now running
-    // shares the claimant, so a release here would take the gate out from under
-    // it; it comes back through the funnel when that sequence finishes.
+    // No release on this path: the running sequence shares the claim and hands
+    // the gate back through the funnel when it finishes.
     guard !isWorking else {
       log.error("synthesis: a hardware sequence started before the teardown could begin; nothing was taken down")
       return false
@@ -552,8 +534,7 @@ final class SynthesisCoordinator {
       return false
     }
     if let holder = refusedBy {
-      // Unclaimed and going ahead regardless, so the log line is the only record
-      // that this teardown overlapped someone else's configuration.
+      // The only record that this teardown overlapped someone else's configuration.
       log.error("synthesis reset: \(holder.rawValue, privacy: .public) still held the reconfiguration gate after the wait; the teardown goes ahead without the claim")
     }
     let engaged = pairings

--- a/Candela/App/UpdaterModel.swift
+++ b/Candela/App/UpdaterModel.swift
@@ -53,4 +53,18 @@ final class UpdaterModel {
   func checkForUpdates() {
     controller.checkForUpdates(nil)
   }
+
+  /// Re-reads everything mirrored here from the updater. For the settings reset,
+  /// which removes the whole defaults domain and takes Sparkle's keys with it:
+  /// without this the About pane keeps showing the toggle and the check date
+  /// that were true before the wipe.
+  ///
+  /// The toggle is assigned only when it differs, so a refresh does not send a
+  /// redundant write back through `didSet`.
+  func refreshFromUpdater() {
+    let automatic = controller.updater.automaticallyChecksForUpdates
+    if automaticallyChecksForUpdates != automatic { automaticallyChecksForUpdates = automatic }
+    lastUpdateCheckDate = controller.updater.lastUpdateCheckDate
+    canCheckForUpdates = controller.updater.canCheckForUpdates
+  }
 }

--- a/Candela/App/UpdaterModel.swift
+++ b/Candela/App/UpdaterModel.swift
@@ -54,13 +54,8 @@ final class UpdaterModel {
     controller.checkForUpdates(nil)
   }
 
-  /// Re-reads everything mirrored here from the updater. For the settings reset,
-  /// which removes the whole defaults domain and takes Sparkle's keys with it:
-  /// without this the About pane keeps showing the toggle and the check date
-  /// that were true before the wipe.
-  ///
-  /// The toggle is assigned only when it differs, so a refresh does not send a
-  /// redundant write back through `didSet`.
+  /// For the settings reset, whose wipe takes Sparkle's keys with it. The toggle
+  /// is assigned only on change, so nothing echoes back through `didSet`.
   func refreshFromUpdater() {
     let automatic = controller.updater.automaticallyChecksForUpdates
     if automaticallyChecksForUpdates != automatic { automaticallyChecksForUpdates = automatic }

--- a/Candela/AppKitIslands/MediaKeyEventTap.swift
+++ b/Candela/AppKitIslands/MediaKeyEventTap.swift
@@ -226,12 +226,13 @@ final class MediaKeyEventTap {
     thread.name = "MediaKeyEventTap"
     thread.start()
 
-    // The deadman switch, in two threads. A PROBER makes a cheap WindowServer
-    // round-trip every 2 s (`CGWindowListCopyWindowInfo`, a real RPC unlike
-    // display-bounds reads, which are locally cached) and posts the self-ping
-    // described below. A MONITOR checks each second for a committed revocation
-    // (AX poll, covering toggles the notification path misses) and for a probe
-    // stuck over 5 s; either invalidates the port through the nonisolated
+    // The deadman switch, in two threads. A PROBER polls the grant every 0.5 s
+    // (`AXIsProcessTrustedWithOptions`, covering committed revocations the
+    // notification path misses) and posts the synthetic self-ping described
+    // below every 2 s, so the liveness evidence comes from our own event stream
+    // rather than from any WindowServer call. A MONITOR compares clocks each
+    // second and makes no calls of its own: a ping unanswered over 5 s, or a
+    // probe in flight that long, invalidates the port through the nonisolated
     // teardown, the same kernel-level release as process death.
     //
     // 5 s tolerates the platform's legitimate stalls: mode changes and rotation

--- a/Candela/AppKitIslands/VolumeFeedbackSound.swift
+++ b/Candela/AppKitIslands/VolumeFeedbackSound.swift
@@ -9,27 +9,33 @@ import Foundation
 /// honoring the user's "Play feedback when volume is changed" Sound setting.
 @MainActor
 final class VolumeFeedbackSound {
-  /// Retained across the async playback (a local would deallocate mid-play).
-  private var player: AVAudioPlayer?
+  private static let soundURL = URL(
+    fileURLWithPath: "/System/Library/LoginPlugins/BezelServices.loginPlugin/Contents/Resources/volume.aiff"
+  )
+
+  /// Built once and retained: this fires on every volume keypress, and the fork's
+  /// per-press player re-read and re-decoded the file each time. A local would
+  /// also deallocate mid-play.
+  private lazy var player: AVAudioPlayer? = {
+    let player = try? AVAudioPlayer(contentsOf: Self.soundURL)
+    player?.volume = 1
+    player?.prepareToPlay()
+    return player
+  }()
 
   func play() {
-    guard Self.feedbackEnabled() else { return }
-    let url = URL(
-      fileURLWithPath: "/System/Library/LoginPlugins/BezelServices.loginPlugin/Contents/Resources/volume.aiff"
-    )
-    player = try? AVAudioPlayer(contentsOf: url)
-    player?.volume = 1
-    player?.play()
+    guard Self.feedbackEnabled(), let player else { return }
+    // A press during the previous blip restarts it rather than being swallowed:
+    // `play()` on a playing player is a no-op.
+    player.currentTime = 0
+    player.play()
   }
 
-  /// Fork parity: the setting lives in another domain, so the global prefs
-  /// plist is parsed directly (`UserDefaults.standard` won't surface it).
+  /// The global domain is in every app's defaults search list, the same route
+  /// `_HIHideMenuBar` is read by. The fork parsed
+  /// `~/Library/Preferences/.GlobalPreferences.plist` per keypress instead, which
+  /// also reads behind cfprefsd's cache.
   private static func feedbackEnabled() -> Bool {
-    let path = NSString(string: "~/Library/Preferences/.GlobalPreferences.plist").expandingTildeInPath
-    guard let data = FileManager.default.contents(atPath: path),
-          let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil)
-          as? [String: Any]
-    else { return false }
-    return plist["com.apple.sound.beep.feedback"] as? Int == 1
+    UserDefaults.standard.bool(forKey: "com.apple.sound.beep.feedback")
   }
 }

--- a/Candela/AppKitIslands/VolumeFeedbackSound.swift
+++ b/Candela/AppKitIslands/VolumeFeedbackSound.swift
@@ -13,9 +13,8 @@ final class VolumeFeedbackSound {
     fileURLWithPath: "/System/Library/LoginPlugins/BezelServices.loginPlugin/Contents/Resources/volume.aiff"
   )
 
-  /// Built once and retained: this fires on every volume keypress, and the fork's
-  /// per-press player re-read and re-decoded the file each time. A local would
-  /// also deallocate mid-play.
+  /// Built once: the fork re-decoded the file on every keypress. Retained
+  /// because a local would deallocate mid-play.
   private lazy var player: AVAudioPlayer? = {
     let player = try? AVAudioPlayer(contentsOf: Self.soundURL)
     player?.volume = 1
@@ -31,10 +30,8 @@ final class VolumeFeedbackSound {
     player.play()
   }
 
-  /// The global domain is in every app's defaults search list, the same route
-  /// `_HIHideMenuBar` is read by. The fork parsed
-  /// `~/Library/Preferences/.GlobalPreferences.plist` per keypress instead, which
-  /// also reads behind cfprefsd's cache.
+  /// The global domain is on every app's defaults search list; the fork parsed
+  /// the plist per keypress, behind cfprefsd's cache.
   private static func feedbackEnabled() -> Bool {
     UserDefaults.standard.bool(forKey: "com.apple.sound.beep.feedback")
   }

--- a/Candela/Checkup/CheckupCopy.swift
+++ b/Candela/Checkup/CheckupCopy.swift
@@ -6,9 +6,8 @@ enum CheckupCopy {
 
   // MARK: - Getting ready
 
-  /// The window's first frame. The environment read behind it is up to 128 I2C
-  /// fragment reads on a panel that answers, so the window is up well before it
-  /// has a flow to show.
+  /// The window's first frame: the environment read can take seconds on a panel
+  /// that answers DDC.
   static let preparingTitle = "Getting ready"
   static let preparingBody = "Reading what each attached display answers."
 
@@ -73,9 +72,8 @@ enum CheckupCopy {
   static let hdrEngagedLine =
     "This display is in HDR mode, which stops DDC: readback checks will be recorded as not observed. Turn HDR off and run the checkup again to have them run."
 
-  /// All the failure actually observes: `OverlayWindow.screen(for:)` found no
-  /// `NSScreen`. Mirroring is the usual cause, not the only one, so the copy
-  /// states the observation and offers mirroring as the thing to check.
+  /// All the failure observes is a missing `NSScreen`; mirroring is the usual
+  /// cause, not the only one.
   static let noScreenReason = "macOS reports no screen for this display right now"
 
   static let fieldNotShown =
@@ -91,9 +89,8 @@ enum CheckupCopy {
     "The visual fields take at most \(seconds / 60) minutes if every one is shown three times. Nothing runs until you continue."
   }
 
-  /// The mode legs re-sync the display once for the native resolution and once
-  /// per advertised rate, so the panel blanks several times before the fields
-  /// start. Unwarned, that reads as the app breaking the display.
+  /// The mode legs blank the panel once per rate; unwarned, that reads as the
+  /// app breaking the display.
   static let planModeSweep =
     "The display will go dark for a moment as each resolution and refresh rate is tested, once per rate. It is put back to the mode it started in before the visual fields begin."
 
@@ -286,8 +283,7 @@ enum CheckupCopy {
 
   static let export = "Export report"
   static let copySummary = "Copy summary"
-  /// The summary's only exit. The run is already saved by the time this page is
-  /// up, so it closes the window and ends nothing.
+  /// Closes the window; the run is already saved.
   static let done = "Done"
   static let copied = "Copied"
   static let exportFailed = "The report could not be saved."

--- a/Candela/Checkup/CheckupCopy.swift
+++ b/Candela/Checkup/CheckupCopy.swift
@@ -4,6 +4,14 @@ import CandelaKit
 /// (no em dashes, no key names, no verdict on the display) can be checked at once.
 enum CheckupCopy {
 
+  // MARK: - Getting ready
+
+  /// The window's first frame. The environment read behind it is up to 128 I2C
+  /// fragment reads on a panel that answers, so the window is up well before it
+  /// has a flow to show.
+  static let preparingTitle = "Getting ready"
+  static let preparingBody = "Reading what each attached display answers."
+
   // MARK: - Scenario
 
   static let scenarioTitle = "What is this checkup for?"
@@ -65,11 +73,13 @@ enum CheckupCopy {
   static let hdrEngagedLine =
     "This display is in HDR mode, which stops DDC: readback checks will be recorded as not observed. Turn HDR off and run the checkup again to have them run."
 
-  /// Quoted on the pick page and in the mid-run failure; both come from the missing NSScreen.
-  static let mirroringReason = "mirroring another display; a field cannot be shown on it"
+  /// All the failure actually observes: `OverlayWindow.screen(for:)` found no
+  /// `NSScreen`. Mirroring is the usual cause, not the only one, so the copy
+  /// states the observation and offers mirroring as the thing to check.
+  static let noScreenReason = "macOS reports no screen for this display right now"
 
   static let fieldNotShown =
-    "This field could not be shown on the display: \(mirroringReason). Nothing was recorded for it."
+    "This field could not be shown: \(noScreenReason). The usual cause is mirroring, since a mirrored display has no screen of its own to draw on. Nothing was recorded for it."
 
   // MARK: - Plan
 
@@ -80,6 +90,12 @@ enum CheckupCopy {
   static func planWorstCase(seconds: Int) -> String {
     "The visual fields take at most \(seconds / 60) minutes if every one is shown three times. Nothing runs until you continue."
   }
+
+  /// The mode legs re-sync the display once for the native resolution and once
+  /// per advertised rate, so the panel blanks several times before the fields
+  /// start. Unwarned, that reads as the app breaking the display.
+  static let planModeSweep =
+    "The display will go dark for a moment as each resolution and refresh rate is tested, once per rate. It is put back to the mode it started in before the visual fields begin."
 
   // MARK: - The measured legs
 
@@ -270,6 +286,9 @@ enum CheckupCopy {
 
   static let export = "Export report"
   static let copySummary = "Copy summary"
+  /// The summary's only exit. The run is already saved by the time this page is
+  /// up, so it closes the window and ends nothing.
+  static let done = "Done"
   static let copied = "Copied"
   static let exportFailed = "The report could not be saved."
   static let acknowledge = "OK"
@@ -335,20 +354,21 @@ enum CheckupCopy {
   /// Every fixed string plus one sample of each parameterised one, so the copy
   /// rules can be asserted over the surface rather than over a reviewer's memory.
   static var allStringsForTest: [String] {
-    [scenarioTitle, scenarioSubtitle, scenarioNew, scenarioUsed, scenarioRecheck, pickTitle,
-     pickSubtitle, pickEmpty, planTitle, planSubtitle, identityTitle, capabilitiesTitle,
+    [preparingTitle, preparingBody,
+     scenarioTitle, scenarioSubtitle, scenarioNew, scenarioUsed, scenarioRecheck, pickTitle,
+     pickSubtitle, pickEmpty, planTitle, planSubtitle, planModeSweep, identityTitle, capabilitiesTitle,
      nativeModeTitle, refreshTitle, hdrTitle, running, refusalNote, plantDisclosureTitle,
      plantDisclosure, plantMissedTwice, showAgain, showAgainCap, start, continueLabel, back,
      answerPrompt, recordedPrefix, answerNothing, answerOne, answerMore, answerRound,
      answerNotRound, tapHint, secondDotTitle, secondDotPrompt, onlyDisplayStrip, summaryTitle,
-     summaryComplete, export, copySummary, copied, exportFailed, acknowledge,
+     summaryComplete, export, copySummary, done, copied, exportFailed, acknowledge,
      attestationNote, serialLabel, manufacturedLabel, nativeResolutionLabel,
      maximumRefreshLabel, hdrFlagsLabel, macOSLabel, notReported, flagPresent, flagAbsent,
      identityNotRead, manufactured(week: 51, year: 2025), hdrFlagsLine(pq: true, hdrGamma: false),
      completionLine(.complete), completionLine(.incomplete(reason: closedReason)),
      headerSentence, plantMissed(size: 4), planWorstCase(seconds: 600), secondsLeft(1),
      secondsLeft(20), summaryIncomplete(reason: closedReason), closedReason, fieldWindowTitle,
-     detectedAt(pixels: 4), hdrEngagedLine, mirroringReason, fieldNotShown,
+     detectedAt(pixels: 4), hdrEngagedLine, noScreenReason, fieldNotShown,
      pixelSizeLine(width: 3840, height: 2160),
      occlusionLine(fieldIDs: [CheckupCheckID.field(.black), CheckupCheckID.field(.gray7)]) ?? "",
      CheckupScenario.allCases.map(scenarioWords).joined(separator: " ")]

--- a/Candela/Checkup/CheckupFlowModel.swift
+++ b/Candela/Checkup/CheckupFlowModel.swift
@@ -34,8 +34,8 @@ final class CheckupFlowModel {
 
   /// The save seam: the pane's store in the app, a recorder in the suite.
   var onSaved: (CheckupReportEnvelope) -> Void = { _ in }
-  /// The close seam, shaped like the setup flow's: the window is the AppKit
-  /// island, so the summary's Done asks for a close rather than performing one.
+  /// The close seam: the window is the AppKit island, so Done asks rather than
+  /// performs.
   var onClose: () -> Void = {}
 
   /// The one field the control is planted on. Optional only because `first(where:)` is.
@@ -185,14 +185,13 @@ final class CheckupFlowModel {
       finish(.complete)
 
     case .summary:
-      // Unreachable: `finish` sets `finished` before it sets this page, so the
-      // guard above already returned. The summary's exit is `close()`.
+      // Unreachable: `finish` sets `finished` before this page, so the guard
+      // above returned.
       break
     }
   }
 
-  /// The summary's Done. The report is saved by the time this page is up, so
-  /// there is nothing left to end and the window simply goes.
+  /// The summary's Done. The report is already saved, so nothing is abandoned.
   func close() {
     onClose()
   }
@@ -418,10 +417,9 @@ final class CheckupFlowModel {
     kind: CheckupFieldKind, plant: CheckupPlant?, answer: CheckupFieldAnswer,
     tappedRegion: (x: Int, y: Int)?
   ) {
-    // With the control missed, nothing on the pixel sweep can be graded, and a
-    // report must not print an attestation as if it could be. What was reported
-    // still rides along: the rule forbids recording the session as clean, not
-    // recording what the person said they saw.
+    // With the control missed nothing can be graded, and a report must not print
+    // an attestation as if it could be. The person's own report still rides
+    // along: the rule forbids recording the session as clean, not what they saw.
     if kind.carriesPlant, plantRecord?.missed == true {
       recordField(
         kind,
@@ -504,21 +502,19 @@ final class CheckupFlowModel {
   }
 
   /// A pixel field's attestation only means something at a known sensitivity;
-  /// with the control missed the grade is inconclusive whatever was reported.
-  /// The report is kept beside the reason rather than dropped.
+  /// with the control missed the grade is inconclusive, with the report kept
+  /// beside the reason.
   private func gradedVerdict(_ kind: CheckupFieldKind, _ verdict: CheckupVerdict) -> CheckupVerdict {
     guard kind.carriesPlant, plantRecord?.missed == true else { return verdict }
     return .inconclusive(Self.ungraded(with: verdict.text))
   }
 
-  /// The ungraded reason, carrying whatever the showing established.
   static func ungraded(with reported: String?) -> String {
     guard let reported, !reported.isEmpty else { return ungradedText }
     return "\(ungradedText); \(reported)"
   }
 
-  /// What the person reported about a mark, before any grading. Nil when they
-  /// reported no mark, so nothing is appended to an ungraded reason.
+  /// Nil when no mark was reported, so nothing is appended to the ungraded reason.
   static func reportedMark(
     _ answer: CheckupFieldAnswer, region: (x: Int, y: Int)?
   ) -> String? {
@@ -657,8 +653,7 @@ final class CheckupFlowModel {
     ])
   }
 
-  /// A field the run left behind. Nobody attested to anything, so it is
-  /// `notObserved` with its reason, never the user's self-report.
+  /// Nobody attested to anything, so `notObserved`, never a self-report.
   private func recordUnanswered(_ kind: CheckupFieldKind) {
     guard !claims.contains(where: { $0.id == CheckupCheckID.field(kind) }) else { return }
     recordField(kind, verdict: gradedVerdict(kind, .notObserved("no answer given")))

--- a/Candela/Checkup/CheckupFlowModel.swift
+++ b/Candela/Checkup/CheckupFlowModel.swift
@@ -34,6 +34,9 @@ final class CheckupFlowModel {
 
   /// The save seam: the pane's store in the app, a recorder in the suite.
   var onSaved: (CheckupReportEnvelope) -> Void = { _ in }
+  /// The close seam, shaped like the setup flow's: the window is the AppKit
+  /// island, so the summary's Done asks for a close rather than performing one.
+  var onClose: () -> Void = {}
 
   /// The one field the control is planted on. Optional only because `first(where:)` is.
   static let plantedField = CheckupFieldKind.protocolOrder.first { $0.carriesPlant }
@@ -182,8 +185,16 @@ final class CheckupFlowModel {
       finish(.complete)
 
     case .summary:
+      // Unreachable: `finish` sets `finished` before it sets this page, so the
+      // guard above already returned. The summary's exit is `close()`.
       break
     }
+  }
+
+  /// The summary's Done. The report is saved by the time this page is up, so
+  /// there is nothing left to end and the window simply goes.
+  func close() {
+    onClose()
   }
 
   func back() {
@@ -407,10 +418,15 @@ final class CheckupFlowModel {
     kind: CheckupFieldKind, plant: CheckupPlant?, answer: CheckupFieldAnswer,
     tappedRegion: (x: Int, y: Int)?
   ) {
-    // With the control missed, nothing on the pixel sweep can be graded,
-    // and a report must not print an attestation as if it could be.
+    // With the control missed, nothing on the pixel sweep can be graded, and a
+    // report must not print an attestation as if it could be. What was reported
+    // still rides along: the rule forbids recording the session as clean, not
+    // recording what the person said they saw.
     if kind.carriesPlant, plantRecord?.missed == true {
-      recordField(kind, verdict: .inconclusive(Self.ungradedText))
+      recordField(
+        kind,
+        verdict: .inconclusive(
+          Self.ungraded(with: Self.reportedMark(answer, region: tappedRegion))))
       page = instructionPage(for: kind)
       return
     }
@@ -488,9 +504,28 @@ final class CheckupFlowModel {
   }
 
   /// A pixel field's attestation only means something at a known sensitivity;
-  /// with the control missed it is inconclusive whatever the user reported.
+  /// with the control missed the grade is inconclusive whatever was reported.
+  /// The report is kept beside the reason rather than dropped.
   private func gradedVerdict(_ kind: CheckupFieldKind, _ verdict: CheckupVerdict) -> CheckupVerdict {
-    kind.carriesPlant && plantRecord?.missed == true ? .inconclusive(Self.ungradedText) : verdict
+    guard kind.carriesPlant, plantRecord?.missed == true else { return verdict }
+    return .inconclusive(Self.ungraded(with: verdict.text))
+  }
+
+  /// The ungraded reason, carrying whatever the showing established.
+  static func ungraded(with reported: String?) -> String {
+    guard let reported, !reported.isEmpty else { return ungradedText }
+    return "\(ungradedText); \(reported)"
+  }
+
+  /// What the person reported about a mark, before any grading. Nil when they
+  /// reported no mark, so nothing is appended to an ungraded reason.
+  static func reportedMark(
+    _ answer: CheckupFieldAnswer, region: (x: Int, y: Int)?
+  ) -> String? {
+    switch answer {
+    case .oneMark, .moreThanOne: defectText(region)
+    case .nothing, .roundAndUncut, .notRound: nil
+    }
   }
 
   static func defectText(_ region: (x: Int, y: Int)?) -> String {
@@ -622,9 +657,11 @@ final class CheckupFlowModel {
     ])
   }
 
+  /// A field the run left behind. Nobody attested to anything, so it is
+  /// `notObserved` with its reason, never the user's self-report.
   private func recordUnanswered(_ kind: CheckupFieldKind) {
     guard !claims.contains(where: { $0.id == CheckupCheckID.field(kind) }) else { return }
-    recordField(kind, verdict: gradedVerdict(kind, .selfReported("no answer given")))
+    recordField(kind, verdict: gradedVerdict(kind, .notObserved("no answer given")))
   }
 
   private func instructionPage(for kind: CheckupFieldKind) -> CheckupPage {

--- a/Candela/Checkup/CheckupLiveEnvironment.swift
+++ b/Candela/Checkup/CheckupLiveEnvironment.swift
@@ -141,7 +141,7 @@ enum CheckupLiveEnvironment {
         // clamp passes NaN through as full white. Nothing to book is better.
         guard let size = pixels[identityKey], size.0 > 0, size.1 > 0 else {
           log.error("""
-          checkup showing not booked: no pixel size for \(identityKey, privacy: .public)
+          checkup showing not booked: no pixel size for \(DisplayLogging.tag(for: identityKey), privacy: .public)
           """)
           return
         }

--- a/Candela/Checkup/CheckupPages.swift
+++ b/Candela/Checkup/CheckupPages.swift
@@ -95,6 +95,29 @@ struct CheckupPageScaffold<Content: View, Actions: View>: View {
   }
 }
 
+// MARK: - Getting ready
+
+/// The window's content until the environment read returns. Same backdrop and
+/// heading as every page, so what arrives after it is a fill rather than a
+/// replacement.
+struct CheckupPreparingView: View {
+  var body: some View {
+    ZStack {
+      CheckupBackdrop()
+      VStack(spacing: 22) {
+        OnboardingHeading(
+          title: CheckupCopy.preparingTitle, subtitle: CheckupCopy.preparingBody)
+        ProgressView()
+          .controlSize(.small)
+      }
+      .frame(maxWidth: CheckupStyle.pageWidth)
+      .padding(.horizontal, 24)
+    }
+    .frame(minWidth: 720, minHeight: 560)
+    .preferredColorScheme(.dark)
+  }
+}
+
 // MARK: - Scenario
 
 struct CheckupScenarioPage: View {
@@ -202,11 +225,15 @@ struct CheckupPlanPage: View {
           }
           .frame(maxWidth: .infinity, alignment: .leading)
         }
-        Text(CheckupCopy.planWorstCase(seconds: CheckupPlan.worstCaseFieldSeconds))
+        Text(CheckupCopy.planModeSweep)
           .font(.callout)
           .foregroundStyle(OnboardingStyle.bodyColor)
           .fixedSize(horizontal: false, vertical: true)
           .padding(.top, 6)
+        Text(CheckupCopy.planWorstCase(seconds: CheckupPlan.worstCaseFieldSeconds))
+          .font(.callout)
+          .foregroundStyle(OnboardingStyle.bodyColor)
+          .fixedSize(horizontal: false, vertical: true)
       }
     } actions: {
       CheckupAdvanceButton(model: model, title: CheckupCopy.continueLabel)
@@ -444,19 +471,27 @@ struct CheckupSummaryPage: View {
       }
     } actions: {
       VStack(spacing: 10) {
+        // Both secondary: the page's one primary action sits below, where the
+        // scaffold puts every other page's, so the flow ends where the eye
+        // already expects Continue.
         HStack(spacing: 10) {
           Button(CheckupCopy.export) { export() }
-            .buttonStyle(OnboardingPrimaryButtonStyle(accent: CheckupStyle.accent))
+            .buttonStyle(OnboardingSecondaryButtonStyle())
             .accessibilityLabel(Text(verbatim: CheckupCopy.export))
           Button(CheckupCopy.copySummary) { copySummary() }
             .buttonStyle(OnboardingSecondaryButtonStyle())
             .accessibilityLabel(Text(verbatim: CheckupCopy.copySummary))
         }
-        if justCopied {
-          Text(CheckupCopy.copied)
-            .font(.caption)
-            .foregroundStyle(OnboardingStyle.faintColor)
-        }
+        Text(CheckupCopy.copied)
+          .font(.caption)
+          .foregroundStyle(OnboardingStyle.faintColor)
+          // Laid out either way: confirming a copy must not shove Done down.
+          .opacity(justCopied ? 1 : 0)
+          .accessibilityHidden(!justCopied)
+        Button(CheckupCopy.done) { model.close() }
+          .buttonStyle(OnboardingPrimaryButtonStyle(accent: CheckupStyle.accent))
+          .keyboardShortcut(.defaultAction)
+          .accessibilityLabel(Text(verbatim: CheckupCopy.done))
       }
       .alert(
         CheckupCopy.exportFailed,

--- a/Candela/Checkup/CheckupPages.swift
+++ b/Candela/Checkup/CheckupPages.swift
@@ -471,12 +471,15 @@ struct CheckupSummaryPage: View {
       }
     } actions: {
       VStack(spacing: 10) {
-        // Both secondary: the page's one primary action sits below, where the
-        // scaffold puts every other page's, so the flow ends where the eye
-        // already expects Continue.
+        // Export carries the emphasis. It is the thing this flow exists to
+        // produce: a report nobody saves is a run that left nothing behind, and
+        // the save rate is a metric this feature is judged on. Done keeps its
+        // place at the foot, where every other page's way onward sits, and its
+        // Return shortcut, but it is styled as the exit it is rather than as
+        // the action to take.
         HStack(spacing: 10) {
           Button(CheckupCopy.export) { export() }
-            .buttonStyle(OnboardingSecondaryButtonStyle())
+            .buttonStyle(OnboardingPrimaryButtonStyle(accent: CheckupStyle.accent))
             .accessibilityLabel(Text(verbatim: CheckupCopy.export))
           Button(CheckupCopy.copySummary) { copySummary() }
             .buttonStyle(OnboardingSecondaryButtonStyle())
@@ -489,7 +492,7 @@ struct CheckupSummaryPage: View {
           .opacity(justCopied ? 1 : 0)
           .accessibilityHidden(!justCopied)
         Button(CheckupCopy.done) { model.close() }
-          .buttonStyle(OnboardingPrimaryButtonStyle(accent: CheckupStyle.accent))
+          .buttonStyle(OnboardingSecondaryButtonStyle())
           .keyboardShortcut(.defaultAction)
           .accessibilityLabel(Text(verbatim: CheckupCopy.done))
       }

--- a/Candela/Checkup/CheckupPages.swift
+++ b/Candela/Checkup/CheckupPages.swift
@@ -97,9 +97,8 @@ struct CheckupPageScaffold<Content: View, Actions: View>: View {
 
 // MARK: - Getting ready
 
-/// The window's content until the environment read returns. Same backdrop and
-/// heading as every page, so what arrives after it is a fill rather than a
-/// replacement.
+/// Shown until the environment read returns. Same backdrop and heading as every
+/// page, so the flow reads as a fill rather than a replacement.
 struct CheckupPreparingView: View {
   var body: some View {
     ZStack {
@@ -471,12 +470,8 @@ struct CheckupSummaryPage: View {
       }
     } actions: {
       VStack(spacing: 10) {
-        // Export carries the emphasis. It is the thing this flow exists to
-        // produce: a report nobody saves is a run that left nothing behind, and
-        // the save rate is a metric this feature is judged on. Done keeps its
-        // place at the foot, where every other page's way onward sits, and its
-        // Return shortcut, but it is styled as the exit it is rather than as
-        // the action to take.
+        // Export carries the emphasis: a report nobody saves is a run that left
+        // nothing behind. Done keeps the foot and Return, styled as an exit.
         HStack(spacing: 10) {
           Button(CheckupCopy.export) { export() }
             .buttonStyle(OnboardingPrimaryButtonStyle(accent: CheckupStyle.accent))

--- a/Candela/Checkup/CheckupWindowController.swift
+++ b/Candela/Checkup/CheckupWindowController.swift
@@ -39,6 +39,14 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
     // A present() while the window is up only brings it forward, keeping the
     // user's place in a run. Read before ordering front, which makes it visible.
     let needsFlow = !window.isVisible
+    if needsFlow {
+      // Both before the window is visible: the environment read can take
+      // seconds, and an empty window that fills in and then jumps to centre
+      // reads as a glitch. On a re-presentation this also clears the previous
+      // run's summary, which would otherwise sit there through the read.
+      window.contentView = NSHostingView(rootView: CheckupPreparingView())
+      window.center()
+    }
     // Same as the setup window: modern `NSApp.activate()` cannot activate an
     // accessory app from inside a status-item tracking session.
     NSApp.activate(ignoringOtherApps: true)
@@ -52,7 +60,6 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
       // flow into it now would start a run nobody is looking at.
       guard window.isVisible else { return }
       self.installFlow(in: window, environment: environment)
-      window.center()
     }
   }
 
@@ -70,6 +77,9 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
       window: fieldWindow, beforeShow: { [weak self] entry in self?.moveOffTarget(entry) })
     let model = CheckupFlowModel(environment: environment)
     model.onSaved = onSaved
+    // `windowShouldClose` does not abandon on the summary, so the close this
+    // routes to leaves the saved report exactly as it stands.
+    model.onClose = { [weak window] in window?.performClose(nil) }
     self.model = model
 
     fieldWindow.onAnswer = { [weak self] answer in

--- a/Candela/Checkup/CheckupWindowController.swift
+++ b/Candela/Checkup/CheckupWindowController.swift
@@ -40,10 +40,9 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
     // user's place in a run. Read before ordering front, which makes it visible.
     let needsFlow = !window.isVisible
     if needsFlow {
-      // Both before the window is visible: the environment read can take
-      // seconds, and an empty window that fills in and then jumps to centre
-      // reads as a glitch. On a re-presentation this also clears the previous
-      // run's summary, which would otherwise sit there through the read.
+      // Before the window shows: the read can take seconds, and a window that
+      // fills in then jumps to centre reads as a glitch. Also clears a previous
+      // run's summary.
       window.contentView = NSHostingView(rootView: CheckupPreparingView())
       window.center()
     }
@@ -77,8 +76,8 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
       window: fieldWindow, beforeShow: { [weak self] entry in self?.moveOffTarget(entry) })
     let model = CheckupFlowModel(environment: environment)
     model.onSaved = onSaved
-    // `windowShouldClose` does not abandon on the summary, so the close this
-    // routes to leaves the saved report exactly as it stands.
+    // `windowShouldClose` does not abandon on the summary, so the saved report
+    // is untouched.
     model.onClose = { [weak window] in window?.performClose(nil) }
     self.model = model
 

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -179,8 +179,9 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// fast cadence and log an error ten times a second.
   private static let maxVerifyAttempts = 5
   /// Spec §4: one capture per enrolled display per 60 s, and the window list on
-  /// the same clock.
-  private static let samplingInterval: Duration = .seconds(60)
+  /// the same clock. The Kit holds the value because the settings surfaces judge
+  /// a reading stale against multiples of it.
+  private static let samplingInterval: Duration = OledCareCadence.sampling
   /// How often a DISPLAYED nomination re-checks window geometry. One second: a
   /// dim clearing within a second reads as cleanup, while a dim sitting on moved
   /// content for a whole sampling slot reads as burn-in, the symptom the feature
@@ -368,8 +369,14 @@ final class OledCareCoordinator: CheckupCareHolding {
     })
 
     reconcileEnrollment()
-    // start() is single-shot (the chrome guard above), so there is never a
-    // previous driver to cancel here.
+    startDriver()
+  }
+
+  /// Creates the loop, cancelling any previous one. `start()` is single-shot (its
+  /// chrome guard), so the only other caller is `reconcileEnrollment`, cutting an
+  /// idle sleep short when a display enrolls.
+  private func startDriver() {
+    driver?.cancel()
     driver = Task { @MainActor [weak self] in
       while !Task.isCancelled {
         // Strong self is confined to the non-suspending half of the iteration
@@ -506,10 +513,12 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// per-app panel-seconds, and the window attribution derived from them,
   /// cleared in one step, in memory and on disk.
   ///
-  /// The panel's TOTAL HOURS are deliberately NOT cleared. They are a different
-  /// measurement with its own reset path (`PanelHoursTracker.reset()`, driven
-  /// by the settings reset), and a control labelled for exposure history must
-  /// not silently destroy a lifetime counter. Per-app hours ARE cleared: they
+  /// The panel's TOTAL HOURS are deliberately NOT cleared, and neither is the
+  /// time-at-brightness histogram. Both are different measurements with their
+  /// own reset paths (`PanelHoursTracker.reset()` and
+  /// `WearSignalTracker.reset()`, driven by the settings reset), and a control
+  /// labelled for exposure history must not silently destroy a lifetime
+  /// counter. The confirmation dialog names both. Per-app hours ARE cleared: they
   /// are derived from the same observations as the map, and leaving them would
   /// let the health view keep naming apps for a history the user just deleted.
   func clearExposureHistory(for persistenceKey: String) {
@@ -615,12 +624,11 @@ final class OledCareCoordinator: CheckupCareHolding {
     // Same reason, same moment: a live wear tracker's debounced write-through
     // would re-persist the histogram the wipe just removed.
     //
-    // DISCARDED as well as reset, unlike `trackers`, because `flush()` writes
-    // unconditionally: `reset()` alone leaves the object here, so the first
-    // sleep or quit AFTER the latch clears re-creates `oledWearSeconds` as an
-    // all-zero histogram, exactly what `reset()` promises not to leave behind.
-    // (A `guard !resetting` in `flushExposureHistory` does NOT fix it: every
-    // caller is already excluded by the latch.)
+    // DISCARDED as well as reset, unlike `trackers`: the objects held here
+    // describe a domain that no longer exists, and a pane that wants one after
+    // the wipe gets a fresh tracker off the wiped keys. `reset()` alone is now
+    // enough to stop the write (it clears the tracker's accumulation flag, so
+    // `flush()` is a no-op), but the discard is the statement of intent.
     for tracker in wearTrackers.values { tracker.reset() }
     wearTrackers.removeAll()
   }
@@ -694,6 +702,10 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// standby their tracker, since the panel stopped being driven).
   private func reconcileEnrollment() {
     guard let model else { return }
+    // The driver sleeps on the idle cadence only where this was true at the last
+    // `cadence()`, so it is the exact condition under which a new enrollment
+    // would otherwise wait up to 30 s for its first tick.
+    let wasIdle = states.isEmpty
     var seen: Set<String> = []
     for displayState in model.displays {
       let key = displayState.display.persistenceKey
@@ -768,6 +780,12 @@ final class OledCareCoordinator: CheckupCareHolding {
       }
       dropState(for: key)
     }
+
+    // Restarting is what cuts the in-flight sleep short; the fresh task ticks
+    // before it sleeps, so the first tick after an enrollment is prompt. Guarded
+    // on `driver` because `start()` reconciles BEFORE creating the loop, and
+    // this must not create it early.
+    if wasIdle, !states.isEmpty, driver != nil { startDriver() }
   }
 
   private func dropState(for key: String) {
@@ -824,7 +842,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     // Drained independently of `states`: these entries outlive the state that
     // issued them by design (I-2), including across a reset.
     drainPendingRemovalVerifications()
-    // Users who never enroll pay nothing past this line.
+    // Users who never enroll do no work past this line, and `cadence()` drops the
+    // loop to `OledCareCadence.idle` so they do not pay for the wakeup either.
     guard !states.isEmpty else { return }
     let idleSeconds = OledCareSignalSources.systemIdleSeconds()
     let assertionHeld = OledCareSignalSources.displaySleepAssertionHeld()
@@ -1021,12 +1040,18 @@ final class OledCareCoordinator: CheckupCareHolding {
 
   /// A given-up verify drops the fast cadence only when nothing is wanted (the
   /// strand case); a wanted dim keeps it, whichever way it is delivered.
+  ///
+  /// `anythingEnrolled` is the whole of the idle cadence: with no enrolled
+  /// display `tick()` returns at its empty guard, so the 2 s wakeup bought
+  /// nothing for a user who never opted in. A pending removal verification still
+  /// outranks it, since those entries outlive the state that issued them.
   private func cadence() -> Duration {
     OledCareCadence.interval(
       anyOverlayUp: states.values.contains { $0.lastAppliedAlpha != nil },
       anyLockDimEngaged: states.values.contains(where: \.lockDimEngaged),
       verificationPending: states.values.contains(where: \.needsVerify)
-        || !pendingRemovalVerifications.isEmpty
+        || !pendingRemovalVerifications.isEmpty,
+      anythingEnrolled: !states.isEmpty
     )
   }
 

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -1819,8 +1819,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     // safe mode, no sampling pass will carry this key to disk.
     saveExposureHistory(for: key)
     log.info("""
-    checkup showing booked: \(key, privacy: .public) \(luminance, privacy: .public) \
-    \(seconds, privacy: .public)s
+    checkup showing booked: \(DisplayLogging.tag(for: key), privacy: .public) \
+    \(luminance, privacy: .public) \(seconds, privacy: .public)s
     """)
   }
 
@@ -1889,7 +1889,8 @@ final class OledCareCoordinator: CheckupCareHolding {
       return .empty
     } catch {
       log.error("""
-      OLED care: stored model comparison for \(key, privacy: .public) is unreadable \
+      OLED care: stored model comparison for \
+      \(DisplayLogging.tag(for: key), privacy: .public) is unreadable \
       (\(error.localizedDescription, privacy: .public)); starting over
       """)
       return .empty
@@ -1921,7 +1922,8 @@ final class OledCareCoordinator: CheckupCareHolding {
       return .empty
     } catch {
       log.error("""
-      OLED care: stored exposure map for \(key, privacy: .public) is unreadable \
+      OLED care: stored exposure map for \
+      \(DisplayLogging.tag(for: key), privacy: .public) is unreadable \
       (\(error.localizedDescription, privacy: .public)); starting over
       """)
       return .empty
@@ -1944,7 +1946,8 @@ final class OledCareCoordinator: CheckupCareHolding {
       return .empty
     } catch {
       log.error("""
-      OLED care: stored per-app hours for \(key, privacy: .public) are unreadable \
+      OLED care: stored per-app hours for \
+      \(DisplayLogging.tag(for: key), privacy: .public) are unreadable \
       (\(error.localizedDescription, privacy: .public)); starting over
       """)
       return .empty
@@ -1954,7 +1957,8 @@ final class OledCareCoordinator: CheckupCareHolding {
   private func quarantine(_ key: String, reason: String, failure: OledStoreDecodeFailure) {
     unwritableExposureKeys.insert(key)
     log.error("""
-    OLED care: stored \(reason, privacy: .public) for \(key, privacy: .public) was written by a \
+    OLED care: stored \(reason, privacy: .public) for \
+    \(DisplayLogging.tag(for: key), privacy: .public) was written by a \
     schema this build does not read (\(String(describing: failure), privacy: .public)); keeping \
     the stored bytes and recording nothing new for this display until its history is deleted
     """)
@@ -1992,25 +1996,26 @@ final class OledCareCoordinator: CheckupCareHolding {
     // later one might. The dirty flag is still cleared above, so this display
     // simply records nothing until the user deletes its history.
     guard !unwritableExposureKeys.contains(key) else { return }
+    let tag = DisplayLogging.tag(for: key)
     if let map = accumulators[key]?.map {
       if let data = try? JSONEncoder().encode(map) {
         UserDefaults.standard.set(data, forKey: Self.exposureKeyName(key))
       } else {
-        log.error("OLED care: could not encode the exposure map for \(key, privacy: .public)")
+        log.error("OLED care: could not encode the exposure map for \(tag, privacy: .public)")
       }
     }
     if let hours = ownerHours[key]?.hours {
       if let data = try? JSONEncoder().encode(hours) {
         UserDefaults.standard.set(data, forKey: Self.ownerHoursKeyName(key))
       } else {
-        log.error("OLED care: could not encode the per-app hours for \(key, privacy: .public)")
+        log.error("OLED care: could not encode the per-app hours for \(tag, privacy: .public)")
       }
     }
     if let comparison = comparisons[key] {
       if let data = try? JSONEncoder().encode(comparison) {
         UserDefaults.standard.set(data, forKey: Self.modelComparisonKeyName(key))
       } else {
-        log.error("OLED care: could not encode the model comparison for \(key, privacy: .public)")
+        log.error("OLED care: could not encode the model comparison for \(tag, privacy: .public)")
       }
     }
   }

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -179,8 +179,7 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// fast cadence and log an error ten times a second.
   private static let maxVerifyAttempts = 5
   /// Spec §4: one capture per enrolled display per 60 s, and the window list on
-  /// the same clock. The Kit holds the value because the settings surfaces judge
-  /// a reading stale against multiples of it.
+  /// the same clock. Kit-owned so the settings panes can derive staleness from it.
   private static let samplingInterval: Duration = OledCareCadence.sampling
   /// How often a DISPLAYED nomination re-checks window geometry. One second: a
   /// dim clearing within a second reads as cleanup, while a dim sitting on moved
@@ -372,9 +371,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     startDriver()
   }
 
-  /// Creates the loop, cancelling any previous one. `start()` is single-shot (its
-  /// chrome guard), so the only other caller is `reconcileEnrollment`, cutting an
-  /// idle sleep short when a display enrolls.
+  /// Also called from `reconcileEnrollment`, to cut an idle sleep short when a
+  /// display enrolls.
   private func startDriver() {
     driver?.cancel()
     driver = Task { @MainActor [weak self] in
@@ -513,12 +511,10 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// per-app panel-seconds, and the window attribution derived from them,
   /// cleared in one step, in memory and on disk.
   ///
-  /// The panel's TOTAL HOURS are deliberately NOT cleared, and neither is the
-  /// time-at-brightness histogram. Both are different measurements with their
-  /// own reset paths (`PanelHoursTracker.reset()` and
-  /// `WearSignalTracker.reset()`, driven by the settings reset), and a control
-  /// labelled for exposure history must not silently destroy a lifetime
-  /// counter. The confirmation dialog names both. Per-app hours ARE cleared: they
+  /// Total hours and the time-at-brightness histogram are NOT cleared: each has
+  /// its own reset path off the settings reset, and a control labelled for
+  /// exposure history must not destroy a lifetime counter. The confirmation
+  /// dialog names both. Per-app hours ARE cleared: they
   /// are derived from the same observations as the map, and leaving them would
   /// let the health view keep naming apps for a history the user just deleted.
   func clearExposureHistory(for persistenceKey: String) {
@@ -624,11 +620,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     // Same reason, same moment: a live wear tracker's debounced write-through
     // would re-persist the histogram the wipe just removed.
     //
-    // DISCARDED as well as reset, unlike `trackers`: the objects held here
-    // describe a domain that no longer exists, and a pane that wants one after
-    // the wipe gets a fresh tracker off the wiped keys. `reset()` alone is now
-    // enough to stop the write (it clears the tracker's accumulation flag, so
-    // `flush()` is a no-op), but the discard is the statement of intent.
+    // Discarded as well as reset, unlike `trackers`: a pane that wants one after
+    // the wipe gets a fresh tracker off the wiped keys.
     for tracker in wearTrackers.values { tracker.reset() }
     wearTrackers.removeAll()
   }
@@ -702,9 +695,7 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// standby their tracker, since the panel stopped being driven).
   private func reconcileEnrollment() {
     guard let model else { return }
-    // The driver sleeps on the idle cadence only where this was true at the last
-    // `cadence()`, so it is the exact condition under which a new enrollment
-    // would otherwise wait up to 30 s for its first tick.
+    // The condition under which the driver is asleep on the idle cadence.
     let wasIdle = states.isEmpty
     var seen: Set<String> = []
     for displayState in model.displays {
@@ -781,10 +772,8 @@ final class OledCareCoordinator: CheckupCareHolding {
       dropState(for: key)
     }
 
-    // Restarting is what cuts the in-flight sleep short; the fresh task ticks
-    // before it sleeps, so the first tick after an enrollment is prompt. Guarded
-    // on `driver` because `start()` reconciles BEFORE creating the loop, and
-    // this must not create it early.
+    // Restarting cuts the idle sleep short; the fresh task ticks before it
+    // sleeps. `driver != nil`: `start()` reconciles before creating the loop.
     if wasIdle, !states.isEmpty, driver != nil { startDriver() }
   }
 
@@ -842,8 +831,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     // Drained independently of `states`: these entries outlive the state that
     // issued them by design (I-2), including across a reset.
     drainPendingRemovalVerifications()
-    // Users who never enroll do no work past this line, and `cadence()` drops the
-    // loop to `OledCareCadence.idle` so they do not pay for the wakeup either.
+    // Users who never enroll do no work past this line; `cadence()` idles the
+    // loop for them too.
     guard !states.isEmpty else { return }
     let idleSeconds = OledCareSignalSources.systemIdleSeconds()
     let assertionHeld = OledCareSignalSources.displaySleepAssertionHeld()
@@ -1041,10 +1030,9 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// A given-up verify drops the fast cadence only when nothing is wanted (the
   /// strand case); a wanted dim keeps it, whichever way it is delivered.
   ///
-  /// `anythingEnrolled` is the whole of the idle cadence: with no enrolled
-  /// display `tick()` returns at its empty guard, so the 2 s wakeup bought
-  /// nothing for a user who never opted in. A pending removal verification still
-  /// outranks it, since those entries outlive the state that issued them.
+  /// With nothing enrolled `tick()` returns at its empty guard, so the loop
+  /// idles; a pending removal verification still outranks that, since those
+  /// entries outlive the state that issued them.
   private func cadence() -> Duration {
     OledCareCadence.interval(
       anyOverlayUp: states.values.contains { $0.lastAppliedAlpha != nil },

--- a/Candela/Onboarding/OnboardingCanvas.swift
+++ b/Candela/Onboarding/OnboardingCanvas.swift
@@ -56,10 +56,8 @@ struct OnboardingCanvas: View {
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @Environment(\.controlActiveState) private var activeState
 
-  /// When the window stopped being key, and how long it has spent that way.
-  /// The drift reads a clock with that time discounted, so a pause costs two
-  /// blurred layers at 30 fps and nothing else: coming back resumes the motion
-  /// instead of jumping it forward by however long the person was away.
+  /// Off-key time is discounted from the drift clock, so coming back resumes the
+  /// motion instead of jumping it forward.
   @State private var offKeySince: Date?
   @State private var offKeyTotal: TimeInterval = 0
 
@@ -73,8 +71,7 @@ struct OnboardingCanvas: View {
           blobs(at: drift(at: context.date))
         }
       } else {
-        // Nothing off-key is being looked at: behind another app, minimized or
-        // on another Space, the window has resigned key either way.
+        // Off-key covers behind another app, minimized and another Space alike.
         blobs(at: drift(at: offKeySince ?? .now))
       }
       // Vignette keeps edges dark so content owns the middle.

--- a/Candela/Onboarding/OnboardingCanvas.swift
+++ b/Candela/Onboarding/OnboardingCanvas.swift
@@ -49,21 +49,33 @@ enum OnboardingAct: Equatable {
 
 /// The persistent layer under every page: a near-black ground, two
 /// drifting glow blobs in the act's hues, and a vignette. Slow movement
-/// always; Reduce Motion stills it entirely.
+/// while the window is being looked at; Reduce Motion stills it entirely.
 struct OnboardingCanvas: View {
   var act: OnboardingAct
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.controlActiveState) private var activeState
+
+  /// When the window stopped being key, and how long it has spent that way.
+  /// The drift reads a clock with that time discounted, so a pause costs two
+  /// blurred layers at 30 fps and nothing else: coming back resumes the motion
+  /// instead of jumping it forward by however long the person was away.
+  @State private var offKeySince: Date?
+  @State private var offKeyTotal: TimeInterval = 0
 
   var body: some View {
     ZStack {
       Color(red: 0.035, green: 0.035, blue: 0.06)
       if reduceMotion {
         blobs(at: 0)
-      } else {
+      } else if activeState == .key {
         TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
-          blobs(at: context.date.timeIntervalSinceReferenceDate)
+          blobs(at: drift(at: context.date))
         }
+      } else {
+        // Nothing off-key is being looked at: behind another app, minimized or
+        // on another Space, the window has resigned key either way.
+        blobs(at: drift(at: offKeySince ?? .now))
       }
       // Vignette keeps edges dark so content owns the middle.
       RadialGradient(
@@ -74,6 +86,19 @@ struct OnboardingCanvas: View {
     .animation(.easeInOut(duration: 1.4), value: act)
     .ignoresSafeArea()
     .accessibilityHidden(true)
+    .onAppear { if activeState != .key, offKeySince == nil { offKeySince = .now } }
+    .onChange(of: activeState) { _, state in
+      if state == .key {
+        if let since = offKeySince { offKeyTotal += Date.now.timeIntervalSince(since) }
+        offKeySince = nil
+      } else if offKeySince == nil {
+        offKeySince = .now
+      }
+    }
+  }
+
+  private func drift(at date: Date) -> TimeInterval {
+    date.timeIntervalSinceReferenceDate - offKeyTotal
   }
 
   private func blobs(at time: TimeInterval) -> some View {

--- a/Candela/Onboarding/OnboardingWindowController.swift
+++ b/Candela/Onboarding/OnboardingWindowController.swift
@@ -16,12 +16,12 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
   private let model: AppModel
   private let actions: SettingsActions
   private let onCompletion: () -> Void
-  /// Fires after the window closes ONLY when the close came from the finish
-  /// page's "Start Using …" button. ⌘W, the red close button and Skip Setup
-  /// complete Setup but stay quiet: the user asked to dismiss a window,
-  /// not to be handed a menu.
-  var onFinishedByButton: (() -> Void)?
-  private var closedByFinishButton = false
+  /// Fires after a FIRST-RUN Setup window closes, by any route: "Start Using …",
+  /// Skip Setup, ⌘W or the red close button. Every one of them leaves a
+  /// first-run user looking at a desktop with no window and no Dock icon, which
+  /// is the whole reason the landing callout exists. A Setup re-run from
+  /// Settings stays quiet: that user already knows where the app lives.
+  var onFirstRunClosed: (() -> Void)?
   /// Constructed once and reused like the window, which is only safe because
   /// `isEnabled` is a LIVE read of `SMAppService.mainApp.status`. No copy
   /// of the registration state is held, so nothing here goes stale after a
@@ -119,17 +119,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     }
     flow.onKeepSize = { [weak applier] in applier?.keep() }
     flow.onRevertSize = { [weak applier] in applier?.revert() }
-    flow.onClose = { [weak self, weak flow] in
-      guard let self else { return }
-      // The flow's own close fires from the finish advance and from Skip
-      // Setup. On the finish page the skip link never renders, so a close
-      // arriving there IS the finish, and only that close earns the landing
-      // callout.
-      if flow?.currentPage == .finish {
-        self.closedByFinishButton = true
-      }
-      self.window?.performClose(nil)
-    }
+    flow.onClose = { [weak self] in self?.window?.performClose(nil) }
     self.flowModel = flow
     self.applier = applier
     window.contentView = NSHostingView(rootView: OnboardingFlowView(model: flow))
@@ -212,10 +202,13 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     // observation loop dies rather than staying armed behind a closed window. An
     // answer still waiting on its first preview observation survives this.
     applier?.cancel()
+    // Read from the harvest this presentation was built on, BEFORE
+    // `onCompletion` records the schema version a later harvest would read back
+    // as "not a first run".
+    let wasFirstRun = flowModel?.environment.isFirstRun ?? false
     onCompletion()
-    if closedByFinishButton {
-      closedByFinishButton = false
-      onFinishedByButton?()
+    if wasFirstRun {
+      onFirstRunClosed?()
     }
   }
 }

--- a/Candela/Onboarding/OnboardingWindowController.swift
+++ b/Candela/Onboarding/OnboardingWindowController.swift
@@ -16,11 +16,8 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
   private let model: AppModel
   private let actions: SettingsActions
   private let onCompletion: () -> Void
-  /// Fires after a FIRST-RUN Setup window closes, by any route: "Start Using …",
-  /// Skip Setup, ⌘W or the red close button. Every one of them leaves a
-  /// first-run user looking at a desktop with no window and no Dock icon, which
-  /// is the whole reason the landing callout exists. A Setup re-run from
-  /// Settings stays quiet: that user already knows where the app lives.
+  /// Fires after a first-run Setup window closes by any route: each leaves a new
+  /// user with no window and no Dock icon. A re-run from Settings stays quiet.
   var onFirstRunClosed: (() -> Void)?
   /// Constructed once and reused like the window, which is only safe because
   /// `isEnabled` is a LIVE read of `SMAppService.mainApp.status`. No copy
@@ -202,9 +199,8 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     // observation loop dies rather than staying armed behind a closed window. An
     // answer still waiting on its first preview observation survives this.
     applier?.cancel()
-    // Read from the harvest this presentation was built on, BEFORE
-    // `onCompletion` records the schema version a later harvest would read back
-    // as "not a first run".
+    // Before `onCompletion`, which records the schema version that makes a later
+    // read say "not a first run".
     let wasFirstRun = flowModel?.environment.isFirstRun ?? false
     onCompletion()
     if wasFirstRun {

--- a/Candela/Panel/PanelMirroringSection.swift
+++ b/Candela/Panel/PanelMirroringSection.swift
@@ -209,8 +209,8 @@ struct PanelMirroringSection: View {
       //
       // Nothing is lost by closing: the answer was never available here, since an
       // engage's Keep/Revert lives in a floating panel built to outlive this
-      // menu. Sliders and the HDR toggle stay put because they are in-place
-      // adjustments, not choices.
+      // menu. Sliders stay put: a drag is an in-place adjustment nothing waits
+      // on. The HDR button ends tracking too, for the starvation reason above.
       PanelMenu.endTracking()
     }
     .disabled(!enabled || coordinator.isApplying)

--- a/Candela/Panel/PanelResolutionSection.swift
+++ b/Candela/Panel/PanelResolutionSection.swift
@@ -272,8 +272,9 @@ struct PanelResolutionSection: View {
     // rows while the screen did not change and nothing said why.
     //
     // Nothing is lost by closing: the confirmation window was built to outlive
-    // this menu, so the answer is already somewhere else. Sliders and the HDR
-    // toggle stay put because they are in-place adjustments, not choices.
+    // this menu, so the answer is already somewhere else. Sliders stay put: a
+    // drag is an in-place adjustment nothing waits on. The HDR button ends
+    // tracking too, for the starvation reason above rather than for this one.
     PanelMenu.endTracking()
   }
 }

--- a/Candela/Panel/PanelView.swift
+++ b/Candela/Panel/PanelView.swift
@@ -229,11 +229,21 @@ struct PanelView: View {
 
   /// Which pane holds the switch that brings a hidden display back. The
   /// built-in's lives on Menu Bar and an external's on the display's own page,
-  /// so one sentence cannot serve both.
-  static func unhideHint(hasExternals: Bool) -> String {
-    hasExternals
-      ? "Show one again in Settings → Displays."
-      : "Show it again in Settings → Menu Bar."
+  /// so one sentence cannot serve both, and a rig with both kinds hidden needs
+  /// both named: pointing only at Displays sends a clamshell user looking for a
+  /// switch that is not there.
+  static func unhideHint(builtInHidden: Bool, externalsHidden: Bool) -> String {
+    switch (builtInHidden, externalsHidden) {
+    case (true, true):
+      "Show them again in Settings → Menu Bar and Settings → Displays."
+    case (true, false):
+      "Show it again in Settings → Menu Bar."
+    case (false, true):
+      "Show one again in Settings → Displays."
+    default:
+      // (false, false): nothing is hidden, so nothing asked this question.
+      "Show one again in Settings → Displays."
+    }
   }
 
   /// Two empties: nothing attached is a hardware fact, everything hidden is
@@ -250,7 +260,12 @@ struct PanelView: View {
         )
       } else {
         Text("Every display is hidden")
-        emptyCaption(Self.unhideHint(hasExternals: !model.displays.isEmpty))
+        // Nothing is visible in this branch, so every display that EXISTS is a
+        // display that is hidden.
+        emptyCaption(Self.unhideHint(
+          builtInHidden: model.builtIn != nil && !Self.showsBuiltIn(model),
+          externalsHidden: !model.displays.isEmpty
+        ))
       }
     }
     .font(.system(size: 13))
@@ -322,8 +337,12 @@ struct PanelView: View {
         // No window can take focus while a menu tracking session runs, so
         // without this System Settings opens behind whatever is frontmost. Same
         // constraint `SettingsOpener` states for the footer's gear.
+        //
+        // Queued rather than called straight after, the shape both sibling
+        // buttons use: `endTracking` asks the session to end, and a synchronous
+        // open on the next line still runs inside it.
         PanelMenu.endTracking()
-        AccessibilityPermission.openSystemSettings()
+        Task { @MainActor in AccessibilityPermission.openSystemSettings() }
       }
       .buttonStyle(.link)
       .font(.system(size: 12))
@@ -451,10 +470,35 @@ extension PanelView {
   ) -> String? {
     guard !isHDREngaged else { return nil }
     if capabilityProbed, !supportsHDR {
-      return DiagnosticsCopy.hdrNoAnswer(app: AppInfo.productName)
+      return Self.hdrNoModesCaption
     }
     guard isShowingSynthesizedSize else { return nil }
     return SynthesisCopy.hdrBlockedBySynthesizedSize
+  }
+
+  /// The panel's own sentence for a display that reports no HDR modes. Not
+  /// `DiagnosticsCopy.hdrNoAnswer`, which is written for a row that goes on to
+  /// give both causes: on its own "has no HDR answer" reads as the app not
+  /// knowing rather than as the display having nothing to offer.
+  static let hdrNoModesCaption = "No HDR modes were found for this display."
+
+  /// Whether the panel's HDR button is live. The unprobed reading is grey, which
+  /// is what shipped before the caption existed: `supportsHDR` is false until the
+  /// async refresh answers, so a button enabled on that reading is one a click
+  /// reaches a moment before the app knows whether the display has HDR at all.
+  /// Grey and uncaptioned for that moment, then the probe brings both.
+  ///
+  /// The engaged escape outranks all of it, the same asymmetry `hdrRefusalReason`
+  /// keeps: with HDR live this button IS the way out, and a way out that greys
+  /// itself in the state it exists to leave is not one. A panel swap drops the
+  /// probe flag while the engaged and capability caches still answer for the
+  /// display that left, so without this arm the exit went grey for the length of
+  /// the reconfiguration refresh.
+  static func hdrButtonIsEnabled(
+    isHDREngaged: Bool, capabilityProbed: Bool, supportsHDR: Bool, refusalReason: String?
+  ) -> Bool {
+    if isHDREngaged { return true }
+    return capabilityProbed && supportsHDR && refusalReason == nil
   }
 }
 
@@ -553,9 +597,14 @@ private struct DisplayHeaderRow: View {
     // status item), which would leave a phantom highlight on the next open.
     .onDisappear { isHovering = false }
     .fixedSize()
-    // Disable, don't hide, on non-HDR displays. `supportsHDR` is
+    // Disable, don't hide, on non-HDR displays. Both flags are
     // observation-tracked, so the button enables when the async refresh lands.
-    .disabled(!controller.supportsHDR || refusalReason != nil)
+    .disabled(!PanelView.hdrButtonIsEnabled(
+      isHDREngaged: controller.isHDREngaged,
+      capabilityProbed: controller.hdrCapabilityProbed,
+      supportsHDR: controller.supportsHDR,
+      refusalReason: refusalReason
+    ))
     // No `.help`: the panel delivers no tooltip at all, enabled controls
     // included. Menu tracking is the cause, not the greying next door.
     .accessibilityLabel("\(displayName) HDR mode")

--- a/Candela/Panel/PanelView.swift
+++ b/Candela/Panel/PanelView.swift
@@ -227,17 +227,30 @@ struct PanelView: View {
     DisplayPrefs(persistenceKey: persistenceKey)
   }
 
+  /// Which pane holds the switch that brings a hidden display back. The
+  /// built-in's lives on Menu Bar and an external's on the display's own page,
+  /// so one sentence cannot serve both.
+  static func unhideHint(hasExternals: Bool) -> String {
+    hasExternals
+      ? "Show one again in Settings → Displays."
+      : "Show it again in Settings → Menu Bar."
+  }
+
   /// Two empties: nothing attached is a hardware fact, everything hidden is
   /// undoable, so that branch says where to undo it.
   private var emptyState: some View {
     VStack(spacing: 4) {
       if model.displays.isEmpty, model.builtIn == nil {
         Text("No controllable displays")
+        // Discovery keeps only displays that answer with an IOAVService, so a
+        // DisplayLink or AirPlay panel never reaches the panel at all and the
+        // line above reads as a fault in the app.
+        emptyCaption(
+          "Displays on DisplayLink, AirPlay or Sidecar have no DDC channel, so they cannot be controlled."
+        )
       } else {
         Text("Every display is hidden")
-        Text("Show one again in Settings → Displays.")
-          .font(.system(size: 11))
-          .foregroundStyle(.tertiary)
+        emptyCaption(Self.unhideHint(hasExternals: !model.displays.isEmpty))
       }
     }
     .font(.system(size: 13))
@@ -245,6 +258,15 @@ struct PanelView: View {
     .multilineTextAlignment(.center)
     .frame(maxWidth: .infinity)
     .padding(.vertical, 6)
+  }
+
+  /// `fixedSize` on the vertical axis only: the panel is a fixed 280 pt wide, so
+  /// a caption that wraps must be allowed the height its wrap needs.
+  private func emptyCaption(_ text: String) -> some View {
+    Text(verbatim: text)
+      .font(.system(size: 11))
+      .foregroundStyle(.tertiary)
+      .fixedSize(horizontal: false, vertical: true)
   }
 
   // MARK: - Slider visibility
@@ -297,6 +319,10 @@ struct PanelView: View {
         .fixedSize(horizontal: false, vertical: true)
       Spacer(minLength: 8)
       Button("Open Settings…") {
+        // No window can take focus while a menu tracking session runs, so
+        // without this System Settings opens behind whatever is frontmost. Same
+        // constraint `SettingsOpener` states for the footer's gear.
+        PanelMenu.endTracking()
         AccessibilityPermission.openSystemSettings()
       }
       .buttonStyle(.link)
@@ -496,6 +522,11 @@ private struct DisplayHeaderRow: View {
   private var hdrModeButton: some View {
     Button {
       Task { await controller.setHDRMode(nextMode) }
+      // ENDING TRACKING IS THE POINT OF THIS LINE, not a courtesy, and the same
+      // rule the Resolution and Mirroring rows state at length: tracking starves
+      // the main-actor work the Task above queues, so the click looks dead until
+      // the panel is dismissed and every queued toggle then fires at once.
+      PanelMenu.endTracking()
     } label: {
       Text(modeLabel)
         .font(.system(size: 12))

--- a/Candela/Panel/PanelView.swift
+++ b/Candela/Panel/PanelView.swift
@@ -436,10 +436,24 @@ extension PanelView {
   /// exit, and greying that would be the forbidden shape: a recovery control
   /// unavailable in the state it recovers from.
   /// `BrightnessController.setHDRMode` enforces the same asymmetry.
+  ///
+  /// The capability arm comes before the synthesized-size one: a display that reports
+  /// no HDR modes would not gain HDR by dropping the size, so naming the size there
+  /// would send a person to do something that changes nothing.
+  ///
+  /// `capabilityProbed` is the whole of the guard against libel. `supportsHDR` is
+  /// false before the async refresh answers as well as after it answers no, and a
+  /// caption on the first reading calls an HDR display incapable for as long as the
+  /// refresh takes.
   static func hdrRefusalReason(
-    isShowingSynthesizedSize: Bool, isHDREngaged: Bool
+    isShowingSynthesizedSize: Bool, isHDREngaged: Bool,
+    supportsHDR: Bool, capabilityProbed: Bool
   ) -> String? {
-    guard isShowingSynthesizedSize, !isHDREngaged else { return nil }
+    guard !isHDREngaged else { return nil }
+    if capabilityProbed, !supportsHDR {
+      return DiagnosticsCopy.hdrNoAnswer(app: AppInfo.productName)
+    }
+    guard isShowingSynthesizedSize else { return nil }
     return SynthesisCopy.hdrBlockedBySynthesizedSize
   }
 }
@@ -512,7 +526,9 @@ private struct DisplayHeaderRow: View {
   private var refusalReason: String? {
     PanelView.hdrRefusalReason(
       isShowingSynthesizedSize: isShowingSynthesizedSize,
-      isHDREngaged: controller.isHDREngaged
+      isHDREngaged: controller.isHDREngaged,
+      supportsHDR: controller.supportsHDR,
+      capabilityProbed: controller.hdrCapabilityProbed
     )
   }
 

--- a/Candela/Panel/PanelView.swift
+++ b/Candela/Panel/PanelView.swift
@@ -227,11 +227,8 @@ struct PanelView: View {
     DisplayPrefs(persistenceKey: persistenceKey)
   }
 
-  /// Which pane holds the switch that brings a hidden display back. The
-  /// built-in's lives on Menu Bar and an external's on the display's own page,
-  /// so one sentence cannot serve both, and a rig with both kinds hidden needs
-  /// both named: pointing only at Displays sends a clamshell user looking for a
-  /// switch that is not there.
+  /// The built-in's switch lives on Menu Bar, an external's on its own page, so
+  /// pointing only at Displays sends a clamshell user to a switch that is not there.
   static func unhideHint(builtInHidden: Bool, externalsHidden: Bool) -> String {
     switch (builtInHidden, externalsHidden) {
     case (true, true):
@@ -252,16 +249,14 @@ struct PanelView: View {
     VStack(spacing: 4) {
       if model.displays.isEmpty, model.builtIn == nil {
         Text("No controllable displays")
-        // Discovery keeps only displays that answer with an IOAVService, so a
-        // DisplayLink or AirPlay panel never reaches the panel at all and the
-        // line above reads as a fault in the app.
+        // Discovery drops anything without an IOAVService, so a DisplayLink or
+        // AirPlay panel never appears here and the line above reads as a fault.
         emptyCaption(
           "Displays on DisplayLink, AirPlay or Sidecar have no DDC channel, so they cannot be controlled."
         )
       } else {
         Text("Every display is hidden")
-        // Nothing is visible in this branch, so every display that EXISTS is a
-        // display that is hidden.
+        // Nothing is visible here, so every display that exists is hidden.
         emptyCaption(Self.unhideHint(
           builtInHidden: model.builtIn != nil && !Self.showsBuiltIn(model),
           externalsHidden: !model.displays.isEmpty
@@ -275,8 +270,7 @@ struct PanelView: View {
     .padding(.vertical, 6)
   }
 
-  /// `fixedSize` on the vertical axis only: the panel is a fixed 280 pt wide, so
-  /// a caption that wraps must be allowed the height its wrap needs.
+  /// The panel is fixed-width, so a wrapping caption needs its height freed.
   private func emptyCaption(_ text: String) -> some View {
     Text(verbatim: text)
       .font(.system(size: 11))
@@ -334,13 +328,9 @@ struct PanelView: View {
         .fixedSize(horizontal: false, vertical: true)
       Spacer(minLength: 8)
       Button("Open Settings…") {
-        // No window can take focus while a menu tracking session runs, so
-        // without this System Settings opens behind whatever is frontmost. Same
-        // constraint `SettingsOpener` states for the footer's gear.
-        //
-        // Queued rather than called straight after, the shape both sibling
-        // buttons use: `endTracking` asks the session to end, and a synchronous
-        // open on the next line still runs inside it.
+        // No window can take focus during menu tracking, so System Settings would
+        // open behind the frontmost app. Queued: `endTracking` only asks the
+        // session to end, and a synchronous open still runs inside it.
         PanelMenu.endTracking()
         Task { @MainActor in AccessibilityPermission.openSystemSettings() }
       }
@@ -456,14 +446,9 @@ extension PanelView {
   /// unavailable in the state it recovers from.
   /// `BrightnessController.setHDRMode` enforces the same asymmetry.
   ///
-  /// The capability arm comes before the synthesized-size one: a display that reports
-  /// no HDR modes would not gain HDR by dropping the size, so naming the size there
-  /// would send a person to do something that changes nothing.
-  ///
-  /// `capabilityProbed` is the whole of the guard against libel. `supportsHDR` is
-  /// false before the async refresh answers as well as after it answers no, and a
-  /// caption on the first reading calls an HDR display incapable for as long as the
-  /// refresh takes.
+  /// Capability before size: dropping the size would not bring HDR to a display
+  /// with no HDR modes. `capabilityProbed` guards the unprobed reading, where
+  /// `supportsHDR` is false only because the refresh has not answered.
   static func hdrRefusalReason(
     isShowingSynthesizedSize: Bool, isHDREngaged: Bool,
     supportsHDR: Bool, capabilityProbed: Bool
@@ -476,24 +461,13 @@ extension PanelView {
     return SynthesisCopy.hdrBlockedBySynthesizedSize
   }
 
-  /// The panel's own sentence for a display that reports no HDR modes. Not
-  /// `DiagnosticsCopy.hdrNoAnswer`, which is written for a row that goes on to
-  /// give both causes: on its own "has no HDR answer" reads as the app not
-  /// knowing rather than as the display having nothing to offer.
+  /// Not `DiagnosticsCopy.hdrNoAnswer`: alone, "has no HDR answer" reads as the
+  /// app not knowing.
   static let hdrNoModesCaption = "No HDR modes were found for this display."
 
-  /// Whether the panel's HDR button is live. The unprobed reading is grey, which
-  /// is what shipped before the caption existed: `supportsHDR` is false until the
-  /// async refresh answers, so a button enabled on that reading is one a click
-  /// reaches a moment before the app knows whether the display has HDR at all.
-  /// Grey and uncaptioned for that moment, then the probe brings both.
-  ///
-  /// The engaged escape outranks all of it, the same asymmetry `hdrRefusalReason`
-  /// keeps: with HDR live this button IS the way out, and a way out that greys
-  /// itself in the state it exists to leave is not one. A panel swap drops the
-  /// probe flag while the engaged and capability caches still answer for the
-  /// display that left, so without this arm the exit went grey for the length of
-  /// the reconfiguration refresh.
+  /// Grey and uncaptioned until the probe answers. Engaged outranks everything,
+  /// as in `hdrRefusalReason`: this button is the way out of HDR, and a panel
+  /// swap drops the probe flag while the engaged cache still reads true.
   static func hdrButtonIsEnabled(
     isHDREngaged: Bool, capabilityProbed: Bool, supportsHDR: Bool, refusalReason: String?
   ) -> Bool {
@@ -582,10 +556,8 @@ private struct DisplayHeaderRow: View {
   private var hdrModeButton: some View {
     Button {
       Task { await controller.setHDRMode(nextMode) }
-      // ENDING TRACKING IS THE POINT OF THIS LINE, not a courtesy, and the same
-      // rule the Resolution and Mirroring rows state at length: tracking starves
-      // the main-actor work the Task above queues, so the click looks dead until
-      // the panel is dismissed and every queued toggle then fires at once.
+      // Tracking starves the main-actor work queued above: without this the click
+      // looks dead until the panel closes, then every queued toggle fires at once.
       PanelMenu.endTracking()
     } label: {
       Text(modeLabel)

--- a/Candela/Settings/AboutPane.swift
+++ b/Candela/Settings/AboutPane.swift
@@ -28,8 +28,11 @@ struct AboutPane: View {
         // The sentence belongs to the row, not the button: `SettingsActionRow`
         // republishes it as the control's accessibility hint (contract 3).
         SettingsActionRow(verbatim: checkNowLine, dividerFollows: true) {
+          // Stated twice, like Run Setup Again below: SwiftUI does not publish
+          // a `Button`'s own title to the accessibility layer.
           Button("Check for Updates") { updater.checkForUpdates() }
             .buttonStyle(SettingsPrimaryButtonStyle())
+            .accessibilityLabel("Check for Updates")
             .disabled(!updater.canCheckForUpdates)
         }
         SettingsCardDivider()

--- a/Candela/Settings/AboutPane.swift
+++ b/Candela/Settings/AboutPane.swift
@@ -28,8 +28,7 @@ struct AboutPane: View {
         // The sentence belongs to the row, not the button: `SettingsActionRow`
         // republishes it as the control's accessibility hint (contract 3).
         SettingsActionRow(verbatim: checkNowLine, dividerFollows: true) {
-          // Stated twice, like Run Setup Again below: SwiftUI does not publish
-          // a `Button`'s own title to the accessibility layer.
+          // SwiftUI does not publish a `Button` title to accessibility.
           Button("Check for Updates") { updater.checkForUpdates() }
             .buttonStyle(SettingsPrimaryButtonStyle())
             .accessibilityLabel("Check for Updates")

--- a/Candela/Settings/AboutPane.swift
+++ b/Candela/Settings/AboutPane.swift
@@ -39,6 +39,7 @@ struct AboutPane: View {
         SettingRow("When this is on, \(AppInfo.productName) checks about once a day, in the background.") {
           Toggle("Check for updates automatically", isOn: $updater.automaticallyChecksForUpdates)
             .themedSwitch()
+            .accessibilityLabel("Check for updates automatically")
         }
         SettingsCardDivider()
         // Holds however the toggle above is set, so it sits under both rows

--- a/Candela/Settings/AdvancedPage.swift
+++ b/Candela/Settings/AdvancedPage.swift
@@ -445,8 +445,10 @@ struct AdvancedPage: View {
         }
       }
     }
-    // The retries branch only. The enabler branch stays live under a block.
-    .disabled(isBlocked && appPrefs.startupAction == .read)
+    // The retries branch only. The enabler branch stays live under a block, and
+    // so does the never-answered verdict: greying a statement of fact says the
+    // fact is unavailable rather than that a control is.
+    .disabled(isBlocked && !readbackNeverAnswered && appPrefs.startupAction == .read)
   }
 
   /// NOT `DDCReadEvidence.worst(...)`: worst-wins folds a display whose

--- a/Candela/Settings/AdvancedPage.swift
+++ b/Candela/Settings/AdvancedPage.swift
@@ -158,6 +158,7 @@ struct AdvancedPage: View {
           }
         ))
         .themedSwitch()
+        .accessibilityLabel("Dim with a screen overlay")
         .prefIdentifier(.avoidGamma, persistenceKey: persistenceKey)
       }
 
@@ -171,6 +172,7 @@ struct AdvancedPage: View {
           set: { shown in writer.write(.hideOsd) { $0.hideOsd = !shown } }
         ))
         .themedSwitch()
+        .accessibilityLabel("Show the volume indicator")
         .prefIdentifier(.hideOsd, persistenceKey: persistenceKey)
       }
       // The hooks hang on the row above, which always renders: on the caption
@@ -257,6 +259,8 @@ struct AdvancedPage: View {
           stored: { storedRemapText(command) },
           commit: { commitRemap(command, $0) },
           prompt: Text("Standard"),
+          // The surrounding `LabeledContent` draws this but publishes none.
+          fieldLabel: Text(verbatim: "\(DDCCommandCopy.title(command)) control code"),
           // Not a `SettingRow` caption: the sub-group's one caption covers
           // every control, and repeating it per field would read as separate
           // settings.

--- a/Candela/Settings/AdvancedPage.swift
+++ b/Candela/Settings/AdvancedPage.swift
@@ -286,9 +286,8 @@ struct AdvancedPage: View {
   /// the "looks functional while `ddcTrafficBlock` voids it" case the greying
   /// rule forbids.
   ///
-  /// The enabler in the other branch does NOT grey. It writes an app-level
-  /// pref that applies to every display, and one display's blocked wire is no
-  /// reason to withhold a global switch.
+  /// The enabler branch does NOT grey: it writes an app-level pref, and one
+  /// display's blocked wire is no reason to withhold a global switch.
   @ViewBuilder private var combinedDimmingSection: some View {
     SettingsCardSection(title: "Combined Dimming") {
       if appPrefs.combinedBrightness {
@@ -433,9 +432,8 @@ struct AdvancedPage: View {
           .prefIdentifier(.pollingCount, persistenceKey: persistenceKey)
         }
       } else {
-        // The same read-only-with-an-inline-enabler shape as Combined Dimming
-        // above, and ungreyed for the same reason: `startupAction` is app-level,
-        // so this display's blocked wire is no reason to withhold it.
+        // Same shape as Combined Dimming above, ungreyed for the same reason:
+        // `startupAction` is app-level.
         LabeledContent("Startup readback", value: "Off")
         SettingsCardDivider()
         SettingRow("A global setting: applies to every display.") {
@@ -449,9 +447,8 @@ struct AdvancedPage: View {
         }
       }
     }
-    // The retries branch only. The enabler branch stays live under a block, and
-    // so does the never-answered verdict: greying a statement of fact says the
-    // fact is unavailable rather than that a control is.
+    // The retries branch only. The enabler stays live, and so does the
+    // never-answered verdict: greying a fact says the fact is unavailable.
     .disabled(isBlocked && !readbackNeverAnswered && appPrefs.startupAction == .read)
   }
 
@@ -488,8 +485,8 @@ struct AdvancedPage: View {
         .accessibilityIdentifier("action.restoreAdvanced.\(persistenceKey)")
         .alert("Restore this display's advanced settings?", isPresented: $confirmingRestore) {
           Button("Restore", role: .destructive) { restoreAdvancedDefaults() }
-          // Cancel takes Return: without the explicit shortcut the destructive
-          // button holds the primary role.
+          // Cancel takes Return; otherwise the destructive button holds the
+          // primary role.
           Button("Cancel", role: .cancel) {}
             .keyboardShortcut(.defaultAction)
         } message: {

--- a/Candela/Settings/AdvancedPage.swift
+++ b/Candela/Settings/AdvancedPage.swift
@@ -275,12 +275,16 @@ struct AdvancedPage: View {
 
   // MARK: - Combined Dimming
 
-  /// Greys with the other sections, with no carve-out. The handoff
-  /// point is reachable only from `.combined` and `.softwareOnly`, and both
-  /// blocked states route elsewhere: `.hardwareControlOff` to `.software`,
-  /// `.macOSDrivesBrightness` to `.native`. A live control here would be the
-  /// "looks functional while `ddcTrafficBlock` voids it" case the greying
+  /// The per-display handoff point greys with the other sections: it is
+  /// reachable only from `.combined` and `.softwareOnly`, and both blocked
+  /// states route elsewhere (`.hardwareControlOff` to `.software`,
+  /// `.macOSDrivesBrightness` to `.native`), so a live control there would be
+  /// the "looks functional while `ddcTrafficBlock` voids it" case the greying
   /// rule forbids.
+  ///
+  /// The enabler in the other branch does NOT grey. It writes an app-level
+  /// pref that applies to every display, and one display's blocked wire is no
+  /// reason to withhold a global switch.
   @ViewBuilder private var combinedDimmingSection: some View {
     SettingsCardSection(title: "Combined Dimming") {
       if appPrefs.combinedBrightness {
@@ -340,11 +344,11 @@ struct AdvancedPage: View {
           .buttonStyle(SettingsSecondaryButtonStyle())
           .accessibilityLabel("Turn On Dim Past the Display's Minimum")
           .prefIdentifier(.disableCombinedBrightness)
-          .disabled(isBlocked)
         }
       }
     }
-    .disabled(isBlocked)
+    // The handoff branch only. The enabler branch stays live under a block.
+    .disabled(isBlocked && appPrefs.combinedBrightness)
   }
 
   /// The engine's own range, never a literal pair: `DisplayPrefs` clamps writes
@@ -425,7 +429,9 @@ struct AdvancedPage: View {
           .prefIdentifier(.pollingCount, persistenceKey: persistenceKey)
         }
       } else {
-        // The same read-only-with-an-inline-enabler shape as Combined Dimming above.
+        // The same read-only-with-an-inline-enabler shape as Combined Dimming
+        // above, and ungreyed for the same reason: `startupAction` is app-level,
+        // so this display's blocked wire is no reason to withhold it.
         LabeledContent("Startup readback", value: "Off")
         SettingsCardDivider()
         SettingRow("A global setting: applies to every display.") {
@@ -436,11 +442,11 @@ struct AdvancedPage: View {
           .buttonStyle(SettingsSecondaryButtonStyle())
           .accessibilityLabel("Ask the Display at Startup")
           .prefIdentifier(.startupAction)
-          .disabled(isBlocked)
         }
       }
     }
-    .disabled(isBlocked)
+    // The retries branch only. The enabler branch stays live under a block.
+    .disabled(isBlocked && appPrefs.startupAction == .read)
   }
 
   /// NOT `DDCReadEvidence.worst(...)`: worst-wins folds a display whose
@@ -476,7 +482,10 @@ struct AdvancedPage: View {
         .accessibilityIdentifier("action.restoreAdvanced.\(persistenceKey)")
         .alert("Restore this display's advanced settings?", isPresented: $confirmingRestore) {
           Button("Restore", role: .destructive) { restoreAdvancedDefaults() }
+          // Cancel takes Return: without the explicit shortcut the destructive
+          // button holds the primary role.
           Button("Cancel", role: .cancel) {}
+            .keyboardShortcut(.defaultAction)
         } message: {
           // Names the scope in plain terms, including the unmute.
           Text("This turns hardware control and the volume indicator back on for \(state.display.name), switches software dimming back from a screen overlay to the color profile, clears its command tuning, control codes and response curves, and returns the dimming handoff and readback retries to their defaults. A display left muted in hardware is unmuted too, unless it is in HDR mode. Nothing else about this display changes.")

--- a/Candela/Settings/AllModesPage.swift
+++ b/Candela/Settings/AllModesPage.swift
@@ -94,9 +94,8 @@ struct AllModesPage: View {
       // nothing, so no empty state flashes on every push.
       if let catalog {
         if catalog.all.isEmpty {
-          // An enumerated display with nothing in it. Without this the page
-          // draws a Show control over a titled, empty card, which reads as a
-          // list that failed to load.
+          // Without this the page draws a Show control over an empty card, which
+          // reads as a list that failed to load.
           SettingsRowNote(verbatim: Self.noModesNote)
         } else {
           listControls(catalog)
@@ -128,8 +127,8 @@ struct AllModesPage: View {
 
   // MARK: - Controls
 
-  /// Word for word what `DisplaySizeRows` says on the hub for the same display,
-  /// so the two surfaces do not describe one silent panel two ways.
+  /// Word for word what the hub's size rows say, so one silent panel is not
+  /// described two ways.
   static let noModesNote =
     "\(AppInfo.productName) found no resolutions it can switch between on this display."
 

--- a/Candela/Settings/AllModesPage.swift
+++ b/Candela/Settings/AllModesPage.swift
@@ -93,8 +93,15 @@ struct AllModesPage: View {
       // A nil catalog is "not enumerated yet", NOT "no modes". It renders as
       // nothing, so no empty state flashes on every push.
       if let catalog {
-        listControls(catalog)
-        modeList(catalog)
+        if catalog.all.isEmpty {
+          // An enumerated display with nothing in it. Without this the page
+          // draws a Show control over a titled, empty card, which reads as a
+          // list that failed to load.
+          SettingsRowNote(verbatim: Self.noModesNote)
+        } else {
+          listControls(catalog)
+          modeList(catalog)
+        }
       }
     })
     // Enumeration is several CoreGraphics round-trips, so it runs once per
@@ -120,6 +127,11 @@ struct AllModesPage: View {
   }
 
   // MARK: - Controls
+
+  /// Word for word what `DisplaySizeRows` says on the hub for the same display,
+  /// so the two surfaces do not describe one silent panel two ways.
+  static let noModesNote =
+    "\(AppInfo.productName) found no resolutions it can switch between on this display."
 
   @ViewBuilder private func listControls(_ catalog: DisplayModeCoordinator.Catalog) -> some View {
     SettingsCardSection {

--- a/Candela/Settings/AmbientBrightnessRow.swift
+++ b/Candela/Settings/AmbientBrightnessRow.swift
@@ -51,6 +51,7 @@ struct AmbientBrightnessRow: View {
           set: { request($0, for: displayID) }
         ))
         .themedSwitch()
+        .accessibilityLabel("Automatically adjust brightness")
       }
       // macOS can move this setting underneath us with no notification, so
       // re-read on appear, on activation (the trip to System Settings and back)

--- a/Candela/Settings/AppMenuPane.swift
+++ b/Candela/Settings/AppMenuPane.swift
@@ -138,6 +138,7 @@ struct AppMenuPane: View {
         }
       ))
       .themedSwitch()
+      .accessibilityLabel("Show the built-in display in the menu bar")
       .prefIdentifier(.hideBuiltInDisplay)
     }
   }
@@ -155,6 +156,7 @@ struct AppMenuPane: View {
         }
       ))
       .themedSwitch()
+      .accessibilityLabel("Show Keep Display Awake in the menu bar")
       .prefIdentifier(.hideKeepAwake)
     }
   }
@@ -171,6 +173,7 @@ struct AppMenuPane: View {
         }
       ))
       .themedSwitch()
+      .accessibilityLabel("Show an All Displays brightness slider")
       .prefIdentifier(.hideCombinedBrightness)
     }
   }
@@ -185,6 +188,7 @@ struct AppMenuPane: View {
         }
       ))
       .themedSwitch()
+      .accessibilityLabel("Show a contrast slider")
       .prefIdentifier(.showContrast)
     }
   }
@@ -201,6 +205,7 @@ struct AppMenuPane: View {
         }
       ))
       .themedSwitch()
+      .accessibilityLabel("Snap to 25% steps")
       .prefIdentifier(.enableSliderSnap)
     }
   }
@@ -219,6 +224,7 @@ struct AppMenuPane: View {
         }
       ))
       .themedSwitch()
+      .accessibilityLabel("Show percentages")
       .prefIdentifier(.enableSliderPercent)
     }
   }

--- a/Candela/Settings/ArrangementPane.swift
+++ b/Candela/Settings/ArrangementPane.swift
@@ -377,6 +377,7 @@ struct ArrangementPane: View {
           }
         ))
         .themedSwitch()
+        .accessibilityLabel("Remember how these displays are arranged")
         .prefIdentifier(.restoreArrangement)
       }
       // The mirror hooks hang HERE, on the one row of this section that is

--- a/Candela/Settings/BannerRegion.swift
+++ b/Candela/Settings/BannerRegion.swift
@@ -22,12 +22,9 @@ struct BannerRegion: View {
   @Environment(SettingsActions.self) private var actions
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-  /// Measured by `measureDomainFreshness()`, never in `body`. Re-measured on
-  /// the display change, on `prefsRevision` (both resets bump it, so a wiped
-  /// domain reads as fresh again rather than staying stale behind a cache), and
-  /// on this display's brightness, because the engine's own store writes
-  /// `combinedBrightness.<key>` through `UserDefaults` directly and bumps
-  /// nothing. Without that last one a slider drag no longer retires the banner.
+  /// Never measured in `body`; see `measureDomainFreshness()`. Brightness is a
+  /// trigger because the engine writes its level straight to `UserDefaults`
+  /// with no revision bump, and a drag has to retire the banner.
   @State private var domainIsFresh: Bool?
 
   private var persistenceKey: String { state.display.persistenceKey }
@@ -69,13 +66,9 @@ struct BannerRegion: View {
     .onAppear { measureDomainFreshness() }
     .onChange(of: persistenceKey) { _, _ in measureDomainFreshness() }
     .onChange(of: model.prefsRevision) { _, _ in measureDomainFreshness() }
-    // The engine's stored level is written straight to `UserDefaults` with no
-    // revision bump, so this is the only signal that a drag has just filled the
-    // domain this banner calls empty. Gated on the fresh state: this fires at
-    // drag rate and the scan is a whole-domain dictionary walk, so once the
-    // domain reads as stored there is no question left to ask. It can only read
-    // fresh again through a wipe, and both resets bump `prefsRevision`, which
-    // re-measures above.
+    // Fires at drag rate and the scan walks the whole domain, so stop once the
+    // domain reads as stored: only a wipe makes it fresh again, and both resets
+    // bump `prefsRevision`.
     .onChange(of: state.controller.brightness) { _, _ in
       guard domainIsFresh != false else { return }
       measureDomainFreshness()
@@ -447,18 +440,10 @@ struct BannerRegion: View {
       && domainIsFresh == true
   }
 
-  /// Whether this display's prefs domain is empty, or nil until measured.
-  ///
-  /// `hasAnyStoredValue` materialises the whole UserDefaults dictionary and
-  /// scans it by suffix, and this region renders on two placements and
-  /// re-evaluates every countdown second, so it cannot run from `body`. nil
-  /// draws no banner: erring to silent for one frame beats flashing "first time
-  /// seeing this display" at a display that has settings.
-  ///
-  /// The two cheap terms of `showsFirstSight` are checked FIRST, and they answer
-  /// for the built-in and for every dismissed display without a scan: the banner
-  /// cannot show for either, so the dictionary walk would be work with no
-  /// question behind it.
+  /// `hasAnyStoredValue` walks the whole UserDefaults dictionary and this region
+  /// re-renders every countdown second, so it cannot run from `body`. nil draws
+  /// no banner: a silent frame beats flashing "first time" at a configured display.
+  /// The cheap terms go first so the built-in and dismissed displays skip the scan.
   private func measureDomainFreshness() {
     guard persistenceKey != "builtIn",
           !model.dismissedFirstSightKeys.contains(persistenceKey)

--- a/Candela/Settings/BannerRegion.swift
+++ b/Candela/Settings/BannerRegion.swift
@@ -23,9 +23,11 @@ struct BannerRegion: View {
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   /// Measured by `measureDomainFreshness()`, never in `body`. Re-measured on
-  /// the display change and on `prefsRevision`, which is every event that can
-  /// flip it: both resets bump it, so a wiped domain reads as fresh again
-  /// rather than staying stale behind a cache.
+  /// the display change, on `prefsRevision` (both resets bump it, so a wiped
+  /// domain reads as fresh again rather than staying stale behind a cache), and
+  /// on this display's brightness, because the engine's own store writes
+  /// `combinedBrightness.<key>` through `UserDefaults` directly and bumps
+  /// nothing. Without that last one a slider drag no longer retires the banner.
   @State private var domainIsFresh: Bool?
 
   private var persistenceKey: String { state.display.persistenceKey }
@@ -67,6 +69,17 @@ struct BannerRegion: View {
     .onAppear { measureDomainFreshness() }
     .onChange(of: persistenceKey) { _, _ in measureDomainFreshness() }
     .onChange(of: model.prefsRevision) { _, _ in measureDomainFreshness() }
+    // The engine's stored level is written straight to `UserDefaults` with no
+    // revision bump, so this is the only signal that a drag has just filled the
+    // domain this banner calls empty. Gated on the fresh state: this fires at
+    // drag rate and the scan is a whole-domain dictionary walk, so once the
+    // domain reads as stored there is no question left to ask. It can only read
+    // fresh again through a wipe, and both resets bump `prefsRevision`, which
+    // re-measures above.
+    .onChange(of: state.controller.brightness) { _, _ in
+      guard domainIsFresh != false else { return }
+      measureDomainFreshness()
+    }
   }
 
   /// One banner's chrome, in the same content column as the page below. Applied
@@ -441,7 +454,18 @@ struct BannerRegion: View {
   /// re-evaluates every countdown second, so it cannot run from `body`. nil
   /// draws no banner: erring to silent for one frame beats flashing "first time
   /// seeing this display" at a display that has settings.
+  ///
+  /// The two cheap terms of `showsFirstSight` are checked FIRST, and they answer
+  /// for the built-in and for every dismissed display without a scan: the banner
+  /// cannot show for either, so the dictionary walk would be work with no
+  /// question behind it.
   private func measureDomainFreshness() {
+    guard persistenceKey != "builtIn",
+          !model.dismissedFirstSightKeys.contains(persistenceKey)
+    else {
+      domainIsFresh = false
+      return
+    }
     domainIsFresh = !DisplayPrefs.hasAnyStoredValue(forKey: persistenceKey)
   }
 }

--- a/Candela/Settings/BannerRegion.swift
+++ b/Candela/Settings/BannerRegion.swift
@@ -22,6 +22,12 @@ struct BannerRegion: View {
   @Environment(SettingsActions.self) private var actions
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+  /// Measured by `measureDomainFreshness()`, never in `body`. Re-measured on
+  /// the display change and on `prefsRevision`, which is every event that can
+  /// flip it: both resets bump it, so a wiped domain reads as fresh again
+  /// rather than staying stale behind a cache.
+  @State private var domainIsFresh: Bool?
+
   private var persistenceKey: String { state.display.persistenceKey }
   private var displayID: CGDirectDisplayID { state.display.id }
   private var coordinator: DisplayModeCoordinator { model.displayModes }
@@ -34,8 +40,8 @@ struct BannerRegion: View {
     // `DisplayPrefs` is plain UserDefaults, not observable; this re-runs the
     // strand and first-sight checks after a write anywhere.
     let _ = model.prefsRevision
-    // Read once and handed down: `hasAnyStoredValue` materialises the whole
-    // UserDefaults dictionary, and this region re-renders every countdown second.
+    // Read once and handed down, so the animation key and the rendered card
+    // cannot disagree.
     let cards = visibleCards
     // Spacing per card, not on the stack: a padded container would leave dead
     // space when every banner is absent, the usual state here.
@@ -58,6 +64,9 @@ struct BannerRegion: View {
       guard !isMuted, case .failed = model.muteRecoveryPhases[persistenceKey] else { return }
       model.setMuteRecoveryPhase(nil, for: persistenceKey)
     }
+    .onAppear { measureDomainFreshness() }
+    .onChange(of: persistenceKey) { _, _ in measureDomainFreshness() }
+    .onChange(of: model.prefsRevision) { _, _ in measureDomainFreshness() }
   }
 
   /// One banner's chrome, in the same content column as the page below. Applied
@@ -422,7 +431,18 @@ struct BannerRegion: View {
     // launch.
     persistenceKey != "builtIn"
       && !model.dismissedFirstSightKeys.contains(persistenceKey)
-      && !DisplayPrefs.hasAnyStoredValue(forKey: persistenceKey)
+      && domainIsFresh == true
+  }
+
+  /// Whether this display's prefs domain is empty, or nil until measured.
+  ///
+  /// `hasAnyStoredValue` materialises the whole UserDefaults dictionary and
+  /// scans it by suffix, and this region renders on two placements and
+  /// re-evaluates every countdown second, so it cannot run from `body`. nil
+  /// draws no banner: erring to silent for one frame beats flashing "first time
+  /// seeing this display" at a display that has settings.
+  private func measureDomainFreshness() {
+    domainIsFresh = !DisplayPrefs.hasAnyStoredValue(forKey: persistenceKey)
   }
 }
 

--- a/Candela/Settings/BuiltInDisplayPane.swift
+++ b/Candela/Settings/BuiltInDisplayPane.swift
@@ -51,6 +51,7 @@ struct BuiltInDisplayPane: View {
             set: { enabled in writer.write(.isDisabled) { $0.isDisabled = !enabled } }
           ))
           .themedSwitch()
+          .accessibilityLabel("Control this display with the keyboard")
           .prefIdentifier(.isDisabled, persistenceKey: "builtIn")
         }
       }

--- a/Candela/Settings/CheckupPane.swift
+++ b/Candela/Settings/CheckupPane.swift
@@ -62,6 +62,13 @@ enum CheckupHistoryScope {
     if let newest = dated.max(by: { $0.date < $1.date }) { return newest.key }
     return (candidates.first { !$0.isBuiltIn } ?? candidates.first)?.key
   }
+
+  /// Whether reloading the history has to read every display's runs. Only the
+  /// default scope needs them: it follows the most recent run anywhere, so a
+  /// run finishing on another display moves the history to it. A scope the user
+  /// picked stays put, and reading the whole store to confirm that decodes every
+  /// stored run for nothing.
+  static func needsEveryDisplay(chosenByHand: Bool) -> Bool { !chosenByHand }
 }
 
 /// The Checkup pillar: the launcher, this display's past runs, and the
@@ -96,6 +103,10 @@ struct CheckupPane: View {
   }
 
   var body: some View {
+    // `DisplayPrefs` is plain UserDefaults and not observable, and the scope
+    // picker is NAMED through it, so without this read a rename elsewhere in
+    // the window leaves the old name in the menu.
+    let _ = model.prefsRevision
     SettingsPageScaffold {
       SettingsPageHeader(title: CheckupPaneCopy.title, subtitle: CheckupPaneCopy.subtitle)
       runSection
@@ -113,7 +124,14 @@ struct CheckupPane: View {
     }
     .onChange(of: activeState) { _, state in
       guard state != .inactive else { return }
-      refresh()
+      // The sweep decodes every stored run for every display, and the only
+      // thing it buys is the default scope. Once the scope was picked by hand
+      // it cannot move, so coming back to the window reads one display.
+      if CheckupHistoryScope.needsEveryDisplay(chosenByHand: chosenByHand) {
+        refresh()
+      } else {
+        reload()
+      }
     }
   }
 
@@ -123,8 +141,12 @@ struct CheckupPane: View {
     SettingsCardSection(title: CheckupPaneCopy.runTitle) {
       VStack(alignment: .leading, spacing: 10) {
         SettingsRowNote(verbatim: CheckupPaneCopy.runNote)
+        // Stated twice on purpose: SwiftUI does not publish a `Button`'s own
+        // title to the accessibility layer, so without this the button
+        // announces as a bare "button".
         Button(CheckupPaneCopy.run) { actions.openCheckup() }
           .buttonStyle(SettingsPrimaryButtonStyle())
+          .accessibilityLabel(Text(verbatim: CheckupPaneCopy.run))
       }
       .padding(.vertical, 2)
     }
@@ -232,6 +254,7 @@ struct CheckupPane: View {
         SettingsRowNote(verbatim: CheckupPaneCopy.verifyNote)
         Button(CheckupPaneCopy.verify) { verify() }
           .buttonStyle(SettingsSecondaryButtonStyle())
+          .accessibilityLabel(Text(verbatim: CheckupPaneCopy.verify))
         if let verification {
           // The answer is about the file and never about the display: a report
           // that validates is one nobody edited, and nothing more.
@@ -245,6 +268,7 @@ struct CheckupPane: View {
         SettingsRowNote(verbatim: ProvenanceCopy.checkNote)
         Button(ProvenanceCopy.check) { checkProvenance() }
           .buttonStyle(SettingsSecondaryButtonStyle())
+          .accessibilityLabel(Text(verbatim: ProvenanceCopy.check))
         if let provenanceVerdict {
           // Styled like the verify answer above it: both are a sentence about a file.
           Text(verbatim: provenanceVerdict)
@@ -327,14 +351,21 @@ private struct CheckupHistoryRow: View {
         .fixedSize(horizontal: false, vertical: true)
 
       HStack(spacing: 8) {
+        // Every title is stated twice: SwiftUI publishes none of them to the
+        // accessibility layer, and a list of runs whose buttons all announce as
+        // "button" is unusable. The details label follows the visible one, so
+        // the spoken title says which way the row is about to go.
         Button(CheckupPaneCopy.export) { export() }
           .buttonStyle(SettingsSecondaryButtonStyle())
+          .accessibilityLabel(Text(verbatim: CheckupPaneCopy.export))
         Button(CheckupPaneCopy.copySummary) { copySummary() }
           .buttonStyle(SettingsSecondaryButtonStyle())
-        Button(showingDetails ? CheckupPaneCopy.hideDetails : CheckupPaneCopy.showDetails) {
-          showingDetails.toggle()
-        }
-        .buttonStyle(SettingsSecondaryButtonStyle())
+          .accessibilityLabel(Text(verbatim: CheckupPaneCopy.copySummary))
+        let detailsTitle = showingDetails
+          ? CheckupPaneCopy.hideDetails : CheckupPaneCopy.showDetails
+        Button(detailsTitle) { showingDetails.toggle() }
+          .buttonStyle(SettingsSecondaryButtonStyle())
+          .accessibilityLabel(Text(verbatim: detailsTitle))
         if justCopied {
           Text(verbatim: CheckupPaneCopy.copied)
             .font(.caption)

--- a/Candela/Settings/CheckupPane.swift
+++ b/Candela/Settings/CheckupPane.swift
@@ -63,11 +63,8 @@ enum CheckupHistoryScope {
     return (candidates.first { !$0.isBuiltIn } ?? candidates.first)?.key
   }
 
-  /// Whether reloading the history has to read every display's runs. Only the
-  /// default scope needs them: it follows the most recent run anywhere, so a
-  /// run finishing on another display moves the history to it. A scope the user
-  /// picked stays put, and reading the whole store to confirm that decodes every
-  /// stored run for nothing.
+  /// Only the default scope follows the newest run anywhere; a hand-picked scope
+  /// stays put, so reading every display's runs for it decodes them for nothing.
   static func needsEveryDisplay(chosenByHand: Bool) -> Bool { !chosenByHand }
 }
 
@@ -103,9 +100,8 @@ struct CheckupPane: View {
   }
 
   var body: some View {
-    // `DisplayPrefs` is plain UserDefaults and not observable, and the scope
-    // picker is NAMED through it, so without this read a rename elsewhere in
-    // the window leaves the old name in the menu.
+    // `DisplayPrefs` is not observable and the scope picker is named through it;
+    // without this a rename leaves the old name in the menu.
     let _ = model.prefsRevision
     SettingsPageScaffold {
       SettingsPageHeader(title: CheckupPaneCopy.title, subtitle: CheckupPaneCopy.subtitle)
@@ -124,9 +120,8 @@ struct CheckupPane: View {
     }
     .onChange(of: activeState) { _, state in
       guard state != .inactive else { return }
-      // The sweep decodes every stored run for every display, and the only
-      // thing it buys is the default scope. Once the scope was picked by hand
-      // it cannot move, so coming back to the window reads one display.
+      // `refresh()` decodes every display's runs, and only the default scope
+      // needs that.
       if CheckupHistoryScope.needsEveryDisplay(chosenByHand: chosenByHand) {
         refresh()
       } else {
@@ -141,9 +136,8 @@ struct CheckupPane: View {
     SettingsCardSection(title: CheckupPaneCopy.runTitle) {
       VStack(alignment: .leading, spacing: 10) {
         SettingsRowNote(verbatim: CheckupPaneCopy.runNote)
-        // Stated twice on purpose: SwiftUI does not publish a `Button`'s own
-        // title to the accessibility layer, so without this the button
-        // announces as a bare "button".
+        // SwiftUI does not publish a `Button` title to accessibility; without
+        // this it announces as "button".
         Button(CheckupPaneCopy.run) { actions.openCheckup() }
           .buttonStyle(SettingsPrimaryButtonStyle())
           .accessibilityLabel(Text(verbatim: CheckupPaneCopy.run))
@@ -351,10 +345,8 @@ private struct CheckupHistoryRow: View {
         .fixedSize(horizontal: false, vertical: true)
 
       HStack(spacing: 8) {
-        // Every title is stated twice: SwiftUI publishes none of them to the
-        // accessibility layer, and a list of runs whose buttons all announce as
-        // "button" is unusable. The details label follows the visible one, so
-        // the spoken title says which way the row is about to go.
+        // Same as the Run button above. The details label follows the visible
+        // title so the spoken one says which way the row goes.
         Button(CheckupPaneCopy.export) { export() }
           .buttonStyle(SettingsSecondaryButtonStyle())
           .accessibilityLabel(Text(verbatim: CheckupPaneCopy.export))

--- a/Candela/Settings/DisplayHeroView.swift
+++ b/Candela/Settings/DisplayHeroView.swift
@@ -269,8 +269,16 @@ struct DisplayHeroView: View {
   @ViewBuilder private var volumeLevelRow: some View {
     if variant == .external, state.volume.isAvailable {
       SettingsCardDivider()
-      levelRow(label: "Volume", caption: nil) { volumeSlider }
+      levelRow(label: "Volume", caption: volumeDisabledReason) { volumeSlider }
     }
+  }
+
+  /// Why the volume slider is refusing input, nil while it takes it. Shown as
+  /// the row's caption rather than only as a tooltip: a greyed control whose
+  /// reason is reachable only by hovering is a greyed control with no reason at
+  /// all for anyone who does not hover.
+  private var volumeDisabledReason: String? {
+    model.volumeSliderDisabledReason(state, displayName: name)
   }
 
   /// Not `SettingRow`: that publishes its caption as the control's accessibility
@@ -329,15 +337,24 @@ struct DisplayHeroView: View {
     ValueSliderRow(
       controller: state.volume,
       systemImage: "speaker.wave.2.fill",
-      accessibilityLabel: "\(name) volume",
+      // Contract 3 again: the caption beside this row is accessibility-hidden,
+      // so the reason has to ride in the label or VoiceOver gets a dimmed
+      // slider with no cause.
+      accessibilityLabel: volumeAccessibilityLabel,
       snapsToStops: appPrefs.enableSliderSnap,
       showsPercent: appPrefs.enableSliderPercent,
       mutedSystemImage: "speaker.slash.fill"
     )
-    .disabled(!model.volumeSliderEnabled(state))
     // Never greyed by CoreAudio. The monitor's own denial is only ONE of
-    // the two causes, so the reason comes from the policy that decided.
-    .help(model.volumeSliderDisabledReason(state, displayName: name) ?? "")
+    // the two causes, so the reason comes from the policy that decided, and it
+    // is drawn rather than hovered: `.help("")` on the enabled slider installed
+    // an empty tooltip on a control with nothing to explain.
+    .disabled(!model.volumeSliderEnabled(state))
+  }
+
+  private var volumeAccessibilityLabel: String {
+    guard let reason = volumeDisabledReason else { return "\(name) volume" }
+    return "\(name) volume. \(reason)"
   }
 
   /// Above black-screen for the keyboard and VoiceOver routes only (a11y

--- a/Candela/Settings/DisplayHeroView.swift
+++ b/Candela/Settings/DisplayHeroView.swift
@@ -273,10 +273,8 @@ struct DisplayHeroView: View {
     }
   }
 
-  /// Why the volume slider is refusing input, nil while it takes it. Shown as
-  /// the row's caption rather than only as a tooltip: a greyed control whose
-  /// reason is reachable only by hovering is a greyed control with no reason at
-  /// all for anyone who does not hover.
+  /// Drawn as the row's caption, not only a tooltip: a reason reachable only by
+  /// hovering is no reason for anyone who does not hover.
   private var volumeDisabledReason: String? {
     model.volumeSliderDisabledReason(state, displayName: name)
   }
@@ -337,18 +335,16 @@ struct DisplayHeroView: View {
     ValueSliderRow(
       controller: state.volume,
       systemImage: "speaker.wave.2.fill",
-      // Contract 3 again: the caption beside this row is accessibility-hidden,
-      // so the reason has to ride in the label or VoiceOver gets a dimmed
-      // slider with no cause.
+      // The caption beside this row is accessibility-hidden, so the reason rides
+      // in the label or VoiceOver gets a dimmed slider with no cause.
       accessibilityLabel: volumeAccessibilityLabel,
       snapsToStops: appPrefs.enableSliderSnap,
       showsPercent: appPrefs.enableSliderPercent,
       mutedSystemImage: "speaker.slash.fill"
     )
     // Never greyed by CoreAudio. The monitor's own denial is only ONE of
-    // the two causes, so the reason comes from the policy that decided, and it
-    // is drawn rather than hovered: `.help("")` on the enabled slider installed
-    // an empty tooltip on a control with nothing to explain.
+    // the two causes, so the reason comes from the policy that decided. Drawn,
+    // not hovered: `.help("")` installed an empty tooltip on the enabled slider.
     .disabled(!model.volumeSliderEnabled(state))
   }
 

--- a/Candela/Settings/DisplayHubView.swift
+++ b/Candela/Settings/DisplayHubView.swift
@@ -479,14 +479,28 @@ struct DisplayHubView: View {
   }
 
   /// Mirrors what the key path consults, so this row cannot say "On" about keys
-  /// that would move nothing. Two unavailability signals and either is enough:
-  /// `volume.isAvailable` is the pref side, `volumeSliderEnabled` is the
-  /// monitor's own denial. The Dell answers its capabilities with no VCP 0x62,
-  /// and "On" there would contradict the greyed slider two sections up.
+  /// that would move nothing, and names WHICH switch turned them off.
+  ///
+  /// The gates stay the two the key path reads, `volume.isAvailable` and
+  /// `volumeSliderEnabled`; only the WORDING is split, and the split reads the
+  /// prefs those two are built from rather than a second copy of their rule.
+  /// Three of the four causes are a switch in this app: hardware control off and
+  /// the volume command's own switch behind the first gate, "Always disabled"
+  /// behind the second. What is left of the second, the capabilities string
+  /// parsing cleanly with no VCP 0x62, is the display itself refusing, and
+  /// it is the only one worth reporting as the hardware's doing: telling a user
+  /// who set the switch themselves that their monitor said no sends them after a
+  /// cable.
   private var volumeKeysStatus: String {
-    if !state.volume.isAvailable || !model.volumeSliderEnabled(state) {
-      return "Not available on this display"
+    if !state.volume.isAvailable {
+      return prefs.forceSoftware
+        ? "Off: hardware control is off"
+        : "Off: the volume command is off"
     }
+    if prefs.audioSinkOverride == .forceNone {
+      return "Off: the volume slider is set to Always disabled"
+    }
+    if !model.volumeSliderEnabled(state) { return "Not available on this display" }
     if prefs.isDisabled { return "Off" }
     let mode = prefs.keyboardVolume
     let active = KeyModePolicy.watchesMediaKeys(mode) || KeyModePolicy.firesCustomShortcuts(mode)
@@ -655,7 +669,10 @@ struct DisplayHubView: View {
           .disabled(model.isResetting)
           .alert("Reset the settings for this display?", isPresented: $confirmingReset) {
             Button("Reset", role: .destructive) { resetDisplay() }
+            // Cancel takes Return: without the explicit shortcut the destructive
+            // button holds the primary role.
             Button("Cancel", role: .cancel) {}
+              .keyboardShortcut(.defaultAction)
           } message: {
             // Names the Advanced-page work explicitly, and names what is
             // NOT lost: the saved levels are the only source of truth on a
@@ -663,7 +680,7 @@ struct DisplayHubView: View {
             // at an unknown brightness. The pinned resolution and rotation are
             // macOS-visible state this button leaves alone, and counted hours are
             // wear data.
-            Text("This unmutes \(state.display.name), turns HDR off while it runs, and clears its \(AppInfo.productName) settings: name, menu bar visibility, keyboard, sound, OLED care, \(SynthesisCopy.optInTitle), and everything under Advanced, including control-code remaps and response curves. A size \(AppInfo.productName) was rendering for this display is taken down first, so the display goes back to one of its own; if that does not finish, the page says so and the rest of the reset still runs. HDR that was turned on in System Settings goes back on at the end. If the display cannot be reached at the time, nothing is sent to it that cannot be confirmed, so some of these may be left for you to change yourself. Saved brightness, volume and contrast levels are kept, and so are its counted hours of use. The remembered resolution and rotation are not changed.")
+            Text("This display is put into a known state first: \(state.display.name) is unmuted and HDR goes off while the reset runs. A size \(AppInfo.productName) was rendering for this display is taken down before that, so the display goes back to one of its own; if that does not finish, the page says so and the rest of the reset still runs. HDR that was turned on in System Settings goes back on at the end. If the display cannot be reached at the time, nothing is sent to it that cannot be confirmed, so some of these may be left for you to change yourself.\n\nThen its \(AppInfo.productName) settings are cleared: name, menu bar visibility, keyboard, sound, OLED care, \(SynthesisCopy.optInTitle), and everything under Advanced, including control-code remaps and response curves.\n\nSaved brightness, volume and contrast levels are kept, and so are its counted hours of use. The remembered resolution and rotation are not changed.")
           }
         Spacer(minLength: 0)
       }

--- a/Candela/Settings/DisplayHubView.swift
+++ b/Candela/Settings/DisplayHubView.swift
@@ -124,6 +124,9 @@ struct DisplayHubView: View {
       SettingRow("Shown in the menu bar.") {
         HStack(spacing: 2) {
           TextField("Name", text: $nameDraft, prompt: Text(verbatim: state.display.name))
+            // The row's own label. Without it the field publishes no
+            // description at all, so it announces as a bare text field.
+            .accessibilityLabel("Name")
             .focused($nameFocused)
             .onSubmit { commitName() }
             .onChange(of: nameFocused) { _, focused in
@@ -183,6 +186,7 @@ struct DisplayHubView: View {
           set: { shown in writer.write(.hideDisplay) { $0.hideDisplay = !shown } }
         ))
         .themedSwitch()
+        .accessibilityLabel("Show in the menu bar")
         .prefIdentifier(.hideDisplay, persistenceKey: persistenceKey)
       }
 
@@ -196,6 +200,7 @@ struct DisplayHubView: View {
           set: { shown in writer.write(.hideVolumeSlider) { $0.hideVolumeSlider = !shown } }
         ))
         .themedSwitch()
+        .accessibilityLabel("Show the volume slider in the menu bar")
         .prefIdentifier(.hideVolumeSlider, persistenceKey: persistenceKey)
       }
     }
@@ -211,6 +216,7 @@ struct DisplayHubView: View {
           set: { enabled in writer.write(.isDisabled) { $0.isDisabled = !enabled } }
         ))
         .themedSwitch()
+        .accessibilityLabel("Use brightness and volume keys for this display")
         .prefIdentifier(.isDisabled, persistenceKey: persistenceKey)
       }
     }
@@ -343,6 +349,7 @@ struct DisplayHubView: View {
           set: { on in setMoreSizes(on, on: catalog.display) }
         ))
         .themedSwitch()
+        .accessibilityLabel(SynthesisCopy.optInTitle)
         // An engage or teardown is a multi-second hardware sequence, and a
         // second flip queued behind one answers a question nobody is asking any
         // more. Courtesy, not the guard: the engine is non-reentrant and the
@@ -451,6 +458,9 @@ struct DisplayHubView: View {
         LabeledContent("Audio device name") {
           HStack(spacing: 8) {
             TextField("", text: $audioNameDraft, prompt: Text("Automatic"))
+              // The surrounding `LabeledContent` draws the label but publishes
+              // none, so the field names itself.
+              .accessibilityLabel("Audio device name")
               .settingsEditableContent()
               .focused($audioNameFocused)
               .onSubmit { commitAudioName() }
@@ -528,6 +538,7 @@ struct DisplayHubView: View {
           set: { on in writer.write(.oledCareEnrolled) { $0.oledCareEnrolled = on } }
         ))
         .themedSwitch()
+        .accessibilityLabel("Enroll this display in OLED care")
         .prefIdentifier(.oledCareEnrolled, persistenceKey: persistenceKey)
       }
 

--- a/Candela/Settings/DisplayHubView.swift
+++ b/Candela/Settings/DisplayHubView.swift
@@ -124,8 +124,7 @@ struct DisplayHubView: View {
       SettingRow("Shown in the menu bar.") {
         HStack(spacing: 2) {
           TextField("Name", text: $nameDraft, prompt: Text(verbatim: state.display.name))
-            // The row's own label. Without it the field publishes no
-            // description at all, so it announces as a bare text field.
+            // Without it the field announces as a bare text field.
             .accessibilityLabel("Name")
             .focused($nameFocused)
             .onSubmit { commitName() }
@@ -458,8 +457,7 @@ struct DisplayHubView: View {
         LabeledContent("Audio device name") {
           HStack(spacing: 8) {
             TextField("", text: $audioNameDraft, prompt: Text("Automatic"))
-              // The surrounding `LabeledContent` draws the label but publishes
-              // none, so the field names itself.
+              // `LabeledContent` draws the label but publishes none.
               .accessibilityLabel("Audio device name")
               .settingsEditableContent()
               .focused($audioNameFocused)
@@ -489,18 +487,11 @@ struct DisplayHubView: View {
   }
 
   /// Mirrors what the key path consults, so this row cannot say "On" about keys
-  /// that would move nothing, and names WHICH switch turned them off.
-  ///
-  /// The gates stay the two the key path reads, `volume.isAvailable` and
-  /// `volumeSliderEnabled`; only the WORDING is split, and the split reads the
-  /// prefs those two are built from rather than a second copy of their rule.
-  /// Three of the four causes are a switch in this app: hardware control off and
-  /// the volume command's own switch behind the first gate, "Always disabled"
-  /// behind the second. What is left of the second, the capabilities string
-  /// parsing cleanly with no VCP 0x62, is the display itself refusing, and
-  /// it is the only one worth reporting as the hardware's doing: telling a user
-  /// who set the switch themselves that their monitor said no sends them after a
-  /// cable.
+  /// that would move nothing, and names which switch turned them off. The gates
+  /// stay the two the key path reads; only the wording splits, off the prefs
+  /// those gates are built from. Only the display's own refusal (a capabilities
+  /// string with no VCP 0x62) is blamed on hardware: telling someone who set the
+  /// switch that their monitor said no sends them after a cable.
   private var volumeKeysStatus: String {
     if !state.volume.isAvailable {
       return prefs.forceSoftware
@@ -680,8 +671,8 @@ struct DisplayHubView: View {
           .disabled(model.isResetting)
           .alert("Reset the settings for this display?", isPresented: $confirmingReset) {
             Button("Reset", role: .destructive) { resetDisplay() }
-            // Cancel takes Return: without the explicit shortcut the destructive
-            // button holds the primary role.
+            // Cancel takes Return; otherwise the destructive button holds the
+            // primary role.
             Button("Cancel", role: .cancel) {}
               .keyboardShortcut(.defaultAction)
           } message: {

--- a/Candela/Settings/DisplayHubView.swift
+++ b/Candela/Settings/DisplayHubView.swift
@@ -845,7 +845,7 @@ struct DisplayHubView: View {
           writer.write(.enableMuteUnmute) { $0.enableMuteUnmute = false }
         } else {
           resetLog.error(
-            "reset on display \(state.display.persistenceKey, privacy: .public): the unmute could not be confirmed as applied, so its mute state and strategy were both left in place"
+            "reset on display \(DisplayLogging.tag(for: state.display.persistenceKey), privacy: .public): the unmute could not be confirmed as applied, so its mute state and strategy were both left in place"
           )
           // `toggleMute` cleared the stored flag on the way out and the panel
           // may still be muted, so put it back, both halves together. A live
@@ -856,7 +856,7 @@ struct DisplayHubView: View {
         }
       case .unknown:
         resetLog.error(
-          "reset on display \(state.display.persistenceKey, privacy: .public): HDR state unknown after the disengage, so the unmute and the mute-strategy change were both skipped; the display keeps its current mute state and strategy"
+          "reset on display \(DisplayLogging.tag(for: state.display.persistenceKey), privacy: .public): HDR state unknown after the disengage, so the unmute and the mute-strategy change were both skipped; the display keeps its current mute state and strategy"
         )
       }
 

--- a/Candela/Settings/GeneralPane.swift
+++ b/Candela/Settings/GeneralPane.swift
@@ -137,6 +137,7 @@ struct GeneralPane: View {
           set: { loginItem.setEnabled($0) } // the live-status rule: the readback happens inside
         ))
         .themedSwitch()
+        .accessibilityLabel("Open at Login")
         // The mirror hooks hang on the toggle, the row that causes the failure
         // and the one row always present: hooks on the failure row would exist
         // only while the failure does, so nothing would watch for it to arrive.
@@ -215,6 +216,7 @@ struct GeneralPane: View {
           }
         ))
         .themedSwitch()
+        .accessibilityLabel("Dim past the display's minimum")
         .prefIdentifier(.disableCombinedBrightness)
       }
 
@@ -254,6 +256,7 @@ struct GeneralPane: View {
           }
         ))
         .themedSwitch()
+        .accessibilityLabel("Match other displays to the built-in display")
         .prefIdentifier(.enableBrightnessSync)
       }
     }

--- a/Candela/Settings/HealthPane.swift
+++ b/Candela/Settings/HealthPane.swift
@@ -438,14 +438,7 @@ private struct MeasurementControls: View {
             // The pref is written whether or not the grant arrives: macOS
             // returns false from the request that merely SHOWS the dialog, so
             // gating the switch on the return value leaves it stuck off.
-            //
-            // Not raised for an un-enrolled display. `reconcileEnrollment` drops
-            // every un-enrolled key, so the prompt would spend a system
-            // permission on a display that is not going to be sampled. Nothing
-            // raises it on enrollment (this switch and guided setup are still
-            // the only two prompting calls in the app), so the recovery is the
-            // missing-grant note below, which names System Settings.
-            if on, prefs.oledCareEnrolled { _ = CGRequestScreenCaptureAccess() }
+            if on { _ = CGRequestScreenCaptureAccess() }
             writer.write(.oledTelemetry) { $0.oledTelemetry = on }
           }
         ))

--- a/Candela/Settings/HealthPane.swift
+++ b/Candela/Settings/HealthPane.swift
@@ -171,12 +171,10 @@ struct HealthPane: View {
 
       SettingsCard {
         VStack(alignment: .leading, spacing: 0) {
-          // At the head of the card, because it governs every control under it:
-          // `reconcileEnrollment` drops every un-enrolled key, and observation
-          // and hours both default ON, so this card can show three switches
-          // reading ON for a display nothing is measuring. The prefs are
-          // legitimately set ahead of enrollment, so nothing here is disabled;
-          // the reveal is the way out.
+          // Heads the card because it governs every control under it: observation
+          // and hours default ON, but `reconcileEnrollment` drops un-enrolled keys,
+          // so three switches can read ON for a display nothing measures. The
+          // prefs are legitimately set ahead of enrollment, so nothing is disabled.
           if !DisplayPrefs(persistenceKey: key).oledCareEnrolled {
             VStack(alignment: .leading, spacing: 8) {
               OledInlineNote(Text(verbatim: "Measurement currently runs on displays enrolled in OLED care, and \(name(state)) is not enrolled. These settings are saved and start applying when it is."))
@@ -411,10 +409,8 @@ private struct MeasurementControls: View {
   /// Reads the comparison record because its paired-reading clock is the only
   /// per-sample timestamp the coordinator keeps. A missing grant has its own note.
   ///
-  /// Ten sampling intervals, not the measuring dot's two: this note tells the
-  /// user macOS may have taken the grant away, so it waits until an ordinary run
-  /// of skipped captures cannot explain the gap. The note's own copy says "over
-  /// 10 minutes" and has to keep agreeing with this.
+  /// The stall window, not the liveness one: this note accuses macOS of taking
+  /// the grant. Its copy says "over 10 minutes" and must keep agreeing.
   private var isSamplingStalled: Bool {
     guard prefs.oledTelemetry, !model.isSafeMode, CGPreflightScreenCaptureAccess(),
       let last = model.oledCare.modelComparison(for: persistenceKey).lastPair

--- a/Candela/Settings/HealthPane.swift
+++ b/Candela/Settings/HealthPane.swift
@@ -171,6 +171,22 @@ struct HealthPane: View {
 
       SettingsCard {
         VStack(alignment: .leading, spacing: 0) {
+          // At the head of the card, because it governs every control under it:
+          // `reconcileEnrollment` drops every un-enrolled key, and observation
+          // and hours both default ON, so this card can show three switches
+          // reading ON for a display nothing is measuring. The prefs are
+          // legitimately set ahead of enrollment, so nothing here is disabled;
+          // the reveal is the way out.
+          if !DisplayPrefs(persistenceKey: key).oledCareEnrolled {
+            VStack(alignment: .leading, spacing: 8) {
+              OledInlineNote(Text(verbatim: "Measurement currently runs on displays enrolled in OLED care, and \(name(state)) is not enrolled. These settings are saved and start applying when it is."))
+              Button("Open OLED Care") { actions.reveal(.pane(.oledCare)) }
+                .buttonStyle(SettingsSecondaryButtonStyle())
+                .accessibilityLabel(Text(verbatim: "Open OLED Care for \(name(state))"))
+            }
+            .padding(.vertical, 8)
+            SettingsCardDivider()
+          }
           MeasurementControls(persistenceKey: key)
           SettingsCardDivider()
           HoursToggle(persistenceKey: key)
@@ -394,11 +410,16 @@ private struct MeasurementControls: View {
 
   /// Reads the comparison record because its paired-reading clock is the only
   /// per-sample timestamp the coordinator keeps. A missing grant has its own note.
+  ///
+  /// Ten sampling intervals, not the measuring dot's two: this note tells the
+  /// user macOS may have taken the grant away, so it waits until an ordinary run
+  /// of skipped captures cannot explain the gap. The note's own copy says "over
+  /// 10 minutes" and has to keep agreeing with this.
   private var isSamplingStalled: Bool {
     guard prefs.oledTelemetry, !model.isSafeMode, CGPreflightScreenCaptureAccess(),
       let last = model.oledCare.modelComparison(for: persistenceKey).lastPair
     else { return false }
-    return Date().timeIntervalSince(last) > 600
+    return Date().timeIntervalSince(last) > OledCareCadence.stallWarningSeconds
   }
 
   var body: some View {
@@ -417,7 +438,14 @@ private struct MeasurementControls: View {
             // The pref is written whether or not the grant arrives: macOS
             // returns false from the request that merely SHOWS the dialog, so
             // gating the switch on the return value leaves it stuck off.
-            if on { _ = CGRequestScreenCaptureAccess() }
+            //
+            // Not raised for an un-enrolled display. `reconcileEnrollment` drops
+            // every un-enrolled key, so the prompt would spend a system
+            // permission on a display that is not going to be sampled. Nothing
+            // raises it on enrollment (this switch and guided setup are still
+            // the only two prompting calls in the app), so the recovery is the
+            // missing-grant note below, which names System Settings.
+            if on, prefs.oledCareEnrolled { _ = CGRequestScreenCaptureAccess() }
             writer.write(.oledTelemetry) { $0.oledTelemetry = on }
           }
         ))

--- a/Candela/Settings/HealthPane.swift
+++ b/Candela/Settings/HealthPane.swift
@@ -443,6 +443,7 @@ private struct MeasurementControls: View {
           }
         ))
         .themedSwitch()
+        .accessibilityLabel("Measure how bright each part of this display is")
         .prefIdentifier(.oledTelemetry, persistenceKey: persistenceKey)
         // What "the resolution of this grid" means, at the size it means it.
         PanelGridMark()
@@ -478,6 +479,7 @@ private struct MeasurementControls: View {
         set: { on in writer.write(.oledWindowObservation) { $0.oledWindowObservation = on } }
       ))
       .themedSwitch()
+      .accessibilityLabel("Note which apps are on this display")
       .prefIdentifier(.oledWindowObservation, persistenceKey: persistenceKey)
     }
   }
@@ -509,6 +511,7 @@ private struct HoursToggle: View {
         set: { on in writer.write(.oledHoursTracking) { $0.oledHoursTracking = on } }
       ))
       .themedSwitch()
+      .accessibilityLabel("Count hours of use")
       .prefIdentifier(.oledHoursTracking, persistenceKey: persistenceKey)
     }
   }

--- a/Candela/Settings/KeyboardPane.swift
+++ b/Candela/Settings/KeyboardPane.swift
@@ -154,6 +154,7 @@ struct KeyboardPane: View {
             set: { setInterceptAlternateKeys($0) }
           ))
           .themedSwitch()
+          .accessibilityLabel("Also accept F14 and F15")
           .prefIdentifier(.disableAltBrightnessKeys)
         }
       }

--- a/Candela/Settings/KeyboardTargetingPage.swift
+++ b/Candela/Settings/KeyboardTargetingPage.swift
@@ -83,6 +83,7 @@ struct KeyboardTargetingPage: View {
           set: { setFineScaleBrightness($0) }
         ))
         .themedSwitch()
+        .accessibilityLabel("Fine steps for brightness and contrast")
         .prefIdentifier(.useFineScaleBrightness)
         .disabled(prefs.keyboardBrightness == .disabled)
       }
@@ -97,6 +98,7 @@ struct KeyboardTargetingPage: View {
           set: { setFineScaleVolume($0) }
         ))
         .themedSwitch()
+        .accessibilityLabel("Fine steps for volume")
         .prefIdentifier(.useFineScaleVolume)
         .disabled(prefs.keyboardVolume == .disabled)
       }
@@ -116,6 +118,7 @@ struct KeyboardTargetingPage: View {
           set: { setSeparateCombinedScale($0) }
         ))
         .themedSwitch()
+        .accessibilityLabel("Extra-fine steps while combined dimming is active")
         .prefIdentifier(.separateCombinedScale)
         .disabled(prefs.keyboardBrightness == .disabled)
       }

--- a/Candela/Settings/OledCareDisplayPage.swift
+++ b/Candela/Settings/OledCareDisplayPage.swift
@@ -30,6 +30,12 @@ struct OledCareDisplayPage: View {
   /// every pref write and on every dim-state change).
   @State private var displaySleepMinutes: Int?
 
+  /// Sampled beside `displaySleepMinutes`, and for the same reason: `body`
+  /// re-evaluates on every pref write and every dim-state change, and a reading
+  /// taken there would make the note below flicker with the page rather than
+  /// describe what was true when it opened.
+  @State private var displaySleepAssertionHeld = false
+
   /// Slider drafts, live only while a drag is in progress. A `Slider` bound
   /// straight to a pref writes, fans out and bumps `prefsRevision` on every
   /// pixel of the drag, re-rendering the page under the user's pointer. Nil
@@ -147,6 +153,7 @@ struct OledCareDisplayPage: View {
     }
     .task {
       displaySleepMinutes = OledCareSignalSources.displaySleepMinutes()
+      displaySleepAssertionHeld = OledCareSignalSources.displaySleepAssertionHeld()
     }
   }
 
@@ -363,14 +370,16 @@ struct OledCareDisplayPage: View {
     }
   }
 
-  /// Live means the pipeline produced a reading inside the last two sampling
-  /// intervals, so a dead grant stills the dot within two minutes whatever the
-  /// prefs claim.
+  /// Live means the pipeline produced a reading inside
+  /// `OledCareCadence.livenessWindowSeconds`, so a dead grant stills the dot
+  /// within two minutes whatever the prefs claim. The window is the Kit's, not a
+  /// number chosen here: the comment used to say two intervals while the code
+  /// said three.
   private func isMeasuringLive(_ summary: PanelHealthSummary) -> Bool {
     guard !model.isSafeMode, prefs.oledTelemetry, CGPreflightScreenCaptureAccess(),
       let last = summary.lastSample
     else { return false }
-    return Date().timeIntervalSince(last) < 180
+    return Date().timeIntervalSince(last) < OledCareCadence.livenessWindowSeconds
   }
 
   /// What the engine is doing right now. `dimStates` is the coordinator's own
@@ -521,6 +530,12 @@ struct OledCareDisplayPage: View {
   /// staticness, and they live on the Health pane, so the caption names that
   /// pane instead of leaving the switch to do nothing silently.
   ///
+  /// The third condition is the display-sleep assertion: the coordinator gates
+  /// nomination on `!state.assertionHeld`, the same term idle dimming has, and
+  /// the reading is system-wide, so our own Keep Display Awake silences this
+  /// control as surely as a video does. The caption lists it; the note says when
+  /// it is the live reason.
+  ///
   /// The caption promises exactly what the code delivers. "Full-screen video is
   /// never dimmed" is the `fullScreenOwner` gate, read from the window list. It
   /// does NOT promise a WINDOWED video is safe, because bounds stability is not
@@ -529,13 +544,21 @@ struct OledCareDisplayPage: View {
   /// The pointer is not an input to `StaticRegionDetector` and the coordinator
   /// supplies none, so that sentence goes in when the falloff exists.
   private var detectionControls: some View {
-    SettingRow("Areas that stay bright and unchanged, like a toolbar or a sidebar, are dimmed a little while you work. Full-screen video is never dimmed. This needs both measurement settings on the Health pane: without them nothing is dimmed.") {
-      Toggle("Automatic static-region dimming", isOn: Binding(
-        get: { prefs.oledDetectionDimming },
-        set: { on in writer.write(.oledDetectionDimming) { $0.oledDetectionDimming = on } }
-      ))
-      .themedSwitch()
-      .prefIdentifier(.oledDetectionDimming, persistenceKey: persistenceKey)
+    SettingRow("Areas that stay bright and unchanged, like a toolbar or a sidebar, are dimmed a little while you work. Full-screen video is never dimmed, and nothing is dimmed while anything is holding the screen awake, including Keep Display Awake. This needs both measurement settings on the Health pane: without them nothing is dimmed.") {
+      VStack(alignment: .leading, spacing: 6) {
+        Toggle("Automatic static-region dimming", isOn: Binding(
+          get: { prefs.oledDetectionDimming },
+          set: { on in writer.write(.oledDetectionDimming) { $0.oledDetectionDimming = on } }
+        ))
+        .themedSwitch()
+        .prefIdentifier(.oledDetectionDimming, persistenceKey: persistenceKey)
+        // In the SAME row as the switch, the idle threshold's warning shape: a
+        // divider between a control and the sentence saying it does nothing
+        // turns the warning into what looks like an unrelated setting.
+        if prefs.oledDetectionDimming, displaySleepAssertionHeld {
+          OledInlineNote(Text("Something was holding the screen awake when this page opened: video playback, a call, or Keep Display Awake. Nothing is dimmed here for as long as that lasts."))
+        }
+      }
     }
   }
 

--- a/Candela/Settings/OledCareDisplayPage.swift
+++ b/Candela/Settings/OledCareDisplayPage.swift
@@ -86,6 +86,7 @@ struct OledCareDisplayPage: View {
             set: { on in writer.write(.oledCareEnrolled) { $0.oledCareEnrolled = on } }
           ))
           .themedSwitch()
+          .accessibilityLabel("Enroll this display in OLED care")
           // Deliberately the hub toggle's identifier: same setting, same
           // display, never both in the rendered tree, so a walk finds one.
           .prefIdentifier(.oledCareEnrolled, persistenceKey: persistenceKey)
@@ -456,6 +457,7 @@ struct OledCareDisplayPage: View {
         set: { on in writer.write(.oledLockDim) { $0.oledLockDim = on } }
       ))
       .themedSwitch()
+      .accessibilityLabel("Dim while the screen is locked")
       .prefIdentifier(.oledLockDim, persistenceKey: persistenceKey)
     }
   }
@@ -471,6 +473,7 @@ struct OledCareDisplayPage: View {
         set: { on in writer.write(.oledBlackoutEnabled) { $0.oledBlackoutEnabled = on } }
       ))
       .themedSwitch()
+      .accessibilityLabel("Turn the screen black after longer")
       .prefIdentifier(.oledBlackoutEnabled, persistenceKey: persistenceKey)
     }
     if prefs.oledBlackoutEnabled {
@@ -502,6 +505,7 @@ struct OledCareDisplayPage: View {
         set: { on in writer.write(.oledUnfocusedDimEnabled) { $0.oledUnfocusedDimEnabled = on } }
       ))
       .themedSwitch()
+      .accessibilityLabel("Dim while this display has nothing in focus")
       .prefIdentifier(.oledUnfocusedDimEnabled, persistenceKey: persistenceKey)
     }
     if prefs.oledUnfocusedDimEnabled {
@@ -557,6 +561,7 @@ struct OledCareDisplayPage: View {
           set: { on in writer.write(.oledDetectionDimming) { $0.oledDetectionDimming = on } }
         ))
         .themedSwitch()
+        .accessibilityLabel("Automatic static-region dimming")
         .prefIdentifier(.oledDetectionDimming, persistenceKey: persistenceKey)
         // In the SAME row as the switch, the idle threshold's warning shape: a
         // divider between a control and the sentence saying it does nothing

--- a/Candela/Settings/OledCareDisplayPage.swift
+++ b/Candela/Settings/OledCareDisplayPage.swift
@@ -27,13 +27,16 @@ struct OledCareDisplayPage: View {
 
   /// `pmset -g` costs a 79 ms process spawn [MEASURED 2026-08-06]. Read ONCE
   /// per page appearance into state, never from `body` (which re-evaluates on
-  /// every pref write and on every dim-state change).
+  /// every pref write and on every dim-state change) and never under the
+  /// dim-state task id.
   @State private var displaySleepMinutes: Int?
 
   /// Sampled beside `displaySleepMinutes`, and for the same reason: `body`
-  /// re-evaluates on every pref write and every dim-state change, and a reading
-  /// taken there would make the note below flicker with the page rather than
-  /// describe what was true when it opened.
+  /// re-evaluates on every pref write, and a reading taken there would make the
+  /// note below flicker with the page. Re-sampled on the engine's dim state
+  /// instead, which is the page's one live signal and the state an assertion
+  /// actually moves, so the note describes now rather than the moment the page
+  /// opened.
   @State private var displaySleepAssertionHeld = false
 
   /// Slider drafts, live only while a drag is in progress. A `Slider` bound
@@ -151,8 +154,11 @@ struct OledCareDisplayPage: View {
         }
       }
     }
-    .task {
-      displaySleepMinutes = OledCareSignalSources.displaySleepMinutes()
+    // Two tasks, not one: the pmset spawn is a per-appearance reading, while the
+    // assertion is a cheap IOKit query that has to follow the engine's dim state.
+    // Keyed together, every dim transition re-spawns pmset.
+    .task { displaySleepMinutes = OledCareSignalSources.displaySleepMinutes() }
+    .task(id: model.oledCare.dimStates[persistenceKey]) {
       displaySleepAssertionHeld = OledCareSignalSources.displaySleepAssertionHeld()
     }
   }
@@ -372,8 +378,8 @@ struct OledCareDisplayPage: View {
 
   /// Live means the pipeline produced a reading inside
   /// `OledCareCadence.livenessWindowSeconds`, so a dead grant stills the dot
-  /// within two minutes whatever the prefs claim. The window is the Kit's, not a
-  /// number chosen here: the comment used to say two intervals while the code
+  /// within a few minutes whatever the prefs claim. The window is the Kit's, not
+  /// a number chosen here: the comment used to say two intervals while the code
   /// said three.
   private func isMeasuringLive(_ summary: PanelHealthSummary) -> Bool {
     guard !model.isSafeMode, prefs.oledTelemetry, CGPreflightScreenCaptureAccess(),
@@ -556,7 +562,7 @@ struct OledCareDisplayPage: View {
         // divider between a control and the sentence saying it does nothing
         // turns the warning into what looks like an unrelated setting.
         if prefs.oledDetectionDimming, displaySleepAssertionHeld {
-          OledInlineNote(Text("Something was holding the screen awake when this page opened: video playback, a call, or Keep Display Awake. Nothing is dimmed here for as long as that lasts."))
+          OledInlineNote(Text("Something is holding the screen awake: video playback, a call, or Keep Display Awake. Nothing is dimmed here for as long as that lasts."))
         }
       }
     }

--- a/Candela/Settings/OledCareDisplayPage.swift
+++ b/Candela/Settings/OledCareDisplayPage.swift
@@ -31,12 +31,8 @@ struct OledCareDisplayPage: View {
   /// dim-state task id.
   @State private var displaySleepMinutes: Int?
 
-  /// Sampled beside `displaySleepMinutes`, and for the same reason: `body`
-  /// re-evaluates on every pref write, and a reading taken there would make the
-  /// note below flicker with the page. Re-sampled on the engine's dim state
-  /// instead, which is the page's one live signal and the state an assertion
-  /// actually moves, so the note describes now rather than the moment the page
-  /// opened.
+  /// Not read in `body` (it re-evaluates on every pref write). Re-sampled on the
+  /// engine's dim state, the one live signal an assertion actually moves.
   @State private var displaySleepAssertionHeld = false
 
   /// Slider drafts, live only while a drag is in progress. A `Slider` bound
@@ -155,9 +151,7 @@ struct OledCareDisplayPage: View {
         }
       }
     }
-    // Two tasks, not one: the pmset spawn is a per-appearance reading, while the
-    // assertion is a cheap IOKit query that has to follow the engine's dim state.
-    // Keyed together, every dim transition re-spawns pmset.
+    // Two tasks: keyed together, every dim transition would re-spawn pmset.
     .task { displaySleepMinutes = OledCareSignalSources.displaySleepMinutes() }
     .task(id: model.oledCare.dimStates[persistenceKey]) {
       displaySleepAssertionHeld = OledCareSignalSources.displaySleepAssertionHeld()
@@ -377,11 +371,8 @@ struct OledCareDisplayPage: View {
     }
   }
 
-  /// Live means the pipeline produced a reading inside
-  /// `OledCareCadence.livenessWindowSeconds`, so a dead grant stills the dot
-  /// within a few minutes whatever the prefs claim. The window is the Kit's, not
-  /// a number chosen here: the comment used to say two intervals while the code
-  /// said three.
+  /// Live means a reading landed inside `OledCareCadence.livenessWindowSeconds`,
+  /// so a dead grant stills the dot within minutes whatever the prefs claim.
   private func isMeasuringLive(_ summary: PanelHealthSummary) -> Bool {
     guard !model.isSafeMode, prefs.oledTelemetry, CGPreflightScreenCaptureAccess(),
       let last = summary.lastSample
@@ -540,11 +531,9 @@ struct OledCareDisplayPage: View {
   /// staticness, and they live on the Health pane, so the caption names that
   /// pane instead of leaving the switch to do nothing silently.
   ///
-  /// The third condition is the display-sleep assertion: the coordinator gates
-  /// nomination on `!state.assertionHeld`, the same term idle dimming has, and
-  /// the reading is system-wide, so our own Keep Display Awake silences this
-  /// control as surely as a video does. The caption lists it; the note says when
-  /// it is the live reason.
+  /// The assertion gate is system-wide, so our own Keep Display Awake silences
+  /// this control as surely as a video does. The caption lists it; the note
+  /// says when it is the live reason.
   ///
   /// The caption promises exactly what the code delivers. "Full-screen video is
   /// never dimmed" is the `fullScreenOwner` gate, read from the window list. It
@@ -563,9 +552,8 @@ struct OledCareDisplayPage: View {
         .themedSwitch()
         .accessibilityLabel("Automatic static-region dimming")
         .prefIdentifier(.oledDetectionDimming, persistenceKey: persistenceKey)
-        // In the SAME row as the switch, the idle threshold's warning shape: a
-        // divider between a control and the sentence saying it does nothing
-        // turns the warning into what looks like an unrelated setting.
+        // Same row as the switch: a divider would make the warning read as an
+        // unrelated setting.
         if prefs.oledDetectionDimming, displaySleepAssertionHeld {
           OledInlineNote(Text("Something is holding the screen awake: video playback, a call, or Keep Display Awake. Nothing is dimmed here for as long as that lasts."))
         }

--- a/Candela/Settings/OledCarePane.swift
+++ b/Candela/Settings/OledCarePane.swift
@@ -165,6 +165,7 @@ struct OledCarePane: View {
               }
             ))
             .themedSwitch()
+            .accessibilityLabel("Automatically hide the menu bar")
             if menuBarRefused != nil {
               OledInlineNote(Text("macOS did not take that change. Menu bar auto-hiding can also be set in System Settings > Control Center."))
             }
@@ -183,6 +184,7 @@ struct OledCarePane: View {
               }
             ))
             .themedSwitch()
+            .accessibilityLabel("Automatically hide the Dock")
             if dockRefused != nil {
               OledInlineNote(Text("macOS did not take that change. Dock auto-hiding can also be set in System Settings > Desktop & Dock."))
             }

--- a/Candela/Settings/OledCareSummary.swift
+++ b/Candela/Settings/OledCareSummary.swift
@@ -546,8 +546,10 @@ struct OledTelemetryTicker: View {
 }
 
 /// The breathing measurement indicator. It may only breathe while readings
-/// genuinely land (`lastSample` within two sampling intervals), so the motion IS
-/// the telemetry: a dead grant stills it within two minutes.
+/// genuinely land (`lastSample` within `OledCareCadence.livenessWindowSeconds`,
+/// two sampling intervals), so the motion IS the telemetry: a dead grant stills
+/// it within two minutes. The caller owns that judgement; this view only draws
+/// it.
 struct OledMeasuringDot: View {
   let live: Bool
 

--- a/Candela/Settings/OledCareSummary.swift
+++ b/Candela/Settings/OledCareSummary.swift
@@ -546,10 +546,9 @@ struct OledTelemetryTicker: View {
 }
 
 /// The breathing measurement indicator. It may only breathe while readings
-/// genuinely land (`lastSample` within `OledCareCadence.livenessWindowSeconds`,
-/// two sampling intervals), so the motion IS the telemetry: a dead grant stills
-/// it within two minutes. The caller owns that judgement; this view only draws
-/// it.
+/// genuinely land (`lastSample` within `OledCareCadence.livenessWindowSeconds`),
+/// so the motion IS the telemetry: a dead grant stills it within a few minutes.
+/// The caller owns that judgement; this view only draws it.
 struct OledMeasuringDot: View {
   let live: Bool
 

--- a/Candela/Settings/OledCareSummary.swift
+++ b/Candela/Settings/OledCareSummary.swift
@@ -548,7 +548,6 @@ struct OledTelemetryTicker: View {
 /// The breathing measurement indicator. It may only breathe while readings
 /// genuinely land (`lastSample` within `OledCareCadence.livenessWindowSeconds`),
 /// so the motion IS the telemetry: a dead grant stills it within a few minutes.
-/// The caller owns that judgement; this view only draws it.
 struct OledMeasuringDot: View {
   let live: Bool
 

--- a/Candela/Settings/PanelHealthView.swift
+++ b/Candela/Settings/PanelHealthView.swift
@@ -396,7 +396,12 @@ struct PanelHealthView: View {
       return "Waiting on Screen Recording; no readings are being taken."
     }
     if summary.confidence == .estimated {
-      return "Not shown while measuring is off. The history recorded so far is kept."
+      // The kept-history half belongs to the lenses that draw history. The live
+      // lens draws the last minute, and a reassurance about a record it does not
+      // show reads as an answer to a question nobody asked.
+      return mode == .now
+        ? "Not shown while measuring is off."
+        : "Not shown while measuring is off. The history recorded so far is kept."
     }
     if mode == .now {
       return "No reading this session yet. One lands within a minute while this display is awake and in use."

--- a/Candela/Settings/PanelHealthView.swift
+++ b/Candela/Settings/PanelHealthView.swift
@@ -384,11 +384,9 @@ struct PanelHealthView: View {
 
   /// Caption under a blank surface, per lens.
   ///
-  /// Same order as `confidenceNote`, and for the same reason: Safe Mode, a
-  /// missing grant and measuring-off each stop readings dead, so the live
-  /// lens's "one lands within a minute" is only true below all three. Above
-  /// them it promised a reading that could never arrive while the banner over
-  /// the map said the opposite.
+  /// Same order as `confidenceNote`: Safe Mode, a missing grant and measuring-off
+  /// all stop readings, so the live lens's "within a minute" is only true below
+  /// them.
   private func mapPlaceholder(_ summary: PanelHealthSummary, mode: SurfaceMode) -> String {
     if model.isSafeMode {
       return "Paused for this session (Safe Mode). History recorded before it is kept."
@@ -397,9 +395,8 @@ struct PanelHealthView: View {
       return "Waiting on Screen Recording; no readings are being taken."
     }
     if summary.confidence == .estimated {
-      // The kept-history half belongs to the lenses that draw history. The live
-      // lens draws the last minute, and a reassurance about a record it does not
-      // show reads as an answer to a question nobody asked.
+      // The live lens draws no history, so the kept-history reassurance is not
+      // for it.
       return mode == .now
         ? "Not shown while measuring is off."
         : "Not shown while measuring is off. The history recorded so far is kept."
@@ -690,12 +687,9 @@ struct PanelExposureMap: View {
 }
 
 /// The ramp's key, since a heat map with no key is a picture rather than a
-/// reading. Never a unit: neither scale has an absolute meaning to put on it.
-///
-/// The ends are callers' words because the two lenses do not share a scale.
-/// History is each cell against the panel's own peak, accumulated; the live
-/// lens is the raw linear luminance of one frame. One legend speaking for both
-/// described whichever it was not drawn under.
+/// reading. Never a unit: neither scale has an absolute meaning. The ends are the
+/// caller's because history (each cell against the panel's peak) and the live
+/// lens (one frame's raw luminance) do not share a scale.
 struct PanelExposureLegend: View {
   var low: String = "Less lit"
   var high: String = "More lit"

--- a/Candela/Settings/PanelHealthView.swift
+++ b/Candela/Settings/PanelHealthView.swift
@@ -289,6 +289,7 @@ struct PanelHealthView: View {
         // with the SYSTEM accent when on.
         Toggle("Windows", isOn: $showsWindowGhosts)
           .themedSwitch(spreads: false)
+          .accessibilityLabel("Windows")
           .help("Outline the windows on this display, from the same permission-free snapshot app attribution uses.")
         Spacer(minLength: 0)
       }

--- a/Candela/Settings/PanelHealthView.swift
+++ b/Candela/Settings/PanelHealthView.swift
@@ -141,7 +141,7 @@ struct PanelHealthView: View {
     } message: {
       Text(
         verbatim:
-          "The accumulated brightness map for \(displayName), and the per-app display time derived from the same observations, are removed from this Mac. This display's total hours of use are a separate count and are not affected."
+          "The accumulated brightness map for \(displayName), and the per-app display time derived from the same observations, are removed from this Mac. Two other counts are kept and are not affected: this display's total hours of use, and its record of time spent at each brightness."
       )
     }
   }
@@ -336,7 +336,13 @@ struct PanelHealthView: View {
         // describing exactly the drawn map.
         .frame(width: mapSize.width, height: mapSize.height)
         .frame(maxWidth: .infinity)
-        PanelExposureLegend()
+        // Per lens, because the scales are different: history is normalized to
+        // this panel's own peak, the live lens is absolute luminance.
+        if surfaceMode == .now {
+          PanelExposureLegend(low: "Darker", high: "Brighter")
+        } else {
+          PanelExposureLegend()
+        }
         if surfaceMode == .now, let live {
           Text(verbatim: "Reading from \(live.at.formatted(date: .omitted, time: .standard)); brightness of what the display was showing.")
             .font(.caption)
@@ -376,19 +382,26 @@ struct PanelHealthView: View {
   }
 
   /// Caption under a blank surface, per lens.
+  ///
+  /// Same order as `confidenceNote`, and for the same reason: Safe Mode, a
+  /// missing grant and measuring-off each stop readings dead, so the live
+  /// lens's "one lands within a minute" is only true below all three. Above
+  /// them it promised a reading that could never arrive while the banner over
+  /// the map said the opposite.
   private func mapPlaceholder(_ summary: PanelHealthSummary, mode: SurfaceMode) -> String {
-    if mode == .now {
-      return "No reading this session yet. One lands within a minute while this display is awake, in use, and Screen Recording is granted."
-    }
     if model.isSafeMode {
       return "Paused for this session (Safe Mode). History recorded before it is kept."
     }
     if summary.confidence != .estimated, screenRecordingMissing {
       return "Waiting on Screen Recording; no readings are being taken."
     }
-    return summary.confidence == .estimated
-      ? "Not shown while measuring is off. The history recorded so far is kept."
-      : "Nothing measured to draw yet. Readings are taken once a minute while this display is awake and in use."
+    if summary.confidence == .estimated {
+      return "Not shown while measuring is off. The history recorded so far is kept."
+    }
+    if mode == .now {
+      return "No reading this session yet. One lands within a minute while this display is awake and in use."
+    }
+    return "Nothing measured to draw yet. Readings are taken once a minute while this display is awake and in use."
   }
 
   /// Current window rectangles over the surface. Same layer policy as the
@@ -671,19 +684,26 @@ struct PanelExposureMap: View {
 }
 
 /// The ramp's key, since a heat map with no key is a picture rather than a
-/// reading. "less/more" and not a unit: the scale is each cell against this
-/// panel's own peak, which has no absolute meaning.
+/// reading. Never a unit: neither scale has an absolute meaning to put on it.
+///
+/// The ends are callers' words because the two lenses do not share a scale.
+/// History is each cell against the panel's own peak, accumulated; the live
+/// lens is the raw linear luminance of one frame. One legend speaking for both
+/// described whichever it was not drawn under.
 struct PanelExposureLegend: View {
+  var low: String = "Less lit"
+  var high: String = "More lit"
+
   var body: some View {
     HStack(spacing: 8) {
-      Text("Less lit")
+      Text(verbatim: low)
       LinearGradient(
         colors: stride(from: 0.0, through: 1.0, by: 0.1).map(PanelExposureScale.color),
         startPoint: .leading, endPoint: .trailing
       )
       .frame(height: 6)
       .clipShape(RoundedRectangle(cornerRadius: 3))
-      Text("More lit")
+      Text(verbatim: high)
     }
     .font(.caption)
     .foregroundStyle(SettingsTheme.faintColor)

--- a/Candela/Settings/ResolutionRows.swift
+++ b/Candela/Settings/ResolutionRows.swift
@@ -290,6 +290,7 @@ struct RememberResolutionRow: View {
           }
         ))
         .themedSwitch()
+        .accessibilityLabel("Remember this resolution")
         .prefIdentifier(.rememberDisplayMode, persistenceKey: persistenceKey)
         switch Self.pinnedRow(
           isRemembering: coordinator.isRemembering(displayID),

--- a/Candela/Settings/RotationRows.swift
+++ b/Candela/Settings/RotationRows.swift
@@ -24,28 +24,21 @@ struct RotationRows: View {
   let state: AppModel.DisplayState
   let coordinator: RotationCoordinator
 
-  /// Read for the mirror sample only. `MirroringCoordinator` is this app's ONE
-  /// definition of "mirrored"; a second sample taken here would disagree with it
-  /// exactly when it matters.
+  /// For the mirror sample only: `MirroringCoordinator` is the one definition of
+  /// "mirrored".
   @Environment(AppModel.self) private var model
 
   private var displayID: CGDirectDisplayID { state.id }
 
-  /// A mirror slave's framebuffer belongs to the display it mirrors, so
-  /// `RotationPolicy` refuses it. Greyed with the reason rather than left live
-  /// and refusing: the click would only produce a report.
+  /// `RotationPolicy` refuses a slave, so greyed with the reason rather than left
+  /// live to produce a report.
   private var isMirrorSlave: Bool {
     model.mirroring.topology.displays.contains { $0.id == displayID && $0.isMirrorSlave }
   }
 
-  /// A display showing a size the app renders is mechanically a slave too, so it
-  /// is refused as well. Kept apart from `isMirrorSlave` because the sentence
-  /// differs: the user paired nothing here, and the way out is the size control.
-  ///
-  /// Off the same coordinator sample as `isMirrorSlave`, not the raw store the
-  /// policy reads: that one is an observation dependency and it unions in a
-  /// pairing the store has not been told about yet, so the caption can never
-  /// lag the flag it explains.
+  /// Mechanically a slave too, but with its own sentence: the user paired
+  /// nothing, and the way out is the size control. Off the coordinator sample,
+  /// not the raw store, so the caption cannot lag the flag it explains.
   private var isSynthesizedSize: Bool {
     MirroringPredicates.isSynthesized(model.mirroring.topology, displayID: displayID)
   }
@@ -66,11 +59,8 @@ struct RotationRows: View {
       // second selection on top of the first.
       .disabled(coordinator.isApplying || isMirrorSlave || isSynthesizedSize)
 
-      // One caption at a time, pairing state first: it is the reason the control
-      // above is dead, and the angle it shows is beside the point while it is.
-      // The synthesis arm ahead of the mirror arm, in the policy's order: such a
-      // display sets the raw flag too, and the mirroring sentence would name a
-      // display the user does not have.
+      // Pairing state first, in the policy's order: a synthesized display sets
+      // the raw mirror flag too, and that sentence names a display nobody paired.
       if isSynthesizedSize {
         SettingsCaption(RotationCopy.refusal(.synthesizedSize))
       } else if isMirrorSlave {

--- a/Candela/Settings/RotationRows.swift
+++ b/Candela/Settings/RotationRows.swift
@@ -24,7 +24,19 @@ struct RotationRows: View {
   let state: AppModel.DisplayState
   let coordinator: RotationCoordinator
 
+  /// Read for the mirror sample only. `MirroringCoordinator` is this app's ONE
+  /// definition of "mirrored"; a second sample taken here would disagree with it
+  /// exactly when it matters.
+  @Environment(AppModel.self) private var model
+
   private var displayID: CGDirectDisplayID { state.id }
+
+  /// A mirror slave's framebuffer belongs to the display it mirrors, so
+  /// `RotationPolicy` refuses it. Greyed with the reason rather than left live
+  /// and refusing: the click would only produce a report.
+  private var isMirrorSlave: Bool {
+    model.mirroring.topology.displays.contains { $0.id == displayID && $0.isMirrorSlave }
+  }
 
   var body: some View {
     // No control at all rather than a dead one. A picker that cannot
@@ -40,11 +52,15 @@ struct RotationRows: View {
       }
       // A rotation takes up to a second; without this the window accepts a
       // second selection on top of the first.
-      .disabled(coordinator.isApplying)
+      .disabled(coordinator.isApplying || isMirrorSlave)
 
-      // The display reports a non-right angle, so the picker above is showing
-      // a fallback rather than the truth. Say so.
-      if coordinator.rotation(of: displayID) == nil {
+      // One caption at a time, mirror state first: it is the reason the control
+      // above is dead, and the angle it shows is beside the point while it is.
+      if isMirrorSlave {
+        SettingsCaption(RotationCopy.refusal(.mirrored))
+      } else if coordinator.rotation(of: displayID) == nil {
+        // The display reports a non-right angle, so the picker above is showing
+        // a fallback rather than the truth. Say so.
         SettingsCaption(RotationCopy.refusal(.unreadable))
       }
     }

--- a/Candela/Settings/RotationRows.swift
+++ b/Candela/Settings/RotationRows.swift
@@ -38,6 +38,18 @@ struct RotationRows: View {
     model.mirroring.topology.displays.contains { $0.id == displayID && $0.isMirrorSlave }
   }
 
+  /// A display showing a size the app renders is mechanically a slave too, so it
+  /// is refused as well. Kept apart from `isMirrorSlave` because the sentence
+  /// differs: the user paired nothing here, and the way out is the size control.
+  ///
+  /// Off the same coordinator sample as `isMirrorSlave`, not the raw store the
+  /// policy reads: that one is an observation dependency and it unions in a
+  /// pairing the store has not been told about yet, so the caption can never
+  /// lag the flag it explains.
+  private var isSynthesizedSize: Bool {
+    MirroringPredicates.isSynthesized(model.mirroring.topology, displayID: displayID)
+  }
+
   var body: some View {
     // No control at all rather than a dead one. A picker that cannot
     // rotate only invites a click that produces a report.
@@ -52,11 +64,16 @@ struct RotationRows: View {
       }
       // A rotation takes up to a second; without this the window accepts a
       // second selection on top of the first.
-      .disabled(coordinator.isApplying || isMirrorSlave)
+      .disabled(coordinator.isApplying || isMirrorSlave || isSynthesizedSize)
 
-      // One caption at a time, mirror state first: it is the reason the control
+      // One caption at a time, pairing state first: it is the reason the control
       // above is dead, and the angle it shows is beside the point while it is.
-      if isMirrorSlave {
+      // The synthesis arm ahead of the mirror arm, in the policy's order: such a
+      // display sets the raw flag too, and the mirroring sentence would name a
+      // display the user does not have.
+      if isSynthesizedSize {
+        SettingsCaption(RotationCopy.refusal(.synthesizedSize))
+      } else if isMirrorSlave {
         SettingsCaption(RotationCopy.refusal(.mirrored))
       } else if coordinator.rotation(of: displayID) == nil {
         // The display reports a non-right angle, so the picker above is showing

--- a/Candela/Settings/SettingsComponents.swift
+++ b/Candela/Settings/SettingsComponents.swift
@@ -65,12 +65,17 @@ enum SafetySentence {
   /// Why no DDC command is reaching this display. Here rather than on
   /// `AdvancedPage` because the HDR half is both spoken in a control label and
   /// shown as the page's caption, and two copies would drift.
+  ///
+  /// Scoped to the HARDWARE settings, not to everything under it: the sections
+  /// below also hold controls that turn the block itself off, and a blanket
+  /// "the settings below have no effect" would be telling the reader that the
+  /// way out does not work either.
   static func trafficBlockExplanation(_ block: DDCTrafficBlock) -> String {
     switch block {
     case .macOSDrivesBrightness:
-      "This display is in HDR mode. macOS is setting its brightness directly, so the settings below have no effect until HDR turns off."
+      "This display is in HDR mode. macOS is setting its brightness directly, so this display's hardware settings below have no effect until HDR turns off."
     case .hardwareControlOff:
-      "Hardware (DDC) control is off for this display, so the settings below have no effect."
+      "Hardware (DDC) control is off for this display, so this display's hardware settings below have no effect."
     }
   }
 }

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -51,10 +51,6 @@ struct SettingsRootView: View {
   @Environment(AppModel.self) private var model
 
   var body: some View {
-    // Rename dependency, registered HERE because `currentTitle` is read here
-    // and `DisplayPrefs` has no observation of its own. Without it the window
-    // title, and so the Window menu, keeps the hardware name after a rename.
-    let _ = model.prefsRevision
     ZStack {
       // One canvas for the life of the window, so a selection change moves the
       // light rather than cutting to a new one.
@@ -145,7 +141,16 @@ struct SettingsRootView: View {
     // the scene's own title at the LEADING edge next to the Back button, and it
     // LINGERS after the pop. With no dependency that changes with the path,
     // `updateNSView` never fires for a push and cannot re-hide it.
-    .background(SettingsWindowConfigurator(title: currentTitle, navigationToken: currentPathDepth))
+    // The title resolves inside a leaf view, which is where the `prefsRevision`
+    // read lives. A rename is a pref write and `DisplayPrefs` has no observation
+    // of its own, so something has to depend on the revision; read at this level
+    // it re-ran the entire shell, canvas included, on every pref write anywhere
+    // in the app.
+    .background(
+      SettingsWindowTitleHost(
+        displayKey: presentation.displayKey,
+        fallbackTitle: selectedPaneTitle,
+        navigationToken: currentPathDepth))
     // Debug screenshot hook: the window has no URL scheme and cannot be driven
     // by clicking without an Accessibility grant, so a capture run names its
     // destination through an env var and this adopts it once, where the
@@ -303,30 +308,15 @@ struct SettingsRootView: View {
     )
   }
 
-  /// Resolved from `presentation` rather than read back from the panes, so the
-  /// title always names what is on screen. Display destinations use the
-  /// display's name as the sidebar and the switcher resolve it: the window
-  /// draws no title of its own any more, so this reaches the Window menu and
-  /// VoiceOver, where the hardware name would be a display nobody renamed.
-  private var currentTitle: String {
-    switch presentation {
-    case let .display(key, _):
-      // The `??` covers the same-frame race, not a second policy:
-      // `presentation` already established the key is connected.
-      model.allControlledStates
-        .first { $0.display.persistenceKey == key }
-        .map {
-          DisplayOrdering.title(
-            friendlyName: DisplayPrefs(persistenceKey: key).friendlyName,
-            hardwareName: $0.display.name)
-        } ?? SettingsRegistry.descriptor(for: .general).title
-    case .pane:
-      if case let .pane(id) = selection {
-        SettingsRegistry.descriptor(for: id).title
-      } else {
-        // The fallback case, which `detailRoot` renders General for.
-        SettingsRegistry.descriptor(for: .general).title
-      }
+  /// The title for a pane destination, and the fallback for a display one. The
+  /// display half lives in `SettingsWindowTitleHost`, which is what keeps the
+  /// rename dependency off this view.
+  private var selectedPaneTitle: String {
+    if case let .pane(id) = selection {
+      SettingsRegistry.descriptor(for: id).title
+    } else {
+      // The fallback case, which `detailRoot` renders General for.
+      SettingsRegistry.descriptor(for: .general).title
     }
   }
 
@@ -735,6 +725,49 @@ enum SettingsWindowMetrics {
   static let idealHeight: CGFloat = 680
 
   static var minContentSize: NSSize { NSSize(width: minWidth, height: minHeight) }
+}
+
+/// Resolves the window title and hosts the configurator, so the only view in the
+/// shell itself that depends on `prefsRevision` is this leaf; the sidebar and
+/// the panes keep their own reads.
+///
+/// A rename is a pref write and `DisplayPrefs` has no observation of its own, so
+/// the title has to hang off the revision. Read in the shell's body that
+/// dependency re-ran the sidebar, the canvas and the detail column on every pref
+/// write in the app; read here it re-runs one background view that draws nothing.
+///
+/// Resolved from the presented display rather than read back from the panes, so
+/// the title always names what is on screen. Display destinations use the name
+/// the sidebar and the switcher resolve: the window draws no title of its own
+/// any more, so this reaches the Window menu and VoiceOver, where the hardware
+/// name would be a display nobody renamed.
+private struct SettingsWindowTitleHost: View {
+  /// The display the detail column is presenting; nil for a pane destination.
+  let displayKey: String?
+  /// Used for a pane destination, and for the same-frame race where the key is
+  /// no longer among the connected states.
+  let fallbackTitle: String
+  let navigationToken: Int
+
+  @Environment(AppModel.self) private var model
+
+  var body: some View {
+    SettingsWindowConfigurator(title: title, navigationToken: navigationToken)
+  }
+
+  private var title: String {
+    guard let displayKey else { return fallbackTitle }
+    // The revision read that this view exists to contain.
+    _ = model.prefsRevision
+    return
+      model.allControlledStates
+      .first { $0.display.persistenceKey == displayKey }
+      .map {
+        DisplayOrdering.title(
+          friendlyName: DisplayPrefs(persistenceKey: displayKey).friendlyName,
+          hardwareName: $0.display.name)
+      } ?? fallbackTitle
+  }
 }
 
 /// The window chrome a `Settings` scene does not offer: the `.resizable` and

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -141,11 +141,8 @@ struct SettingsRootView: View {
     // the scene's own title at the LEADING edge next to the Back button, and it
     // LINGERS after the pop. With no dependency that changes with the path,
     // `updateNSView` never fires for a push and cannot re-hide it.
-    // The title resolves inside a leaf view, which is where the `prefsRevision`
-    // read lives. A rename is a pref write and `DisplayPrefs` has no observation
-    // of its own, so something has to depend on the revision; read at this level
-    // it re-ran the entire shell, canvas included, on every pref write anywhere
-    // in the app.
+    // The title's `prefsRevision` read lives in the leaf: read here it re-ran
+    // the whole shell on every pref write.
     .background(
       SettingsWindowTitleHost(
         displayKey: presentation.displayKey,
@@ -308,9 +305,8 @@ struct SettingsRootView: View {
     )
   }
 
-  /// The title for a pane destination, and the fallback for a display one. The
-  /// display half lives in `SettingsWindowTitleHost`, which is what keeps the
-  /// rename dependency off this view.
+  /// The pane title, and the fallback for a display; the display half lives in
+  /// `SettingsWindowTitleHost` to keep the rename dependency off this view.
   private var selectedPaneTitle: String {
     if case let .pane(id) = selection {
       SettingsRegistry.descriptor(for: id).title
@@ -727,25 +723,17 @@ enum SettingsWindowMetrics {
   static var minContentSize: NSSize { NSSize(width: minWidth, height: minHeight) }
 }
 
-/// Resolves the window title and hosts the configurator, so the only view in the
-/// shell itself that depends on `prefsRevision` is this leaf; the sidebar and
-/// the panes keep their own reads.
+/// Hosts the configurator and resolves the title, so the shell's only
+/// `prefsRevision` dependency is this leaf that draws nothing. A rename is a pref
+/// write with no observation of its own, so the title has to hang off the
+/// revision, and read in the shell it re-ran the whole window per pref write.
 ///
-/// A rename is a pref write and `DisplayPrefs` has no observation of its own, so
-/// the title has to hang off the revision. Read in the shell's body that
-/// dependency re-ran the sidebar, the canvas and the detail column on every pref
-/// write in the app; read here it re-runs one background view that draws nothing.
-///
-/// Resolved from the presented display rather than read back from the panes, so
-/// the title always names what is on screen. Display destinations use the name
-/// the sidebar and the switcher resolve: the window draws no title of its own
-/// any more, so this reaches the Window menu and VoiceOver, where the hardware
+/// Display destinations use the resolved name: the window draws no title of its
+/// own, so this reaches only the Window menu and VoiceOver, where the hardware
 /// name would be a display nobody renamed.
 private struct SettingsWindowTitleHost: View {
-  /// The display the detail column is presenting; nil for a pane destination.
   let displayKey: String?
-  /// Used for a pane destination, and for the same-frame race where the key is
-  /// no longer among the connected states.
+  /// Also covers the same-frame race where the key has left the connected states.
   let fallbackTitle: String
   let navigationToken: Int
 

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -51,6 +51,10 @@ struct SettingsRootView: View {
   @Environment(AppModel.self) private var model
 
   var body: some View {
+    // Rename dependency, registered HERE because `currentTitle` is read here
+    // and `DisplayPrefs` has no observation of its own. Without it the window
+    // title, and so the Window menu, keeps the hardware name after a rename.
+    let _ = model.prefsRevision
     ZStack {
       // One canvas for the life of the window, so a selection change moves the
       // light rather than cutting to a new one.
@@ -301,7 +305,9 @@ struct SettingsRootView: View {
 
   /// Resolved from `presentation` rather than read back from the panes, so the
   /// title always names what is on screen. Display destinations use the
-  /// display's own name.
+  /// display's name as the sidebar and the switcher resolve it: the window
+  /// draws no title of its own any more, so this reaches the Window menu and
+  /// VoiceOver, where the hardware name would be a display nobody renamed.
   private var currentTitle: String {
     switch presentation {
     case let .display(key, _):
@@ -309,7 +315,11 @@ struct SettingsRootView: View {
       // `presentation` already established the key is connected.
       model.allControlledStates
         .first { $0.display.persistenceKey == key }
-        .map(\.display.name) ?? SettingsRegistry.descriptor(for: .general).title
+        .map {
+          DisplayOrdering.title(
+            friendlyName: DisplayPrefs(persistenceKey: key).friendlyName,
+            hardwareName: $0.display.name)
+        } ?? SettingsRegistry.descriptor(for: .general).title
     case .pane:
       if case let .pane(id) = selection {
         SettingsRegistry.descriptor(for: id).title

--- a/Candela/Settings/SettingsSidebar.swift
+++ b/Candela/Settings/SettingsSidebar.swift
@@ -64,6 +64,10 @@ struct SettingsSidebar: View {
             // A headerless break: a header's worth of air with nothing
             // said, so the utility rows do not read as another section.
             .padding(.top, section.gapAbove && index == 0 ? 18 : 0)
+            // The shortcut's only visible trace: the buttons carrying it are
+            // zero-size and hidden from accessibility, and the `Settings`
+            // scene's menu bar is not ours to add an item to.
+            .help(optional: Self.commandHint(for: id))
           }
         }
 
@@ -88,12 +92,20 @@ struct SettingsSidebar: View {
         if model.displays.isEmpty {
           // Without this, someone seeing only "Built-in Display" cannot tell
           // an undetected monitor from a broken app.
-          Text("No external displays connected")
-            .font(.callout)
-            .foregroundStyle(SettingsTheme.faintColor)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.horizontal, 8)
-            .padding(.top, 4)
+          VStack(alignment: .leading, spacing: 4) {
+            Text("No external displays connected")
+              .font(.callout)
+            // Discovery keeps only displays that matched an IOAVService, so a
+            // monitor on one of these routes is attached, visible, and absent
+            // from this list. Said here because from the sidebar the two look
+            // the same.
+            Text("Displays connected over DisplayLink, AirPlay or Sidecar carry no DDC channel, so \(AppInfo.productName) cannot control them and does not list them.")
+              .font(.caption)
+          }
+          .foregroundStyle(SettingsTheme.faintColor)
+          .fixedSize(horizontal: false, vertical: true)
+          .padding(.horizontal, 8)
+          .padding(.top, 4)
         }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
@@ -151,6 +163,14 @@ struct SettingsSidebar: View {
       .padding(.leading, 14)
       .padding(.top, 18)
       .padding(.bottom, 6)
+  }
+
+  /// The ⌘-number the shell binds to this pane, spelled out because the string
+  /// is read as well as shown: `.help` becomes the row's accessibility hint.
+  /// Nil past the ninth row, which is where the shortcuts stop.
+  private static func commandHint(for id: PaneID) -> Text? {
+    guard let index = SettingsRegistry.paneOrder.firstIndex(of: id), index < 9 else { return nil }
+    return Text(verbatim: "Command \(index + 1)")
   }
 
   /// One selectable row, drawing its own selection pill.
@@ -213,9 +233,11 @@ struct SettingsSidebar: View {
     accent: SettingsAccent, ordinal: Int? = nil
   ) -> some View {
     // The SAME resolution the panel uses, so a rename moves the sidebar, the
-    // panel header, the slider's label and the HUD together. The detail pane's
-    // title deliberately does not follow: it stays the hardware name, so
-    // renaming does not relabel the window you are editing it in.
+    // panel header, the slider's label, the HUD and the window's own title
+    // together. The window title used to stay the hardware name so a rename
+    // did not relabel the window you were editing it in; the window stopped
+    // DRAWING its title (`titleVisibility = .hidden`), so what was left of it
+    // was the Window menu and VoiceOver naming a display nobody renamed.
     let prefs = DisplayPrefs(persistenceKey: display.persistenceKey)
     let resolved = DisplayOrdering.title(
       friendlyName: prefs.friendlyName, hardwareName: display.name
@@ -335,5 +357,11 @@ private struct SidebarRowButton<Content: View>: View {
     .buttonStyle(.plain)
     .onHover { hovering = $0 }
     .animation(SettingsTheme.hoverMotion, value: hovering)
+  }
+}
+
+private extension View {
+  @ViewBuilder func help(optional text: Text?) -> some View {
+    if let text { help(text) } else { self }
   }
 }

--- a/Candela/Settings/SettingsSidebar.swift
+++ b/Candela/Settings/SettingsSidebar.swift
@@ -64,9 +64,8 @@ struct SettingsSidebar: View {
             // A headerless break: a header's worth of air with nothing
             // said, so the utility rows do not read as another section.
             .padding(.top, section.gapAbove && index == 0 ? 18 : 0)
-            // The shortcut's only visible trace: the buttons carrying it are
-            // zero-size and hidden from accessibility, and the `Settings`
-            // scene's menu bar is not ours to add an item to.
+            // The shortcut's only trace: the buttons carrying it are zero-size
+            // and hidden from accessibility, and the menu bar is not ours.
             .help(optional: Self.commandHint(for: id))
           }
         }
@@ -95,10 +94,8 @@ struct SettingsSidebar: View {
           VStack(alignment: .leading, spacing: 4) {
             Text("No external displays connected")
               .font(.callout)
-            // Discovery keeps only displays that matched an IOAVService, so a
-            // monitor on one of these routes is attached, visible, and absent
-            // from this list. Said here because from the sidebar the two look
-            // the same.
+            // Discovery drops anything without an IOAVService, so such a monitor
+            // is attached, visible, and absent from this list.
             Text("Displays connected over DisplayLink, AirPlay or Sidecar carry no DDC channel, so \(AppInfo.productName) cannot control them and does not list them.")
               .font(.caption)
           }
@@ -165,9 +162,8 @@ struct SettingsSidebar: View {
       .padding(.bottom, 6)
   }
 
-  /// The ⌘-number the shell binds to this pane, spelled out because the string
-  /// is read as well as shown: `.help` becomes the row's accessibility hint.
-  /// Nil past the ninth row, which is where the shortcuts stop.
+  /// Spelled out because `.help` becomes the row's accessibility hint. Nil past
+  /// the ninth row, where the shortcuts stop.
   private static func commandHint(for id: PaneID) -> Text? {
     guard let index = SettingsRegistry.paneOrder.firstIndex(of: id), index < 9 else { return nil }
     return Text(verbatim: "Command \(index + 1)")
@@ -233,11 +229,9 @@ struct SettingsSidebar: View {
     accent: SettingsAccent, ordinal: Int? = nil
   ) -> some View {
     // The SAME resolution the panel uses, so a rename moves the sidebar, the
-    // panel header, the slider's label, the HUD and the window's own title
-    // together. The window title used to stay the hardware name so a rename
-    // did not relabel the window you were editing it in; the window stopped
-    // DRAWING its title (`titleVisibility = .hidden`), so what was left of it
-    // was the Window menu and VoiceOver naming a display nobody renamed.
+    // panel header, the slider's label, the HUD and the window title together.
+    // The window no longer draws its title, so keeping the hardware name there
+    // only left the Window menu and VoiceOver naming a display nobody renamed.
     let prefs = DisplayPrefs(persistenceKey: display.persistenceKey)
     let resolved = DisplayOrdering.title(
       friendlyName: prefs.friendlyName, hardwareName: display.name

--- a/Candela/Settings/SubPageHeader.swift
+++ b/Candela/Settings/SubPageHeader.swift
@@ -82,10 +82,8 @@ private struct BackButton: View {
     .onHover { hovering = $0 }
     .animation(SettingsTheme.hoverMotion, value: hovering)
     .accessibilityLabel(Text("Back"))
-    // The shortcut has no other trace: the button carrying it is zero-size and
-    // hidden from accessibility, and the window draws no menu item for it.
-    // Spelled out: VoiceOver reads a bare "[" as "left bracket" or skips it
-    // outright, so the punctuation form announces a shortcut nobody can press.
+    // The shortcut's only trace: its button is zero-size and hidden from
+    // accessibility. Spelled out because VoiceOver skips a bare "[".
     .help(Text(verbatim: "Command with the left bracket key"))
   }
 }

--- a/Candela/Settings/SubPageHeader.swift
+++ b/Candela/Settings/SubPageHeader.swift
@@ -82,5 +82,8 @@ private struct BackButton: View {
     .onHover { hovering = $0 }
     .animation(SettingsTheme.hoverMotion, value: hovering)
     .accessibilityLabel(Text("Back"))
+    // The shortcut has no other trace: the button carrying it is zero-size and
+    // hidden from accessibility, and the window draws no menu item for it.
+    .help(Text(verbatim: "Command ["))
   }
 }

--- a/Candela/Settings/SubPageHeader.swift
+++ b/Candela/Settings/SubPageHeader.swift
@@ -84,6 +84,8 @@ private struct BackButton: View {
     .accessibilityLabel(Text("Back"))
     // The shortcut has no other trace: the button carrying it is zero-size and
     // hidden from accessibility, and the window draws no menu item for it.
-    .help(Text(verbatim: "Command ["))
+    // Spelled out: VoiceOver reads a bare "[" as "left bracket" or skips it
+    // outright, so the punctuation form announces a shortcut nobody can press.
+    .help(Text(verbatim: "Command with the left bracket key"))
   }
 }

--- a/Candela/Settings/Theme/ThemedControls.swift
+++ b/Candela/Settings/Theme/ThemedControls.swift
@@ -234,10 +234,8 @@ struct ThemedSegments: View {
           .shadow(color: .black.opacity(isOn ? 0.25 : 0), radius: 2, y: 1)
       }
       .buttonStyle(.plain)
-      // SwiftUI does not publish a `Button`'s own title to the accessibility
-      // layer, so without this every segment announces as a bare "button". Here
-      // rather than at each `ThemedSegments` call site, so no segmented control
-      // in the window can be built without one.
+      // SwiftUI does not publish a `Button` title to accessibility, so without
+      // this every segment announces as "button". Here so no call site can forget.
       .accessibilityLabel(Text(verbatim: label))
       // Selection is carried by weight and fill, neither of which a screen
       // reader can see.

--- a/Candela/Settings/Theme/ThemedControls.swift
+++ b/Candela/Settings/Theme/ThemedControls.swift
@@ -234,6 +234,11 @@ struct ThemedSegments: View {
           .shadow(color: .black.opacity(isOn ? 0.25 : 0), radius: 2, y: 1)
       }
       .buttonStyle(.plain)
+      // SwiftUI does not publish a `Button`'s own title to the accessibility
+      // layer, so without this every segment announces as a bare "button". Here
+      // rather than at each `ThemedSegments` call site, so no segmented control
+      // in the window can be built without one.
+      .accessibilityLabel(Text(verbatim: label))
       // Selection is carried by weight and fill, neither of which a screen
       // reader can see.
       .accessibilityAddTraits(isOn ? [.isSelected] : [])

--- a/Candela/Settings/VirtualDisplaysPane.swift
+++ b/Candela/Settings/VirtualDisplaysPane.swift
@@ -399,15 +399,17 @@ struct VirtualDisplaysPane: View {
       }
     }
     SettingsCardDivider()
-    SettingRow("Width and height can each be 320 to 8192.") {
+    SettingRow(caption: SettingsCaption(verbatim: Self.sizeRangeCaption)) {
       HStack {
         Text("Width and Height")
         Spacer()
         numberField(slot: slot, label: "Width", name: .virtualSlotWidth,
+                    maximum: VirtualDisplayIdentity.maxPixels.wide,
                     get: { $0.width }, set: { $0.width = $1 })
           .prefIdentifier(.virtualSlotWidth, slot: slot)
         Text("x").foregroundStyle(SettingsTheme.faintColor)
         numberField(slot: slot, label: "Height", name: .virtualSlotHeight,
+                    maximum: VirtualDisplayIdentity.maxPixels.high,
                     get: { $0.height }, set: { $0.height = $1 })
           .prefIdentifier(.virtualSlotHeight, slot: slot)
       }
@@ -421,17 +423,33 @@ struct VirtualDisplaysPane: View {
     }
   }
 
+  /// Read off the ceiling the engine clamps to, per axis, so the sentence cannot
+  /// go on promising a height the create path would quietly cut back. The Retina
+  /// half comes off the same constants: the mode is drawn at twice the logical
+  /// size, so it is the doubled size that has to fit the ceiling.
+  static var sizeRangeCaption: String {
+    let (wide, high) = VirtualDisplayIdentity.maxPixels
+    return "Width can be \(minimumPixels) to \(wide), height \(minimumPixels) to \(high); "
+      + "Retina is only available up to \(wide / 2) by \(high / 2), because the display is drawn at double the size."
+  }
+
+  /// Floors the value at something a desktop fits on. Ours, not the engine's:
+  /// `normalized` has no lower bound of its own.
+  static let minimumPixels = 320
+
   private func numberField(
-    slot: Int, label: String, name: PrefName,
+    slot: Int, label: String, name: PrefName, maximum: Int,
     get: @escaping (VirtualSlotDefinition) -> Int,
     set: @escaping (inout VirtualSlotDefinition, Int) -> Void
   ) -> some View {
     CommitOnBlurField(
       stored: { String(get(prefs.virtualSlot(slot))) },
       commit: { text in
-        // 320 floors the value at something a desktop fits on. The engine
-        // still normalizes to even and clamps to the pixel ceiling on create.
-        guard let value = Int(text), (320 ... 8192).contains(value) else { return }
+        // The engine still normalizes to even and clamps to the pixel ceiling on
+        // create; this keeps the field from accepting a number that would be
+        // silently cut back to a different display than the one typed.
+        guard let value = Int(text),
+              (Self.minimumPixels ... maximum).contains(value) else { return }
         var updated = prefs.virtualSlot(slot)
         set(&updated, value)
         prefs.setVirtualSlot(updated, slot: slot)

--- a/Candela/Settings/VirtualDisplaysPane.swift
+++ b/Candela/Settings/VirtualDisplaysPane.swift
@@ -243,6 +243,7 @@ struct VirtualDisplaysPane: View {
                                                     name: .virtualSlotRecreateAtLaunch,
                                                     keyPath: \.recreateAtLaunch))
           .themedSwitch()
+          .accessibilityLabel("Come Back at Launch")
           .prefIdentifier(.virtualSlotRecreateAtLaunch, slot: slot)
       }
       SettingsCardDivider()
@@ -419,6 +420,7 @@ struct VirtualDisplaysPane: View {
       Toggle("Retina (HiDPI)", isOn: binding(slot: slot,
                                              name: .virtualSlotHiDPI, keyPath: \.hiDPI))
         .themedSwitch()
+        .accessibilityLabel("Retina (HiDPI)")
         .prefIdentifier(.virtualSlotHiDPI, slot: slot)
     }
   }

--- a/Candela/Settings/VirtualDisplaysPane.swift
+++ b/Candela/Settings/VirtualDisplaysPane.swift
@@ -31,8 +31,8 @@ struct VirtualDisplaysPane: View {
   /// the sync lands.
   @State private var shownIssue: ShownIssue?
 
-  /// The slot whose removal is being confirmed. Held as the slot rather than a
-  /// flag, so the alert cannot survive a slot switch and delete the wrong one.
+  /// The slot, not a flag, so the alert cannot survive a slot switch and delete
+  /// the wrong one.
   @State private var removingSlot: Int?
 
   private struct ShownIssue: Equatable {
@@ -391,9 +391,7 @@ struct VirtualDisplaysPane: View {
         ForEach(Self.presets.indices, id: \.self) { index in
           Text(Self.presets[index].label).tag(index)
         }
-        // Only while it describes the state. Listed all the time it is an item
-        // that cannot be chosen, since a size becomes custom by being typed
-        // into the fields below.
+        // Only while it describes the state: it cannot be chosen, only typed into.
         if presetIndex == nil {
           Text("Custom").tag(-1)
         }
@@ -425,18 +423,16 @@ struct VirtualDisplaysPane: View {
     }
   }
 
-  /// Read off the ceiling the engine clamps to, per axis, so the sentence cannot
-  /// go on promising a height the create path would quietly cut back. The Retina
-  /// half comes off the same constants: the mode is drawn at twice the logical
-  /// size, so it is the doubled size that has to fit the ceiling.
+  /// Off the engine's per-axis ceiling, so the caption cannot promise a height
+  /// the create path would cut back. Retina is drawn at double size, so the
+  /// doubled size is what has to fit.
   static var sizeRangeCaption: String {
     let (wide, high) = VirtualDisplayIdentity.maxPixels
     return "Width can be \(minimumPixels) to \(wide), height \(minimumPixels) to \(high); "
       + "Retina is only available up to \(wide / 2) by \(high / 2), because the display is drawn at double the size."
   }
 
-  /// Floors the value at something a desktop fits on. Ours, not the engine's:
-  /// `normalized` has no lower bound of its own.
+  /// Something a desktop fits on. Ours: `normalized` has no lower bound.
   static let minimumPixels = 320
 
   private func numberField(
@@ -447,9 +443,8 @@ struct VirtualDisplaysPane: View {
     CommitOnBlurField(
       stored: { String(get(prefs.virtualSlot(slot))) },
       commit: { text in
-        // The engine still normalizes to even and clamps to the pixel ceiling on
-        // create; this keeps the field from accepting a number that would be
-        // silently cut back to a different display than the one typed.
+        // The engine clamps on create anyway; this stops the field accepting a
+        // size it would silently cut back.
         guard let value = Int(text),
               (Self.minimumPixels ... maximum).contains(value) else { return }
         var updated = prefs.virtualSlot(slot)
@@ -475,9 +470,8 @@ struct VirtualDisplaysPane: View {
         // says why) or the last session ended without come-back-at-launch.
         // Create and Apply are the same write through the same path and never
         // appear together, so they share one identifier.
-        // SwiftUI does not publish a `Button`'s own title to the accessibility
-        // layer, so each title here is stated twice or the button announces as
-        // a bare "button".
+        // SwiftUI does not publish a `Button` title to accessibility; without
+        // the label it announces as "button".
         Button("Create Display") { setConfigured(true, slot: slot) }
           .buttonStyle(SettingsPrimaryButtonStyle())
           .accessibilityLabel("Create Display")
@@ -491,10 +485,8 @@ struct VirtualDisplaysPane: View {
           .accessibilityIdentifier("action.slotApply.\(slot)")
       }
       Spacer(minLength: 16)
-      // Trailing ellipsis: the click opens the confirmation, and the
-      // `.destructive` role belongs on the button that does the removing.
-      // Removal clears the slot's stored keys, the minted identity included, so
-      // it is not something a stray click may do.
+      // Confirmed first: removal clears the slot's keys, minted identity included.
+      // The `.destructive` role belongs on the button that removes.
       Button("Remove Display…") { removingSlot = slot }
         .buttonStyle(SettingsDangerButtonStyle())
         .accessibilityLabel("Remove Display…")
@@ -511,10 +503,8 @@ struct VirtualDisplaysPane: View {
             .keyboardShortcut(.defaultAction)
           Button("Remove", role: .destructive) { remove(slot: slot) }
         } message: {
-          // Names the slot's stored settings, since the tile and every field on
-          // this card go with it, and says what a later Create does and does not
-          // bring back: the slot's identity is minted fresh, so macOS meets a
-          // display it has not seen before.
+          // A later Create mints a fresh identity, so macOS meets a display it has
+          // not seen; the message says so.
           Text("The display stops and this slot goes back to its defaults: the name, the size, Retina and Come Back at Launch. Any windows on it move to your other displays. A virtual display created here afterwards counts as a new one, so macOS does not restore this display's place in your arrangement.")
         }
     }

--- a/Candela/Settings/VirtualDisplaysPane.swift
+++ b/Candela/Settings/VirtualDisplaysPane.swift
@@ -31,6 +31,10 @@ struct VirtualDisplaysPane: View {
   /// the sync lands.
   @State private var shownIssue: ShownIssue?
 
+  /// The slot whose removal is being confirmed. Held as the slot rather than a
+  /// flag, so the alert cannot survive a slot switch and delete the wrong one.
+  @State private var removingSlot: Int?
+
   private struct ShownIssue: Equatable {
     var slot: Int
     var failure: VirtualDisplayFailure?
@@ -386,11 +390,16 @@ struct VirtualDisplaysPane: View {
         ForEach(Self.presets.indices, id: \.self) { index in
           Text(Self.presets[index].label).tag(index)
         }
-        Text("Custom").tag(-1)
+        // Only while it describes the state. Listed all the time it is an item
+        // that cannot be chosen, since a size becomes custom by being typed
+        // into the fields below.
+        if presetIndex == nil {
+          Text("Custom").tag(-1)
+        }
       }
     }
     SettingsCardDivider()
-    SettingRow {
+    SettingRow("Width and height can each be 320 to 8192.") {
       HStack {
         Text("Width and Height")
         Spacer()
@@ -437,26 +446,57 @@ struct VirtualDisplaysPane: View {
   private func actionRow(slot: Int, definition: VirtualSlotDefinition, live: VirtualDisplayHandle?) -> some View {
     let drifted = live.map { $0.spec != definition.spec.normalized } ?? false
     let busy = model.virtualSlotBusy.contains(slot)
+    // A `String`, so the display's own name goes in verbatim rather than as a
+    // lookup key.
+    let removalTitle = "Remove \(definition.name)?"
     HStack(spacing: 8) {
       if live == nil {
         // A tile with no running display: the create failed (the status row
         // says why) or the last session ended without come-back-at-launch.
         // Create and Apply are the same write through the same path and never
         // appear together, so they share one identifier.
+        // SwiftUI does not publish a `Button`'s own title to the accessibility
+        // layer, so each title here is stated twice or the button announces as
+        // a bare "button".
         Button("Create Display") { setConfigured(true, slot: slot) }
           .buttonStyle(SettingsPrimaryButtonStyle())
+          .accessibilityLabel("Create Display")
           .accessibilityIdentifier("action.slotApply.\(slot)")
       } else if drifted {
         // The apply path is destroy-and-recreate under the same
         // slot, so the button names that rather than acting on the field edit.
         Button("Apply and Recreate") { setConfigured(true, slot: slot) }
           .buttonStyle(SettingsPrimaryButtonStyle())
+          .accessibilityLabel("Apply and Recreate")
           .accessibilityIdentifier("action.slotApply.\(slot)")
       }
       Spacer(minLength: 16)
-      Button("Remove Display") { remove(slot: slot) }
+      // Trailing ellipsis: the click opens the confirmation, and the
+      // `.destructive` role belongs on the button that does the removing.
+      // Removal clears the slot's stored keys, the minted identity included, so
+      // it is not something a stray click may do.
+      Button("Remove Display…") { removingSlot = slot }
         .buttonStyle(SettingsDangerButtonStyle())
+        .accessibilityLabel("Remove Display…")
         .accessibilityIdentifier("action.slotRemove.\(slot)")
+        .alert(
+          removalTitle,
+          isPresented: Binding(
+            get: { removingSlot == slot },
+            set: { if !$0 { removingSlot = nil } })
+        ) {
+          // Cancel holds Return: a destructive action never takes the primary
+          // role.
+          Button("Cancel", role: .cancel) {}
+            .keyboardShortcut(.defaultAction)
+          Button("Remove", role: .destructive) { remove(slot: slot) }
+        } message: {
+          // Names the slot's stored settings, since the tile and every field on
+          // this card go with it, and says what a later Create does and does not
+          // bring back: the slot's identity is minted fresh, so macOS meets a
+          // display it has not seen before.
+          Text("The display stops and this slot goes back to its defaults: the name, the size, Retina and Come Back at Launch. Any windows on it move to your other displays. A virtual display created here afterwards counts as a new one, so macOS does not restore this display's place in your arrangement.")
+        }
     }
     .padding(.vertical, 8)
     .disabled(busy)

--- a/CandelaAppTests/CheckupAXLabelTests.swift
+++ b/CandelaAppTests/CheckupAXLabelTests.swift
@@ -174,8 +174,7 @@ struct CheckupAXLabelTests {
     #expect(expectAllSpeak(secondDot, "the second dot page") == expected)
   }
 
-  /// Two ways out of the report, and the way out of the window. Export leads,
-  /// and it stays first in the reading order it is emphasized in.
+  /// Export leads: it stays first in the reading order it is emphasized in.
   @Test func theSummaryPageSpeaksItsActionsAndItsWayOut() {
     let flow = CheckupFixture.flow()
     let labels = expectAllSpeak(CheckupSummaryPage(model: flow), "the summary page")

--- a/CandelaAppTests/CheckupAXLabelTests.swift
+++ b/CandelaAppTests/CheckupAXLabelTests.swift
@@ -174,10 +174,11 @@ struct CheckupAXLabelTests {
     #expect(expectAllSpeak(secondDot, "the second dot page") == expected)
   }
 
-  @Test func theSummaryPageSpeaksItsTwoWaysOutOfTheReport() {
+  /// Two ways out of the report, and the way out of the window.
+  @Test func theSummaryPageSpeaksItsActionsAndItsWayOut() {
     let flow = CheckupFixture.flow()
     let labels = expectAllSpeak(CheckupSummaryPage(model: flow), "the summary page")
-    #expect(labels == [CheckupCopy.export, CheckupCopy.copySummary])
+    #expect(labels == [CheckupCopy.export, CheckupCopy.copySummary, CheckupCopy.done])
   }
 
   /// An `NSButton` falls back to its title when no label was set, so blanking the

--- a/CandelaAppTests/CheckupAXLabelTests.swift
+++ b/CandelaAppTests/CheckupAXLabelTests.swift
@@ -174,7 +174,8 @@ struct CheckupAXLabelTests {
     #expect(expectAllSpeak(secondDot, "the second dot page") == expected)
   }
 
-  /// Two ways out of the report, and the way out of the window.
+  /// Two ways out of the report, and the way out of the window. Export leads,
+  /// and it stays first in the reading order it is emphasized in.
   @Test func theSummaryPageSpeaksItsActionsAndItsWayOut() {
     let flow = CheckupFixture.flow()
     let labels = expectAllSpeak(CheckupSummaryPage(model: flow), "the summary page")

--- a/CandelaAppTests/CheckupCopyTests.swift
+++ b/CandelaAppTests/CheckupCopyTests.swift
@@ -81,6 +81,22 @@ struct CheckupCopyTests {
     #expect(!line.contains("field.black"))
   }
 
+  /// The window found no `NSScreen`, which mirroring is the usual but not the
+  /// only cause of. The line says what was observed and offers the cause.
+  @Test func theUnshownFieldStatesTheObservationRatherThanAssertingMirroring() {
+    #expect(CheckupCopy.fieldNotShown.contains(CheckupCopy.noScreenReason))
+    #expect(CheckupCopy.fieldNotShown.contains("usual cause"))
+    #expect(!CheckupCopy.noScreenReason.lowercased().contains("mirror"))
+  }
+
+  /// The mode legs blank the panel once per rate. Unwarned, that reads as the
+  /// app breaking the display.
+  @Test func thePlanSaysTheDisplayWillGoDarkDuringTheModeLegs() {
+    #expect(CheckupCopy.planModeSweep.contains("go dark"))
+    #expect(CheckupCopy.planModeSweep.contains("refresh rate"))
+    #expect(CheckupCopy.planModeSweep.contains("put back"))
+  }
+
   @Test func noCopyCarriesAnEmDashOrAVerdictOnTheDisplay() {
     for s in CheckupCopy.allStringsForTest {
       #expect(!s.contains("—"))

--- a/CandelaAppTests/CheckupFlowModelTests.swift
+++ b/CandelaAppTests/CheckupFlowModelTests.swift
@@ -519,6 +519,75 @@ struct CheckupFlowModelTests {
     flow.startShowing()
     #expect(booked.filter { $0.0 == .gray7 }.count == 3)
   }
+
+  /// A field the run walked past is nobody's attestation. Filing it as one
+  /// inflates the self-reported count with a sentence the user never said.
+  @Test func aFieldNobodyAnsweredIsNotObservedRatherThanSelfReported() async throws {
+    let flow = CheckupFlowModel(environment: environment(presenter: FakePresenter(), entry: entry()))
+    await toFirstField(flow)
+    #expect(flow.page == .witness)
+    await flow.advance()                                  // the card was never shown
+    let unanswered = try #require(flow.claims.first { $0.id == CheckupCheckID.field(.witness) })
+    #expect(unanswered.verdict == .notObserved("no answer given"))
+
+    // The control: a field the user did answer is still recorded as their own report.
+    await flow.advance()
+    flow.startShowing()
+    flow.answer(.oneMark, tappedRegion: flow.plantRegionForTest)
+    let answered = try #require(flow.claims.first { $0.id == CheckupCheckID.field(.black) })
+    #expect(answered.verdict.kind == "selfReported")
+  }
+
+  /// The rule forbids recording the session as clean, not recording what the person
+  /// saw. The grade stays inconclusive and the report rides along with it.
+  @Test func aMarkReportedAfterAMissedControlIsKeptBesideTheUngradedReason() async throws {
+    let flow = CheckupFlowModel(environment: environment(presenter: FakePresenter(), entry: entry()))
+    await toFirstField(flow); flow.startShowing(); flow.answer(.roundAndUncut, tappedRegion: nil); await flow.advance()
+    flow.startShowing(); flow.answer(.nothing, tappedRegion: nil)   // missed at 4 px
+    flow.startShowing(); flow.answer(.nothing, tappedRegion: nil)   // missed at 8 px
+    #expect(flow.plantRecord?.missed == true)
+
+    await flow.advance()
+    #expect(flow.page == .fieldInstruction(.red))
+    flow.startShowing()
+    flow.answer(.oneMark, tappedRegion: (x: 640, y: 480))
+    let red = try #require(flow.claims.first { $0.id == CheckupCheckID.field(.red) })
+    #expect(red.verdict.kind == "inconclusive")
+    #expect(red.verdict.text.contains(CheckupFlowModel.ungradedText))
+    #expect(red.verdict.text.contains("defect reported at 640,480 px"))
+
+    // The control: with nothing reported, the reason stands alone.
+    await flow.advance()
+    #expect(flow.page == .fieldInstruction(.green))
+    flow.startShowing()
+    flow.answer(.nothing, tappedRegion: nil)
+    let green = try #require(flow.claims.first { $0.id == CheckupCheckID.field(.green) })
+    #expect(green.verdict == .inconclusive(CheckupFlowModel.ungradedText))
+  }
+
+  /// The summary is the one page with nothing left to abandon, so its Done goes
+  /// through the close seam and the saved report is untouched.
+  @Test func theSummarysDoneAsksTheWindowToClose() async throws {
+    let flow = CheckupFlowModel(environment: environment(presenter: FakePresenter(), entry: entry()))
+    var closes = 0
+    flow.onClose = { closes += 1 }
+    await toFirstField(flow)
+    flow.startShowing(); flow.answer(.roundAndUncut, tappedRegion: nil)
+    await flow.advance()
+    for kind in CheckupFieldKind.protocolOrder {
+      #expect(flow.page == .fieldInstruction(kind))
+      flow.startShowing()
+      flow.answer(.nothing, tappedRegion: nil)
+      await flow.advance()
+    }
+    await flow.advance()
+    #expect(flow.page == .summary)
+    let saved = try #require(flow.report)
+    flow.close()
+    #expect(closes == 1)
+    #expect(flow.report == saved)
+    #expect(flow.page == .summary)
+  }
 }
 
 /// Suspends a runner leg until the test lets it finish, so an exit can land

--- a/CandelaAppTests/CheckupPaneTests.swift
+++ b/CandelaAppTests/CheckupPaneTests.swift
@@ -101,6 +101,14 @@ struct CheckupPaneTests {
     #expect(CheckupHistoryScope.defaultKey([]) == nil)
   }
 
+  /// The sweep that feeds `defaultKey` decodes every stored run for every
+  /// display, and the pane re-ran it every time the window came back to the
+  /// front. It buys the default scope and nothing else.
+  @Test func onlyTheDefaultScopeNeedsEveryDisplaysHistory() {
+    #expect(CheckupHistoryScope.needsEveryDisplay(chosenByHand: false))
+    #expect(!CheckupHistoryScope.needsEveryDisplay(chosenByHand: true))
+  }
+
   private func report(
     identityVerdict: CheckupVerdict, serial: String? = nil, nativeWidth: Int = 3840,
     nativeHeight: Int = 2160, maxRefreshHz: Double? = 120

--- a/CandelaAppTests/CheckupPaneTests.swift
+++ b/CandelaAppTests/CheckupPaneTests.swift
@@ -101,14 +101,9 @@ struct CheckupPaneTests {
     #expect(CheckupHistoryScope.defaultKey([]) == nil)
   }
 
-  /// The sweep that feeds `defaultKey` decodes every stored run for every
-  /// display, and the pane re-ran it every time the window came back to the
-  /// front. It buys the default scope and nothing else.
-  ///
-  /// The PREDICATE only. The pane's branch that reads it lives inside an
-  /// `.onChange(of: activeState)` in `body` with no seam a host-free test can
-  /// reach, so nothing here would notice the two arms being swapped at the call
-  /// site. Named for what it pins rather than for the behaviour it implies.
+  /// The predicate only: the branch that reads it sits in an `.onChange` in
+  /// `body` with no seam a host-free test can reach, so a swap at the call site
+  /// goes unnoticed here.
   @Test func theEveryDisplaySweepPredicateIsFalseOnceTheScopeWasPickedByHand() {
     #expect(CheckupHistoryScope.needsEveryDisplay(chosenByHand: false))
     #expect(!CheckupHistoryScope.needsEveryDisplay(chosenByHand: true))

--- a/CandelaAppTests/CheckupPaneTests.swift
+++ b/CandelaAppTests/CheckupPaneTests.swift
@@ -104,7 +104,12 @@ struct CheckupPaneTests {
   /// The sweep that feeds `defaultKey` decodes every stored run for every
   /// display, and the pane re-ran it every time the window came back to the
   /// front. It buys the default scope and nothing else.
-  @Test func onlyTheDefaultScopeNeedsEveryDisplaysHistory() {
+  ///
+  /// The PREDICATE only. The pane's branch that reads it lives inside an
+  /// `.onChange(of: activeState)` in `body` with no seam a host-free test can
+  /// reach, so nothing here would notice the two arms being swapped at the call
+  /// site. Named for what it pins rather than for the behaviour it implies.
+  @Test func theEveryDisplaySweepPredicateIsFalseOnceTheScopeWasPickedByHand() {
     #expect(CheckupHistoryScope.needsEveryDisplay(chosenByHand: false))
     #expect(!CheckupHistoryScope.needsEveryDisplay(chosenByHand: true))
   }

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -617,18 +617,38 @@ struct CopyBuilderTests {
     #expect(RotationCopy.previewSubtitle(name: "", to: .ninety) == "90°")
   }
 
+  /// The caption is derived from the ceiling the engine clamps to, per axis. It
+  /// said "320 to 8192" on both for a while, which was false for height: a 6000
+  /// the field accepted came back as 4320. The Retina half is the same ceiling
+  /// read against the doubled framebuffer the host requires it to fit.
+  @Test @MainActor func theVirtualDisplaySizeCaptionReadsTheRealCeilingOnEachAxis() {
+    let caption = VirtualDisplaysPane.sizeRangeCaption
+    #expect(caption.contains(String(VirtualDisplayIdentity.maxPixels.wide)))
+    #expect(caption.contains(String(VirtualDisplayIdentity.maxPixels.high)))
+    #expect(caption.contains(String(VirtualDisplaysPane.minimumPixels)))
+    #expect(VirtualDisplayIdentity.maxPixels.high != VirtualDisplayIdentity.maxPixels.wide)
+    #expect(caption.contains("Retina"))
+    #expect(caption.contains(String(VirtualDisplayIdentity.maxPixels.wide / 2)))
+    #expect(caption.contains(String(VirtualDisplayIdentity.maxPixels.high / 2)))
+  }
+
   @Test func rotationRefusalStatesItsOwnReasonForEveryCase() {
     let rendered = Self.allRotationRefusals.map { render(RotationCopy.refusal($0)) }
-    #expect(rendered.count == 5)
-    #expect(Set(rendered).count == 5)
+    #expect(rendered.count == 6)
+    #expect(Set(rendered).count == 6)
     #expect(render(RotationCopy.refusal(.unavailable)) == render(RotationCopy.unavailable))
     #expect(render(RotationCopy.refusal(.displayGone)).contains("disconnected before the change could be made"))
     #expect(render(RotationCopy.refusal(.unreadable)).contains("does not recognize"))
     #expect(render(RotationCopy.refusal(.unchanged(.ninety))).contains("already in this orientation"))
-    // Says what the display is doing, never that the person mirrored it: a
-    // synthesized size puts a panel in this state without anyone asking for
-    // mirroring, and this sentence is the settings row's caption there too.
+    // Says what the display is doing, never that the person mirrored it.
     #expect(render(RotationCopy.refusal(.mirrored)).contains("showing another display's image"))
+    // And the synthesis arm never borrows that sentence: a rendered size puts a
+    // panel in the same set with nobody having asked for mirroring, so it names
+    // the size and the control that turns it off. This is the settings row's
+    // caption there too.
+    let synthesized = render(RotationCopy.refusal(.synthesizedSize))
+    #expect(synthesized.contains("renders"))
+    #expect(!synthesized.contains("another display's image"))
   }
 
   @Test func rotationCountdownAndFixedSentences() {
@@ -1134,6 +1154,7 @@ struct CopyBuilderTests {
 
   private static let allRotationRefusals: [RotationRefusal] = [
     .unavailable, .displayGone, .unreadable, .unchanged(.ninety), .mirrored,
+    .synthesizedSize,
   ]
 
   private static func guardRotationRefusal(_ refusal: RotationRefusal) -> Int {
@@ -1143,6 +1164,7 @@ struct CopyBuilderTests {
     case .unreadable: 2
     case .unchanged: 3
     case .mirrored: 4
+    case .synthesizedSize: 5
     }
   }
 
@@ -1258,7 +1280,7 @@ struct CopyBuilderTests {
     #expect(Set(Self.allBrightnessPaths.map(Self.guardBrightnessPath)).count == 8)
     #expect(Set(Self.allReadEvidence.map(Self.guardReadEvidence)).count == 4)
     #expect(Set(Self.allMirrorRefusals.map(Self.guardMirrorRefusal)).count == 8)
-    #expect(Set(Self.allRotationRefusals.map(Self.guardRotationRefusal)).count == 5)
+    #expect(Set(Self.allRotationRefusals.map(Self.guardRotationRefusal)).count == 6)
     #expect(Set(Self.allModeReapplyNotices.map(Self.guardModeReapplyNotice)).count == 3)
     #expect(Set(Self.allStartFailureReasons.map(Self.guardStartFailureReason)).count == 2)
     #expect(Set(Self.allLockDimSkips.map(Self.guardLockDimSkip)).count == 4)

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -617,10 +617,8 @@ struct CopyBuilderTests {
     #expect(RotationCopy.previewSubtitle(name: "", to: .ninety) == "90°")
   }
 
-  /// The caption is derived from the ceiling the engine clamps to, per axis. It
-  /// said "320 to 8192" on both for a while, which was false for height: a 6000
-  /// the field accepted came back as 4320. The Retina half is the same ceiling
-  /// read against the doubled framebuffer the host requires it to fit.
+  /// Per axis: one literal for both promised a height the create path cut back.
+  /// Retina reads the same ceiling against the doubled framebuffer.
   @Test @MainActor func theVirtualDisplaySizeCaptionReadsTheRealCeilingOnEachAxis() {
     let caption = VirtualDisplaysPane.sizeRangeCaption
     #expect(caption.contains(String(VirtualDisplayIdentity.maxPixels.wide)))
@@ -642,10 +640,8 @@ struct CopyBuilderTests {
     #expect(render(RotationCopy.refusal(.unchanged(.ninety))).contains("already in this orientation"))
     // Says what the display is doing, never that the person mirrored it.
     #expect(render(RotationCopy.refusal(.mirrored)).contains("showing another display's image"))
-    // And the synthesis arm never borrows that sentence: a rendered size puts a
-    // panel in the same set with nobody having asked for mirroring, so it names
-    // the size and the control that turns it off. This is the settings row's
-    // caption there too.
+    // The synthesis arm never borrows that sentence: nobody asked for mirroring,
+    // so it names the size control instead.
     let synthesized = render(RotationCopy.refusal(.synthesizedSize))
     #expect(synthesized.contains("renders"))
     #expect(!synthesized.contains("another display's image"))

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -619,12 +619,16 @@ struct CopyBuilderTests {
 
   @Test func rotationRefusalStatesItsOwnReasonForEveryCase() {
     let rendered = Self.allRotationRefusals.map { render(RotationCopy.refusal($0)) }
-    #expect(rendered.count == 4)
-    #expect(Set(rendered).count == 4)
+    #expect(rendered.count == 5)
+    #expect(Set(rendered).count == 5)
     #expect(render(RotationCopy.refusal(.unavailable)) == render(RotationCopy.unavailable))
     #expect(render(RotationCopy.refusal(.displayGone)).contains("disconnected before the change could be made"))
     #expect(render(RotationCopy.refusal(.unreadable)).contains("does not recognize"))
     #expect(render(RotationCopy.refusal(.unchanged(.ninety))).contains("already in this orientation"))
+    // Says what the display is doing, never that the person mirrored it: a
+    // synthesized size puts a panel in this state without anyone asking for
+    // mirroring, and this sentence is the settings row's caption there too.
+    #expect(render(RotationCopy.refusal(.mirrored)).contains("showing another display's image"))
   }
 
   @Test func rotationCountdownAndFixedSentences() {
@@ -1129,7 +1133,7 @@ struct CopyBuilderTests {
   }
 
   private static let allRotationRefusals: [RotationRefusal] = [
-    .unavailable, .displayGone, .unreadable, .unchanged(.ninety),
+    .unavailable, .displayGone, .unreadable, .unchanged(.ninety), .mirrored,
   ]
 
   private static func guardRotationRefusal(_ refusal: RotationRefusal) -> Int {
@@ -1138,6 +1142,7 @@ struct CopyBuilderTests {
     case .displayGone: 1
     case .unreadable: 2
     case .unchanged: 3
+    case .mirrored: 4
     }
   }
 
@@ -1253,7 +1258,7 @@ struct CopyBuilderTests {
     #expect(Set(Self.allBrightnessPaths.map(Self.guardBrightnessPath)).count == 8)
     #expect(Set(Self.allReadEvidence.map(Self.guardReadEvidence)).count == 4)
     #expect(Set(Self.allMirrorRefusals.map(Self.guardMirrorRefusal)).count == 8)
-    #expect(Set(Self.allRotationRefusals.map(Self.guardRotationRefusal)).count == 4)
+    #expect(Set(Self.allRotationRefusals.map(Self.guardRotationRefusal)).count == 5)
     #expect(Set(Self.allModeReapplyNotices.map(Self.guardModeReapplyNotice)).count == 3)
     #expect(Set(Self.allStartFailureReasons.map(Self.guardStartFailureReason)).count == 2)
     #expect(Set(Self.allLockDimSkips.map(Self.guardLockDimSkip)).count == 4)

--- a/CandelaAppTests/PanelRowModelTests.swift
+++ b/CandelaAppTests/PanelRowModelTests.swift
@@ -519,3 +519,21 @@ struct CombinedBrightnessRowTests {
     #expect(row.value == 0.4)
   }
 }
+
+/// The empty state's second line names a pane, and the two panes are different
+/// pages: a laptop sent to Displays finds no switch there.
+@Suite("Panel empty state")
+@MainActor
+struct PanelEmptyStateTests {
+  @Test func aHiddenBuiltInAloneIsUndoneOnTheMenuBarPane() {
+    let hint = PanelView.unhideHint(hasExternals: false)
+    #expect(hint.contains("Menu Bar"))
+    #expect(hint.contains("Displays") == false)
+  }
+
+  @Test func aHiddenExternalIsUndoneOnItsOwnPage() {
+    let hint = PanelView.unhideHint(hasExternals: true)
+    #expect(hint.contains("Displays"))
+    #expect(hint.contains("Menu Bar") == false)
+  }
+}

--- a/CandelaAppTests/PanelRowModelTests.swift
+++ b/CandelaAppTests/PanelRowModelTests.swift
@@ -340,10 +340,8 @@ struct PanelRowModelTests {
     ) == nil)
   }
 
-  /// The button greys on the capability, so the caption is the only thing
-  /// standing between a person and a grey control with no reason on it. It is
-  /// the panel's own sentence, not the diagnostics row's: that one is written to
-  /// be read with the two causes that follow it there.
+  /// The panel's own sentence, not the diagnostics row's, which is written to be
+  /// read with the two causes that follow it there.
   @Test func theHDRButtonExplainsItselfOnADisplayThatReportsNoHDRModes() {
     #expect(PanelView.hdrRefusalReason(
       isShowingSynthesizedSize: false, isHDREngaged: false,
@@ -378,10 +376,8 @@ struct PanelRowModelTests {
     ) == nil)
   }
 
-  /// The greying and the caption move together, which is the whole point of
-  /// reading the probe flag here: before it lands the button is grey and silent,
-  /// after it lands a display with no HDR modes is grey and says so, and one
-  /// that has them is live.
+  /// Greying and caption move together: grey and silent before the probe lands,
+  /// grey and captioned after a no, live after a yes.
   @Test func theHDRButtonGreysUntilTheProbeAnswersAndThenAgreesWithItsCaption() {
     func enabled(supportsHDR: Bool, probed: Bool) -> Bool {
       PanelView.hdrButtonIsEnabled(
@@ -408,9 +404,8 @@ struct PanelRowModelTests {
     ))
   }
 
-  /// With HDR live this button is the ONLY way out of it, so nothing greys it.
-  /// A panel swap drops the probe flag while the engaged cache still reads true,
-  /// which is exactly the reading that used to take the exit away.
+  /// With HDR live this button is the only way out. A panel swap drops the probe
+  /// flag while the engaged cache still reads true, which used to grey the exit.
   @Test func theHDRExitStaysLiveEvenWhileTheProbeIsOutstanding() {
     for probed in [false, true] {
       for supportsHDR in [false, true] {
@@ -632,8 +627,7 @@ struct PanelEmptyStateTests {
     #expect(hint.contains("Menu Bar") == false)
   }
 
-  /// A clamshell rig that later opens with both kinds hidden. Naming only
-  /// Displays sends someone looking for the built-in's switch where it is not.
+  /// A clamshell rig opened later with both kinds hidden.
   @Test func bothKindsHiddenNamesBothPanes() {
     let hint = PanelView.unhideHint(builtInHidden: true, externalsHidden: true)
     #expect(hint.contains("Menu Bar"))

--- a/CandelaAppTests/PanelRowModelTests.swift
+++ b/CandelaAppTests/PanelRowModelTests.swift
@@ -314,17 +314,20 @@ struct PanelRowModelTests {
 
   @Test func theHDRButtonExplainsItselfWhileASynthesizedSizeIsShowing() {
     let reason = PanelView.hdrRefusalReason(
-      isShowingSynthesizedSize: true, isHDREngaged: false
+      isShowingSynthesizedSize: true, isHDREngaged: false,
+      supportsHDR: true, capabilityProbed: true
     )
     #expect(reason == SynthesisCopy.hdrBlockedBySynthesizedSize)
   }
 
   @Test func theHDRButtonIsUnrefusedWithNoSizeEngaged() {
     #expect(PanelView.hdrRefusalReason(
-      isShowingSynthesizedSize: false, isHDREngaged: false
+      isShowingSynthesizedSize: false, isHDREngaged: false,
+      supportsHDR: true, capabilityProbed: true
     ) == nil)
     #expect(PanelView.hdrRefusalReason(
-      isShowingSynthesizedSize: false, isHDREngaged: true
+      isShowingSynthesizedSize: false, isHDREngaged: true,
+      supportsHDR: true, capabilityProbed: true
     ) == nil)
   }
 
@@ -332,7 +335,44 @@ struct PanelRowModelTests {
   /// display out of the HDR-over-a-size combination is never the greyed one.
   @Test func theHDRExitIsOfferedEvenWithASizeEngaged() {
     #expect(PanelView.hdrRefusalReason(
-      isShowingSynthesizedSize: true, isHDREngaged: true
+      isShowingSynthesizedSize: true, isHDREngaged: true,
+      supportsHDR: true, capabilityProbed: true
+    ) == nil)
+  }
+
+  /// The button greys on `supportsHDR` alone, so the caption is the only thing
+  /// standing between a person and a grey control with no reason on it.
+  @Test func theHDRButtonExplainsItselfOnADisplayThatReportsNoHDRModes() {
+    #expect(PanelView.hdrRefusalReason(
+      isShowingSynthesizedSize: false, isHDREngaged: false,
+      supportsHDR: false, capabilityProbed: true
+    ) == DiagnosticsCopy.hdrNoAnswer(app: AppInfo.productName))
+  }
+
+  /// The libel case: `supportsHDR` reads false before the async capability refresh
+  /// answers, so an unprobed display must say nothing rather than say no.
+  @Test func theHDRButtonSaysNothingBeforeTheCapabilityRefreshLands() {
+    #expect(PanelView.hdrRefusalReason(
+      isShowingSynthesizedSize: false, isHDREngaged: false,
+      supportsHDR: false, capabilityProbed: false
+    ) == nil)
+  }
+
+  /// A size engaged on a display with no HDR modes: dropping the size would not
+  /// bring HDR, so the caption names the capability rather than the size.
+  @Test func theCapabilityRefusalOutranksTheSizeRefusal() {
+    #expect(PanelView.hdrRefusalReason(
+      isShowingSynthesizedSize: true, isHDREngaged: false,
+      supportsHDR: false, capabilityProbed: true
+    ) == DiagnosticsCopy.hdrNoAnswer(app: AppInfo.productName))
+  }
+
+  /// HDR live on a display whose last probe said it has none: the exit stays
+  /// offered and unexplained, the recovery-control rule the engaged guard exists for.
+  @Test func theHDRExitIsOfferedEvenWhenTheProbeSaysNoHDR() {
+    #expect(PanelView.hdrRefusalReason(
+      isShowingSynthesizedSize: false, isHDREngaged: true,
+      supportsHDR: false, capabilityProbed: true
     ) == nil)
   }
 

--- a/CandelaAppTests/PanelRowModelTests.swift
+++ b/CandelaAppTests/PanelRowModelTests.swift
@@ -340,13 +340,15 @@ struct PanelRowModelTests {
     ) == nil)
   }
 
-  /// The button greys on `supportsHDR` alone, so the caption is the only thing
-  /// standing between a person and a grey control with no reason on it.
+  /// The button greys on the capability, so the caption is the only thing
+  /// standing between a person and a grey control with no reason on it. It is
+  /// the panel's own sentence, not the diagnostics row's: that one is written to
+  /// be read with the two causes that follow it there.
   @Test func theHDRButtonExplainsItselfOnADisplayThatReportsNoHDRModes() {
     #expect(PanelView.hdrRefusalReason(
       isShowingSynthesizedSize: false, isHDREngaged: false,
       supportsHDR: false, capabilityProbed: true
-    ) == DiagnosticsCopy.hdrNoAnswer(app: AppInfo.productName))
+    ) == PanelView.hdrNoModesCaption)
   }
 
   /// The libel case: `supportsHDR` reads false before the async capability refresh
@@ -364,7 +366,7 @@ struct PanelRowModelTests {
     #expect(PanelView.hdrRefusalReason(
       isShowingSynthesizedSize: true, isHDREngaged: false,
       supportsHDR: false, capabilityProbed: true
-    ) == DiagnosticsCopy.hdrNoAnswer(app: AppInfo.productName))
+    ) == PanelView.hdrNoModesCaption)
   }
 
   /// HDR live on a display whose last probe said it has none: the exit stays
@@ -374,6 +376,59 @@ struct PanelRowModelTests {
       isShowingSynthesizedSize: false, isHDREngaged: true,
       supportsHDR: false, capabilityProbed: true
     ) == nil)
+  }
+
+  /// The greying and the caption move together, which is the whole point of
+  /// reading the probe flag here: before it lands the button is grey and silent,
+  /// after it lands a display with no HDR modes is grey and says so, and one
+  /// that has them is live.
+  @Test func theHDRButtonGreysUntilTheProbeAnswersAndThenAgreesWithItsCaption() {
+    func enabled(supportsHDR: Bool, probed: Bool) -> Bool {
+      PanelView.hdrButtonIsEnabled(
+        isHDREngaged: false, capabilityProbed: probed, supportsHDR: supportsHDR,
+        refusalReason: PanelView.hdrRefusalReason(
+          isShowingSynthesizedSize: false, isHDREngaged: false,
+          supportsHDR: supportsHDR, capabilityProbed: probed
+        )
+      )
+    }
+    // Unprobed, either reading of a cache nothing has filled for this panel yet.
+    #expect(!enabled(supportsHDR: false, probed: false))
+    #expect(!enabled(supportsHDR: true, probed: false))
+    #expect(!enabled(supportsHDR: false, probed: true))
+    #expect(enabled(supportsHDR: true, probed: true))
+  }
+
+  /// A refusal greys the button even where the capability is there, which is how
+  /// the synthesized-size caption gets a control to sit under.
+  @Test func aRefusalGreysAnOtherwiseCapableHDRButton() {
+    #expect(!PanelView.hdrButtonIsEnabled(
+      isHDREngaged: false, capabilityProbed: true, supportsHDR: true,
+      refusalReason: SynthesisCopy.hdrBlockedBySynthesizedSize
+    ))
+  }
+
+  /// With HDR live this button is the ONLY way out of it, so nothing greys it.
+  /// A panel swap drops the probe flag while the engaged cache still reads true,
+  /// which is exactly the reading that used to take the exit away.
+  @Test func theHDRExitStaysLiveEvenWhileTheProbeIsOutstanding() {
+    for probed in [false, true] {
+      for supportsHDR in [false, true] {
+        #expect(PanelView.hdrButtonIsEnabled(
+          isHDREngaged: true, capabilityProbed: probed, supportsHDR: supportsHDR,
+          refusalReason: PanelView.hdrRefusalReason(
+            isShowingSynthesizedSize: true, isHDREngaged: true,
+            supportsHDR: supportsHDR, capabilityProbed: probed
+          )
+        ))
+      }
+    }
+  }
+
+  /// Says what was looked for and not found, never that the app does not know.
+  @Test func theNoHDRCaptionNamesTheObservationRatherThanTheAppsIgnorance() {
+    #expect(PanelView.hdrNoModesCaption == "No HDR modes were found for this display.")
+    #expect(PanelView.hdrNoModesCaption != DiagnosticsCopy.hdrNoAnswer(app: AppInfo.productName))
   }
 
   /// The sentence is the mirror of the synthesized-size refusal, and it names
@@ -566,14 +621,22 @@ struct CombinedBrightnessRowTests {
 @MainActor
 struct PanelEmptyStateTests {
   @Test func aHiddenBuiltInAloneIsUndoneOnTheMenuBarPane() {
-    let hint = PanelView.unhideHint(hasExternals: false)
+    let hint = PanelView.unhideHint(builtInHidden: true, externalsHidden: false)
     #expect(hint.contains("Menu Bar"))
     #expect(hint.contains("Displays") == false)
   }
 
   @Test func aHiddenExternalIsUndoneOnItsOwnPage() {
-    let hint = PanelView.unhideHint(hasExternals: true)
+    let hint = PanelView.unhideHint(builtInHidden: false, externalsHidden: true)
     #expect(hint.contains("Displays"))
     #expect(hint.contains("Menu Bar") == false)
+  }
+
+  /// A clamshell rig that later opens with both kinds hidden. Naming only
+  /// Displays sends someone looking for the built-in's switch where it is not.
+  @Test func bothKindsHiddenNamesBothPanes() {
+    let hint = PanelView.unhideHint(builtInHidden: true, externalsHidden: true)
+    #expect(hint.contains("Menu Bar"))
+    #expect(hint.contains("Displays"))
   }
 }

--- a/CandelaAppTests/SettingsSwitchAXLabelTests.swift
+++ b/CandelaAppTests/SettingsSwitchAXLabelTests.swift
@@ -5,14 +5,10 @@ import Foundation
 import SwiftUI
 import Testing
 
-/// Reads the accessibility tree a settings page publishes, not its source.
-///
-/// `themedSwitch` stands a real `Toggle` in through
-/// `accessibilityRepresentation`, and the representation is handed
-/// `configuration.label` as a VIEW. Measured 2026-09-03 against the deployed
-/// app: that view does not become a description, so a switch row announces as a
-/// bare checkbox unless the call site adds `.accessibilityLabel`. This suite is
-/// what keeps the two rows it names from losing theirs again.
+/// Reads the accessibility tree a page publishes, not its source. `themedSwitch`
+/// hands its representation `configuration.label` as a view, which never becomes
+/// a description, so a switch announces as a bare checkbox unless the call site
+/// adds `.accessibilityLabel`.
 @MainActor
 @Suite("Settings switch accessibility labels")
 struct SettingsSwitchAXLabelTests {
@@ -54,8 +50,7 @@ struct SettingsSwitchAXLabelTests {
     labels(view, role: .checkBox, height: height)
   }
 
-  /// Proves the walk can fail, and pins the defect this sweep fixed: the same
-  /// row without the explicit label publishes nothing to read.
+  /// Proves the walk can fail: the same row without the label publishes nothing.
   @Test func aThemedSwitchSpeaksOnlyWhenTheCallSiteLabelsIt() {
     let bare = SettingsCardSection(title: "Probe") {
       SettingRow("What this switch changes.") {
@@ -94,8 +89,7 @@ struct SettingsSwitchAXLabelTests {
     #expect(!spoken.contains(""))
   }
 
-  /// A text field publishes no description of its own either, and the
-  /// `LabeledContent` around one draws its label without publishing it. The
+  /// `LabeledContent` draws a field's label without publishing it. The
   /// control-code fields are the page's only fields.
   @Test func theAdvancedPageFieldsSpeakTheirOwnCopy() {
     let spoken = labels(advancedPage(), role: .textField)

--- a/CandelaAppTests/SettingsSwitchAXLabelTests.swift
+++ b/CandelaAppTests/SettingsSwitchAXLabelTests.swift
@@ -1,0 +1,105 @@
+import AppKit
+import CandelaKit
+import CoreGraphics
+import Foundation
+import SwiftUI
+import Testing
+
+/// Reads the accessibility tree a settings page publishes, not its source.
+///
+/// `themedSwitch` stands a real `Toggle` in through
+/// `accessibilityRepresentation`, and the representation is handed
+/// `configuration.label` as a VIEW. Measured 2026-09-03 against the deployed
+/// app: that view does not become a description, so a switch row announces as a
+/// bare checkbox unless the call site adds `.accessibilityLabel`. This suite is
+/// what keeps the two rows it names from losing theirs again.
+@MainActor
+@Suite("Settings switch accessibility labels")
+struct SettingsSwitchAXLabelTests {
+
+  /// SwiftUI builds no accessibility nodes until an assistive client attaches,
+  /// and a test process is not one.
+  private func attachAnAssistiveClient() {
+    _ = NSApplication.shared
+    (NSApp as NSObject).accessibilitySetValue(
+      true, forAttribute: NSAccessibility.Attribute(rawValue: "AXEnhancedUserInterface"))
+  }
+
+  private func collect(
+    _ element: Any, role: NSAccessibility.Role, depth: Int, into found: inout [AnyObject]
+  ) {
+    guard depth < 32 else { return }
+    let object = element as AnyObject
+    if (object.accessibilityRole?() ?? nil) == role { found.append(object) }
+    for child in (object.accessibilityChildren?() ?? nil) ?? [] {
+      collect(child, role: role, depth: depth + 1, into: &found)
+    }
+  }
+
+  /// Tall enough that a scrolling page lays its whole content out: a row the
+  /// layout never reached would look like a row with no label.
+  private func labels(
+    _ view: some View, role: NSAccessibility.Role, height: CGFloat = 1600
+  ) -> [String] {
+    attachAnAssistiveClient()
+    let host = NSHostingView(rootView: view.frame(width: 720, height: height))
+    host.frame = NSRect(x: 0, y: 0, width: 720, height: height)
+    host.layoutSubtreeIfNeeded()
+    var found: [AnyObject] = []
+    collect(host, role: role, depth: 0, into: &found)
+    return found.map { ($0.accessibilityLabel?() ?? nil) ?? "" }
+  }
+
+  private func switchLabels(_ view: some View, height: CGFloat = 1600) -> [String] {
+    labels(view, role: .checkBox, height: height)
+  }
+
+  /// Proves the walk can fail, and pins the defect this sweep fixed: the same
+  /// row without the explicit label publishes nothing to read.
+  @Test func aThemedSwitchSpeaksOnlyWhenTheCallSiteLabelsIt() {
+    let bare = SettingsCardSection(title: "Probe") {
+      SettingRow("What this switch changes.") {
+        Toggle("Probe switch", isOn: .constant(true)).themedSwitch()
+      }
+    }
+    #expect(switchLabels(bare, height: 200) == [""])
+
+    let labelled = SettingsCardSection(title: "Probe") {
+      SettingRow("What this switch changes.") {
+        Toggle("Probe switch", isOn: .constant(true))
+          .themedSwitch()
+          .accessibilityLabel("Probe switch")
+      }
+    }
+    #expect(switchLabels(labelled, height: 200) == ["Probe switch"])
+  }
+
+  @MainActor private func advancedPage() -> some View {
+    let model = TestFixtures.appModel()
+    let state = TestFixtures.displayState(name: "AX Panel", persistenceKey: "ax-panel")
+    return AdvancedPage(
+      state: state, displays: [("ax-panel", "AX Panel")], onSwitch: { _ in }
+    )
+    .environment(model)
+    .environment(SettingsActions(model: model))
+    .environment(\.settingsAccent, .display(isBuiltIn: false, ordinal: 0))
+  }
+
+  @Test func theAdvancedPageSwitchesSpeakTheirOwnCopy() {
+    let spoken = switchLabels(advancedPage())
+    #expect(spoken.contains("Dim with a screen overlay"))
+    #expect(spoken.contains("Show the volume indicator"))
+    // The hardware-control row takes its label from `SettingRow`'s safety form,
+    // so it is the check that this page has no unlabelled switch at all.
+    #expect(!spoken.contains(""))
+  }
+
+  /// A text field publishes no description of its own either, and the
+  /// `LabeledContent` around one draws its label without publishing it. The
+  /// control-code fields are the page's only fields.
+  @Test func theAdvancedPageFieldsSpeakTheirOwnCopy() {
+    let spoken = labels(advancedPage(), role: .textField)
+    #expect(!spoken.isEmpty)
+    #expect(!spoken.contains(""))
+  }
+}

--- a/CandelaAppTests/SynthesisGateTests.swift
+++ b/CandelaAppTests/SynthesisGateTests.swift
@@ -265,16 +265,9 @@ struct SynthesisGateTests {
     #expect(fixture.synthesis.refusalReason(for: engaged) == nil)
   }
 
-  /// The pref-free teardown refuses a gate it could not claim, as the opt-out
-  /// already did. It is the mirror hotkey's unwind, so without this it tore a
-  /// set down behind another feature's open reconfiguration and answered true,
-  /// leaving its caller to stage a raw mirror change over the result.
-  ///
-  /// The whole-app reset is the one caller that goes on without the claim, and
-  /// only after waiting for it: it is wiping the domain and rebuilding, so a set
-  /// left standing there would outlive everything that knows about it. The
-  /// window is collapsed to nothing here, which is the never-clears case at test
-  /// speed.
+  /// The hotkey's unwind used to tear a set down behind another feature's open
+  /// reconfiguration and answer true. Only the whole-app reset may go on without
+  /// the claim, and only after its wait; a zero window is the never-clears case.
   @Test func aRefusedGateStopsTheUnwindAndTheResetProceedsOnlyAfterItsWait() async throws {
     let fixture = Fixture()
     defer { fixture.forgetPrefs() }
@@ -301,19 +294,14 @@ struct SynthesisGateTests {
     #expect(forced)
     #expect(fixture.synthesis.pairings.isEmpty)
 
-    // Still ours: the forced pass never took the claim, so it must not have
-    // given one back either.
+    // The forced pass never took the claim, so it must not have released one.
     #expect(await fixture.gate.holder == .mirroring)
     await fixture.gate.release(.mirroring)
   }
 
-  /// The other half of the same contract: a holder that lets go inside the
-  /// window is WAITED for, so the reset's teardown runs under its own claim
-  /// rather than alongside somebody else's configuration.
-  ///
-  /// The flag is what separates a wait from a barge. A barge returns while the
-  /// releasing task is still asleep, so it sees the flag unset; only an
-  /// implementation that retried until the gate came free can see it set.
+  /// A holder that lets go inside the window is waited for. The flag separates
+  /// a wait from a barge: a barge returns while the releaser is still asleep and
+  /// sees it unset.
   @Test func aResetWaitsOutAGateHolderThatLetsGoInsideTheWindow() async throws {
     let fixture = Fixture()
     defer { fixture.forgetPrefs() }
@@ -345,22 +333,15 @@ struct SynthesisGateTests {
       await signal.released,
       "the forced pass must wait the holder out rather than barge past it"
     )
-    // The claim it waited for is now ITS claim. The fixture leaves
-    // `releaseClaimIfIdle` unwired, so nothing hands it back here; in the app
-    // the reset's rebuild does. A barge would have left the gate free instead,
-    // since the releasing task above let go of it.
+    // Now its own claim; a barge would have left the gate free. The fixture
+    // leaves `releaseClaimIfIdle` unwired, so nothing hands it back here.
     #expect(await fixture.gate.holder == .displayModes, "the reset holds the claim it waited for")
     await fixture.gate.release(.displayModes)
   }
 
-  /// Both slots taken, and the attended guard answers what the unattended one
-  /// already answered: the reapply pass has skipped on `freeSlots` since it was
-  /// written, while the picker offered the stops anyway and let the engine
-  /// refuse at the allocation.
-  ///
-  /// The engaged panel is the half that makes this a slot question rather than a
-  /// blanket one: an engage tears its own pairing down before it allocates, so
-  /// its slot is free by the time it asks.
+  /// The picker used to offer stops with both slots taken and let the engine
+  /// refuse at allocation. The engaged panel stays unrefused: an engage frees
+  /// its own slot before it allocates.
   @Test func aThirdDisplayIsRefusedOnceBothSynthesisSlotsAreTaken() async throws {
     let fixture = Fixture(secondPanel: true)
     defer { fixture.forgetPrefs() }
@@ -372,8 +353,7 @@ struct SynthesisGateTests {
     _ = await fixture.synthesis.engage(stop, on: second)
     #expect(fixture.synthesis.freeSlots == 0, "the fixture's own control")
 
-    // Never attached to the world: the guard is asked about the display it is
-    // handed, and a third panel on this rig would only be scenery.
+    // Never attached: the guard only reads the display it is handed.
     let third = ConfiguredDisplay(
       id: 11,
       identity: DisplayConfigIdentity(vendor: 0x3669, model: 3, serial: 3, isBuiltIn: false),
@@ -383,18 +363,10 @@ struct SynthesisGateTests {
     #expect(fixture.synthesis.refusalReason(for: first) == nil)
   }
 
-  /// A hardware sequence that STARTS inside the teardown refuses it, even
-  /// though the gate said yes.
-  ///
-  /// The top-of-function `isWorking` reading is taken before two awaits, the
-  /// preview stand-down and the claim, and before the forced path's wait of up
-  /// to two seconds. The gate cannot stand in for it: `claim` is re-entrant per
-  /// claimant and synthesis claims `.displayModes`, the same claimant the mode
-  /// coordinator uses, so a mode preview or apply starting in that window is
-  /// GRANTED rather than refused. Only the second reading catches it.
-  ///
-  /// Driven through the stand-down seam because that is one of the real awaits:
-  /// in the app it enters the mode coordinator's serial queue.
+  /// A sequence that starts inside the teardown refuses it even with the gate
+  /// granted: the mode coordinator shares the `.displayModes` claimant, so only
+  /// the second `isWorking` reading catches it. Driven through the stand-down
+  /// seam because that is one of the real awaits.
   @Test func aSequenceStartingInsideTheTeardownRefusesItEvenWithTheGateGranted() async throws {
     let fixture = Fixture(secondPanel: true)
     defer { fixture.forgetPrefs() }
@@ -406,17 +378,14 @@ struct SynthesisGateTests {
     #expect(fixture.synthesis.isEngaged(displayID: Self.panelID))
     #expect(!fixture.synthesis.isWorking, "the fixture's own control: the teardown starts idle")
 
-    // Parked in `create`, so the interloping engage holds the working depth up
-    // for as long as this test wants it. Armed only now: the engage above had to
-    // land.
+    // Parks the interloping engage in `create` for as long as the test wants.
+    // Armed only now, after the engage above landed.
     let entered = DispatchSemaphore(value: 0)
     let proceed = DispatchSemaphore(value: 0)
     fixture.host.onCreate = {
       entered.signal()
-      // DEADLINED, unlike the parks above: the release comes after the teardown
-      // returns, so a teardown that ran on regardless would block on the engine
-      // executor this park is holding. Ten seconds turns that hang into a
-      // failing expectation.
+      // Deadlined: a teardown that ran on regardless would block on the executor
+      // this park holds, and the release only comes after it returns.
       _ = proceed.wait(timeout: .now() + 10)
     }
 
@@ -440,9 +409,7 @@ struct SynthesisGateTests {
       fixture.synthesis.isEngaged(displayID: Self.panelID),
       "and the refusal must leave the set exactly where it found it"
     )
-    // The claim is deliberately NOT handed back on this path: the sequence now
-    // running shares the `.displayModes` claimant, so a release here would take
-    // the gate out from under it.
+    // Not released: the running sequence shares the claimant.
     #expect(await fixture.gate.holder == .displayModes)
 
     proceed.signal()
@@ -465,9 +432,8 @@ struct SynthesisGateTests {
 
 }
 
-/// Waits for a semaphore off the cooperative pool, deadlined: a blocked thread is
-/// not a suspended one, so an unbounded wait here would hang the suite past any
-/// cancellation. Five seconds is orders of magnitude past what the fakes need.
+/// Off the cooperative pool and deadlined: a blocked thread ignores cancellation,
+/// so an unbounded wait would hang the suite.
 private func awaitSignal(_ semaphore: DispatchSemaphore) async -> Bool {
   await withCheckedContinuation { continuation in
     DispatchQueue.global().async {
@@ -476,8 +442,7 @@ private func awaitSignal(_ semaphore: DispatchSemaphore) async -> Bool {
   }
 }
 
-/// A one-way flag shared by the releasing task and the assertion that reads it,
-/// so "did the reset wait" is something the test observes rather than times.
+/// Lets the test observe, rather than time, whether the reset waited.
 private actor ReleaseSignal {
   private(set) var released = false
   func markReleased() { released = true }

--- a/CandelaAppTests/SynthesisGateTests.swift
+++ b/CandelaAppTests/SynthesisGateTests.swift
@@ -270,10 +270,12 @@ struct SynthesisGateTests {
   /// set down behind another feature's open reconfiguration and answered true,
   /// leaving its caller to stage a raw mirror change over the result.
   ///
-  /// The whole-app reset is the one caller that presses on: it is wiping the
-  /// domain and rebuilding, so a set left standing there would outlive
-  /// everything that knows about it.
-  @Test func aRefusedGateStopsTheUnwindUnlessTheResetForcesIt() async throws {
+  /// The whole-app reset is the one caller that goes on without the claim, and
+  /// only after waiting for it: it is wiping the domain and rebuilding, so a set
+  /// left standing there would outlive everything that knows about it. The
+  /// window is collapsed to nothing here, which is the never-clears case at test
+  /// speed.
+  @Test func aRefusedGateStopsTheUnwindAndTheResetProceedsOnlyAfterItsWait() async throws {
     let fixture = Fixture()
     defer { fixture.forgetPrefs() }
     let display = try fixture.configured(Self.panelID)
@@ -293,13 +295,62 @@ struct SynthesisGateTests {
       "a refusal must leave the set exactly where it found it"
     )
 
-    let forced = await fixture.synthesis.disengageAllForReset(force: true)
+    let forced = await fixture.synthesis.disengageAllForReset(
+      force: true, forcedClaimWait: .zero, forcedClaimRetryDelay: .zero
+    )
     #expect(forced)
     #expect(fixture.synthesis.pairings.isEmpty)
 
     // Still ours: the forced pass never took the claim, so it must not have
     // given one back either.
+    #expect(await fixture.gate.holder == .mirroring)
     await fixture.gate.release(.mirroring)
+  }
+
+  /// The other half of the same contract: a holder that lets go inside the
+  /// window is WAITED for, so the reset's teardown runs under its own claim
+  /// rather than alongside somebody else's configuration.
+  ///
+  /// The flag is what separates a wait from a barge. A barge returns while the
+  /// releasing task is still asleep, so it sees the flag unset; only an
+  /// implementation that retried until the gate came free can see it set.
+  @Test func aResetWaitsOutAGateHolderThatLetsGoInsideTheWindow() async throws {
+    let fixture = Fixture()
+    defer { fixture.forgetPrefs() }
+    let display = try fixture.configured(Self.panelID)
+    let stop = try #require(fixture.modes.catalogs[Self.panelID]?.syntheticStops.first)
+
+    _ = await fixture.synthesis.engage(stop, on: display)
+    #expect(fixture.synthesis.isEngaged(displayID: Self.panelID))
+
+    let held = await fixture.gate.claim(.mirroring)
+    #expect(held.isGranted, "the fixture's own control")
+
+    let signal = ReleaseSignal()
+    let gate = fixture.gate
+    let releaser = Task {
+      try? await Task.sleep(for: .milliseconds(150))
+      await signal.markReleased()
+      await gate.release(.mirroring)
+    }
+
+    let forced = await fixture.synthesis.disengageAllForReset(
+      force: true, forcedClaimWait: .seconds(5), forcedClaimRetryDelay: .milliseconds(10)
+    )
+    await releaser.value
+
+    #expect(forced)
+    #expect(fixture.synthesis.pairings.isEmpty)
+    #expect(
+      await signal.released,
+      "the forced pass must wait the holder out rather than barge past it"
+    )
+    // The claim it waited for is now ITS claim. The fixture leaves
+    // `releaseClaimIfIdle` unwired, so nothing hands it back here; in the app
+    // the reset's rebuild does. A barge would have left the gate free instead,
+    // since the releasing task above let go of it.
+    #expect(await fixture.gate.holder == .displayModes, "the reset holds the claim it waited for")
+    await fixture.gate.release(.displayModes)
   }
 
   /// Both slots taken, and the attended guard answers what the unattended one
@@ -332,8 +383,76 @@ struct SynthesisGateTests {
     #expect(fixture.synthesis.refusalReason(for: first) == nil)
   }
 
-  /// The control for the test above: with nothing selected the gate is free, so
-  /// the refusal there is about the operation rather than about a gate that
+  /// A hardware sequence that STARTS inside the teardown refuses it, even
+  /// though the gate said yes.
+  ///
+  /// The top-of-function `isWorking` reading is taken before two awaits, the
+  /// preview stand-down and the claim, and before the forced path's wait of up
+  /// to two seconds. The gate cannot stand in for it: `claim` is re-entrant per
+  /// claimant and synthesis claims `.displayModes`, the same claimant the mode
+  /// coordinator uses, so a mode preview or apply starting in that window is
+  /// GRANTED rather than refused. Only the second reading catches it.
+  ///
+  /// Driven through the stand-down seam because that is one of the real awaits:
+  /// in the app it enters the mode coordinator's serial queue.
+  @Test func aSequenceStartingInsideTheTeardownRefusesItEvenWithTheGateGranted() async throws {
+    let fixture = Fixture(secondPanel: true)
+    defer { fixture.forgetPrefs() }
+    let display = try fixture.configured(Self.panelID)
+    let second = try fixture.configured(Self.secondPanelID)
+    let stop = try #require(fixture.modes.catalogs[Self.panelID]?.syntheticStops.first)
+
+    _ = await fixture.synthesis.engage(stop, on: display)
+    #expect(fixture.synthesis.isEngaged(displayID: Self.panelID))
+    #expect(!fixture.synthesis.isWorking, "the fixture's own control: the teardown starts idle")
+
+    // Parked in `create`, so the interloping engage holds the working depth up
+    // for as long as this test wants it. Armed only now: the engage above had to
+    // land.
+    let entered = DispatchSemaphore(value: 0)
+    let proceed = DispatchSemaphore(value: 0)
+    fixture.host.onCreate = {
+      entered.signal()
+      // DEADLINED, unlike the parks above: the release comes after the teardown
+      // returns, so a teardown that ran on regardless would block on the engine
+      // executor this park is holding. Ten seconds turns that hang into a
+      // failing expectation.
+      _ = proceed.wait(timeout: .now() + 10)
+    }
+
+    let teardownReachedTheSeam = DispatchSemaphore(value: 0)
+    let interloper = Task { @MainActor [synthesis = fixture.synthesis] in
+      _ = await awaitSignal(teardownReachedTheSeam)
+      _ = await synthesis.engage(stop, on: second)
+    }
+    // Hands the main actor to the interloper and comes back once it is parked in
+    // the engine, which is the interleaving under test.
+    fixture.synthesis.endOutstandingPreview = {
+      teardownReachedTheSeam.signal()
+      return await awaitSignal(entered)
+    }
+
+    let unwound = await fixture.synthesis.disengageAllForReset()
+
+    #expect(fixture.synthesis.isWorking, "the fixture's own control: a sequence really did start")
+    #expect(!unwound, "a sequence that started inside the teardown must refuse it")
+    #expect(
+      fixture.synthesis.isEngaged(displayID: Self.panelID),
+      "and the refusal must leave the set exactly where it found it"
+    )
+    // The claim is deliberately NOT handed back on this path: the sequence now
+    // running shares the `.displayModes` claimant, so a release here would take
+    // the gate out from under it.
+    #expect(await fixture.gate.holder == .displayModes)
+
+    proceed.signal()
+    await interloper.value
+    await fixture.settle()
+    await fixture.gate.release(.displayModes)
+  }
+
+  /// The control for the refusal tests: with nothing selected the gate is free,
+  /// so a refusal there is about the operation rather than about a gate that
   /// refuses everything.
   @Test func theGateIsFreeWithNoSelectionOutstanding() async {
     let fixture = Fixture()
@@ -344,4 +463,22 @@ struct SynthesisGateTests {
     await fixture.revertAnyPreview()
   }
 
+}
+
+/// Waits for a semaphore off the cooperative pool, deadlined: a blocked thread is
+/// not a suspended one, so an unbounded wait here would hang the suite past any
+/// cancellation. Five seconds is orders of magnitude past what the fakes need.
+private func awaitSignal(_ semaphore: DispatchSemaphore) async -> Bool {
+  await withCheckedContinuation { continuation in
+    DispatchQueue.global().async {
+      continuation.resume(returning: semaphore.wait(timeout: .now() + 5) == .success)
+    }
+  }
+}
+
+/// A one-way flag shared by the releasing task and the assertion that reads it,
+/// so "did the reset wait" is something the test observes rather than times.
+private actor ReleaseSignal {
+  private(set) var released = false
+  func markReleased() { released = true }
 }

--- a/CandelaAppTests/SynthesisGateTests.swift
+++ b/CandelaAppTests/SynthesisGateTests.swift
@@ -265,6 +265,73 @@ struct SynthesisGateTests {
     #expect(fixture.synthesis.refusalReason(for: engaged) == nil)
   }
 
+  /// The pref-free teardown refuses a gate it could not claim, as the opt-out
+  /// already did. It is the mirror hotkey's unwind, so without this it tore a
+  /// set down behind another feature's open reconfiguration and answered true,
+  /// leaving its caller to stage a raw mirror change over the result.
+  ///
+  /// The whole-app reset is the one caller that presses on: it is wiping the
+  /// domain and rebuilding, so a set left standing there would outlive
+  /// everything that knows about it.
+  @Test func aRefusedGateStopsTheUnwindUnlessTheResetForcesIt() async throws {
+    let fixture = Fixture()
+    defer { fixture.forgetPrefs() }
+    let display = try fixture.configured(Self.panelID)
+    let stop = try #require(fixture.modes.catalogs[Self.panelID]?.syntheticStops.first)
+
+    _ = await fixture.synthesis.engage(stop, on: display)
+    #expect(fixture.synthesis.isEngaged(displayID: Self.panelID))
+
+    // Held by another feature across both calls below.
+    let held = await fixture.gate.claim(.mirroring)
+    #expect(held.isGranted, "the fixture's own control")
+
+    let refused = await fixture.synthesis.disengageAllForReset()
+    #expect(!refused)
+    #expect(
+      fixture.synthesis.isEngaged(displayID: Self.panelID),
+      "a refusal must leave the set exactly where it found it"
+    )
+
+    let forced = await fixture.synthesis.disengageAllForReset(force: true)
+    #expect(forced)
+    #expect(fixture.synthesis.pairings.isEmpty)
+
+    // Still ours: the forced pass never took the claim, so it must not have
+    // given one back either.
+    await fixture.gate.release(.mirroring)
+  }
+
+  /// Both slots taken, and the attended guard answers what the unattended one
+  /// already answered: the reapply pass has skipped on `freeSlots` since it was
+  /// written, while the picker offered the stops anyway and let the engine
+  /// refuse at the allocation.
+  ///
+  /// The engaged panel is the half that makes this a slot question rather than a
+  /// blanket one: an engage tears its own pairing down before it allocates, so
+  /// its slot is free by the time it asks.
+  @Test func aThirdDisplayIsRefusedOnceBothSynthesisSlotsAreTaken() async throws {
+    let fixture = Fixture(secondPanel: true)
+    defer { fixture.forgetPrefs() }
+    let first = try fixture.configured(Self.panelID)
+    let second = try fixture.configured(Self.secondPanelID)
+    let stop = try #require(fixture.modes.catalogs[Self.panelID]?.syntheticStops.first)
+
+    _ = await fixture.synthesis.engage(stop, on: first)
+    _ = await fixture.synthesis.engage(stop, on: second)
+    #expect(fixture.synthesis.freeSlots == 0, "the fixture's own control")
+
+    // Never attached to the world: the guard is asked about the display it is
+    // handed, and a third panel on this rig would only be scenery.
+    let third = ConfiguredDisplay(
+      id: 11,
+      identity: DisplayConfigIdentity(vendor: 0x3669, model: 3, serial: 3, isBuiltIn: false),
+      name: "MAG341C 3", isBuiltIn: false
+    )
+    #expect(fixture.synthesis.refusalReason(for: third) == .engine(.noFreeSlot))
+    #expect(fixture.synthesis.refusalReason(for: first) == nil)
+  }
+
   /// The control for the test above: with nothing selected the gate is free, so
   /// the refusal there is about the operation rather than about a gate that
   /// refuses everything.

--- a/CandelaKit/Sources/CandelaKit/Audio/AudioRoutingPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Audio/AudioRoutingPolicy.swift
@@ -4,24 +4,16 @@ public enum AudioRoutingPolicy {
   /// Drops CoreAudio's duplicate-counter suffix, then whitespace and parens, so
   /// "MAG 341C (2)" matches "MAG341C".
   ///
-  /// Diverges from the fork's DisplayManager.normalizedName on purpose: the fork
-  /// also stripped every digit, which collapsed "MAG 341C" and "MAG 271C" to the
-  /// same string and routed one panel's volume keys at the other. A trailing
-  /// number that is not parenthesized is part of the model name for the same
-  /// reason: "UltraFine 27" and "UltraFine 32" are two displays.
-  ///
-  /// The parenthesized group goes only when its contents are ALL digits, which
-  /// is the shape CoreAudio's counter has. People name devices "Desk (left)" and
-  /// "Desk (right)", and a rule that dropped every trailing group made those one
-  /// device and routed the keys at whichever answered first.
+  /// Digits stay, unlike the fork: stripping them collapsed "MAG 341C" and "MAG
+  /// 271C" and routed one panel's keys at the other. Only an all-digit group is
+  /// a counter; "Desk (left)" and "Desk (right)" are two devices.
   public static func normalizedName(_ name: String) -> String {
     var head = Substring(name)
     while head.last == " " { head = head.dropLast() }
     if head.last == ")", let open = head.lastIndex(of: "(") {
       let contents = head[head.index(after: open) ..< head.index(before: head.endIndex)]
-      // `isASCII` as well as `isNumber`: the latter is true of every numeric
-      // scalar Unicode knows, so a device named with Eastern Arabic or fullwidth
-      // digits would lose its group and collide with its neighbour.
+      // `isNumber` alone is true of every Unicode digit, so "(٢)" would lose its
+      // group and collide with "(٣)".
       if !contents.isEmpty, contents.allSatisfy({ $0.isASCII && $0.isNumber }) {
         head = head[head.startIndex ..< open]
       }

--- a/CandelaKit/Sources/CandelaKit/Audio/AudioRoutingPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Audio/AudioRoutingPolicy.swift
@@ -1,10 +1,19 @@
 /// Pure volume-key routing decisions: no CoreAudio here, so every branch
 /// is unit-testable.
 public enum AudioRoutingPolicy {
-  /// Fork DisplayManager.normalizedName: strip parens, spaces, and digits, so
-  /// "MAG 341C (2)" matches "MAG341C" and duplicate-counter suffixes vanish.
+  /// Drops CoreAudio's duplicate-counter suffix, then whitespace and parens, so
+  /// "MAG 341C (2)" matches "MAG341C".
+  ///
+  /// Diverges from the fork's DisplayManager.normalizedName on purpose: the fork
+  /// also stripped every digit, which collapsed "MAG 341C" and "MAG 271C" to the
+  /// same string and routed one panel's volume keys at the other.
   public static func normalizedName(_ name: String) -> String {
-    name.filter { !"() 0123456789".contains($0) }
+    var head = Substring(name)
+    while head.last == " " { head = head.dropLast() }
+    if head.last == ")", let open = head.lastIndex(of: "(") {
+      head = head[head.startIndex ..< open]
+    }
+    return String(head.filter { !"() ".contains($0) })
   }
 
   /// Per-display match against the default output device; `audioDeviceNameOverride`

--- a/CandelaKit/Sources/CandelaKit/Audio/AudioRoutingPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Audio/AudioRoutingPolicy.swift
@@ -6,12 +6,25 @@ public enum AudioRoutingPolicy {
   ///
   /// Diverges from the fork's DisplayManager.normalizedName on purpose: the fork
   /// also stripped every digit, which collapsed "MAG 341C" and "MAG 271C" to the
-  /// same string and routed one panel's volume keys at the other.
+  /// same string and routed one panel's volume keys at the other. A trailing
+  /// number that is not parenthesized is part of the model name for the same
+  /// reason: "UltraFine 27" and "UltraFine 32" are two displays.
+  ///
+  /// The parenthesized group goes only when its contents are ALL digits, which
+  /// is the shape CoreAudio's counter has. People name devices "Desk (left)" and
+  /// "Desk (right)", and a rule that dropped every trailing group made those one
+  /// device and routed the keys at whichever answered first.
   public static func normalizedName(_ name: String) -> String {
     var head = Substring(name)
     while head.last == " " { head = head.dropLast() }
     if head.last == ")", let open = head.lastIndex(of: "(") {
-      head = head[head.startIndex ..< open]
+      let contents = head[head.index(after: open) ..< head.index(before: head.endIndex)]
+      // `isASCII` as well as `isNumber`: the latter is true of every numeric
+      // scalar Unicode knows, so a device named with Eastern Arabic or fullwidth
+      // digits would lose its group and collide with its neighbour.
+      if !contents.isEmpty, contents.allSatisfy({ $0.isASCII && $0.isNumber }) {
+        head = head[head.startIndex ..< open]
+      }
     }
     return String(head.filter { !"() ".contains($0) })
   }

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -159,6 +159,13 @@ public final class BrightnessController: PendingWireDraining {
   /// displays.
   public var supportsHDR: Bool { cachedSupportsHDR }
 
+  /// Whether the capability refresh has answered yet, same publishing pattern as
+  /// `supportsHDR`. `supportsHDR` false reads the same for "asked, no HDR modes" and
+  /// for "not asked yet", so anything that EXPLAINS the false (rather than just
+  /// disabling on it) has to wait for this, or it tells an HDR display it has no HDR
+  /// in the window before the first refresh lands.
+  public var hdrCapabilityProbed: Bool { cachedHDRProbed }
+
   /// Whether HDR is live on the display right now, same pattern as `supportsHDR`.
   /// The panel's badge reads STATE from here; `hdrMode` is only the POLICY, so an
   /// externally toggled HDR (mode still `.off`) still reports engaged.
@@ -196,6 +203,10 @@ public final class BrightnessController: PendingWireDraining {
   /// synchronous keypress/drag paths — never awaited there.
   private(set) var cachedHDRActive = false
   private(set) var cachedSupportsHDR = false
+
+  /// Observed, not `@ObservationIgnored`: a caption that reads it has to redraw when
+  /// the first refresh lands.
+  private(set) var cachedHDRProbed = false
 
   /// What the last REFRESH observed, a different fact from `cachedHDRActive`:
   /// transitions write that one optimistically (an exit sets it false before the drop
@@ -1599,6 +1610,9 @@ public final class BrightnessController: PendingWireDraining {
       cachedSupportsHDR = false
       cachedHDRActive = false
     }
+    // Both arms, the backend-less one included: "this build has no HDR backend" is a
+    // settled answer, not a pending one.
+    cachedHDRProbed = true
     // The DDC register just came back, whoever unlocked it. Keyed to the OBSERVED
     // edge rather than to a call because most routes out of HDR have no call of ours
     // in them: HDR switched off in System Settings or on the display's own controls
@@ -1798,8 +1812,12 @@ public final class BrightnessController: PendingWireDraining {
       // now on the wire.
       syncDeadband.reset()
       // Same rule as the read evidence directly above: a verdict earned by the
-      // panel that was here is not a fact about the one that replaced it.
+      // panel that was here is not a fact about the one that replaced it. The HDR
+      // caches keep the old answer until the reconfiguration's refresh supersedes
+      // them; dropping the PROBED flag is what stops anything explaining that
+      // stale answer as though it were about the panel now on the wire.
       resetWireHealth()
+      cachedHDRProbed = false
     }
     coalescer.resetDuplicateState()
     // Dropped with the memo and for the memo's own reason: it names a write

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -2429,7 +2429,7 @@ actor BrightnessWriteCoalescer {
 
   private func drain() async {
     while let write = await nextTarget() {
-      dragPerfLog.log(
+      dragPerfLog.info(
         "coalescer.target \(String(describing: write.target), privacy: .public) gen=\(write.generation)"
       )
       // Epoch gate: a target stamped before a display reconfiguration must not land

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -159,11 +159,8 @@ public final class BrightnessController: PendingWireDraining {
   /// displays.
   public var supportsHDR: Bool { cachedSupportsHDR }
 
-  /// Whether the capability refresh has answered yet, same publishing pattern as
-  /// `supportsHDR`. `supportsHDR` false reads the same for "asked, no HDR modes" and
-  /// for "not asked yet", so anything that EXPLAINS the false (rather than just
-  /// disabling on it) has to wait for this, or it tells an HDR display it has no HDR
-  /// in the window before the first refresh lands.
+  /// `supportsHDR` false reads the same for "no HDR modes" and "not asked yet";
+  /// anything that explains the false has to wait for this.
   public var hdrCapabilityProbed: Bool { cachedHDRProbed }
 
   /// Whether HDR is live on the display right now, same pattern as `supportsHDR`.
@@ -1813,9 +1810,8 @@ public final class BrightnessController: PendingWireDraining {
       syncDeadband.reset()
       // Same rule as the read evidence directly above: a verdict earned by the
       // panel that was here is not a fact about the one that replaced it. The HDR
-      // caches keep the old answer until the reconfiguration's refresh supersedes
-      // them; dropping the PROBED flag is what stops anything explaining that
-      // stale answer as though it were about the panel now on the wire.
+      // caches keep the stale answer until the refresh lands; dropping the probed
+      // flag stops anything explaining it as the new panel's.
       resetWireHealth()
       cachedHDRProbed = false
     }

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessSync.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessSync.swift
@@ -37,7 +37,10 @@ public enum BrightnessSync {
       // Same `path` category as the controller's own mode and settle lines, so
       // one predicate shows the source's adoption and every replication.
       // `delta=` is the released accumulation, not the source's own step.
-      pathLog.log(
+      // `.info` rather than the default level: this fires per target per
+      // adoption, up to 10 Hz with sync on. Never `.debug`, which `log show`
+      // does not surface and the app-regression harness needs.
+      pathLog.info(
         "sync fan-out delta=\(step, format: .fixed(precision: 4)) from=\(source.displayID) to=\(target.displayID)"
       )
       target.setBrightness(target.brightness + step)

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessSync.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessSync.swift
@@ -37,9 +37,8 @@ public enum BrightnessSync {
       // Same `path` category as the controller's own mode and settle lines, so
       // one predicate shows the source's adoption and every replication.
       // `delta=` is the released accumulation, not the source's own step.
-      // `.info` rather than the default level: this fires per target per
-      // adoption, up to 10 Hz with sync on. Never `.debug`, which `log show`
-      // does not surface and the app-regression harness needs.
+      // `.info`: this fires per target per adoption, and `.debug` is invisible
+      // to the `log show` the regression rig needs.
       pathLog.info(
         "sync fan-out delta=\(step, format: .fixed(precision: 4)) from=\(source.displayID) to=\(target.displayID)"
       )

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupReport.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupReport.swift
@@ -59,9 +59,12 @@ public struct CheckupSummary: Equatable, Sendable {
   public var controlMissed = false
   public var demonstratedSomething: Bool { observed > 0 || refused > 0 }
 
+  /// A count, never a diagnosis. "not observed on this panel class" was a claim
+  /// about the hardware over a bucket that also holds every field nobody
+  /// answered; each claim comes with its own reason in the report body.
   public var line: String {
     var parts = ["\(observed) observed", "\(refused) refused",
-                 "\(notObserved) not observed on this panel class",
+                 "\(notObserved) not observed",
                  "\(selfReported) self-reported"]
     if inconclusive > 0 { parts.append("\(inconclusive) inconclusive") }
     if let px = controlDetectedAt { parts.append("control detected at \(px) px") }

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupReport.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupReport.swift
@@ -59,9 +59,8 @@ public struct CheckupSummary: Equatable, Sendable {
   public var controlMissed = false
   public var demonstratedSomething: Bool { observed > 0 || refused > 0 }
 
-  /// A count, never a diagnosis. "not observed on this panel class" was a claim
-  /// about the hardware over a bucket that also holds every field nobody
-  /// answered; each claim comes with its own reason in the report body.
+  /// A count, never a diagnosis: the not-observed bucket also holds every field
+  /// nobody answered, and each claim carries its own reason in the body.
   public var line: String {
     var parts = ["\(observed) observed", "\(refused) refused",
                  "\(notObserved) not observed",

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
@@ -81,8 +81,11 @@ public struct CheckupStore: Sendable {
     }.sorted { $0.startedAt > $1.startedAt }
   }
 
+  /// The model goes through the same sanitizer as a stored run's folder: a
+  /// product name is whatever the panel's EDID says, and a slash or a colon in
+  /// it would reach the save panel as a path.
   public static func exportFileName(for report: CheckupReport) -> String {
     let model = report.identity.productName.isEmpty ? "Display" : report.identity.productName
-    return "Candela Checkup \(model) \(day(report.startedAt)).candela-checkup.json"
+    return "Candela Checkup \(safe(model)) \(day(report.startedAt)).candela-checkup.json"
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
@@ -35,8 +35,19 @@ public struct CheckupStore: Sendable {
     return f.string(from: date)
   }
 
+  /// For a directory this app creates and reads back. Flattens everything
+  /// unusual, spaces included, because nobody ever sees these names.
   static func safe(_ s: String) -> String {
     s.map { $0.isLetter || $0.isNumber || $0 == "-" ? String($0) : "_" }.joined()
+  }
+
+  /// For a name a person meets in a save panel, which is a different job:
+  /// `safe` would hand them "DELL_U2725QE" over a display called DELL U2725QE.
+  /// Only what a path component genuinely cannot carry goes, plus a leading dot,
+  /// which would hide the file.
+  static func safeFileName(_ s: String) -> String {
+    let replaced = String(s.map { $0 == "/" || $0 == ":" ? "_" : $0 })
+    return replaced.hasPrefix(".") ? "_" + String(replaced.dropFirst()) : replaced
   }
 
   /// One encoder for stored and exported envelopes, so an export is
@@ -81,11 +92,12 @@ public struct CheckupStore: Sendable {
     }.sorted { $0.startedAt > $1.startedAt }
   }
 
-  /// The model goes through the same sanitizer as a stored run's folder: a
-  /// product name is whatever the panel's EDID says, and a slash or a colon in
-  /// it would reach the save panel as a path.
+  /// A product name is whatever the panel's EDID says, and a slash or a colon in
+  /// it would reach the save panel as a path. Through the filename sanitizer,
+  /// NOT the folder one: the folder never leaves the app, and this is the name
+  /// the save panel offers.
   public static func exportFileName(for report: CheckupReport) -> String {
     let model = report.identity.productName.isEmpty ? "Display" : report.identity.productName
-    return "Candela Checkup \(safe(model)) \(day(report.startedAt)).candela-checkup.json"
+    return "Candela Checkup \(safeFileName(model)) \(day(report.startedAt)).candela-checkup.json"
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
@@ -35,16 +35,13 @@ public struct CheckupStore: Sendable {
     return f.string(from: date)
   }
 
-  /// For a directory this app creates and reads back. Flattens everything
-  /// unusual, spaces included, because nobody ever sees these names.
+  /// For directory names nobody sees; flattens spaces too.
   static func safe(_ s: String) -> String {
     s.map { $0.isLetter || $0.isNumber || $0 == "-" ? String($0) : "_" }.joined()
   }
 
-  /// For a name a person meets in a save panel, which is a different job:
-  /// `safe` would hand them "DELL_U2725QE" over a display called DELL U2725QE.
-  /// Only what a path component genuinely cannot carry goes, plus a leading dot,
-  /// which would hide the file.
+  /// For a save panel, where `safe` would offer "DELL_U2725QE". Only what a path
+  /// component cannot carry goes, plus a leading dot, which hides the file.
   static func safeFileName(_ s: String) -> String {
     let replaced = String(s.map { $0 == "/" || $0 == ":" ? "_" : $0 })
     return replaced.hasPrefix(".") ? "_" + String(replaced.dropFirst()) : replaced
@@ -92,10 +89,8 @@ public struct CheckupStore: Sendable {
     }.sorted { $0.startedAt > $1.startedAt }
   }
 
-  /// A product name is whatever the panel's EDID says, and a slash or a colon in
-  /// it would reach the save panel as a path. Through the filename sanitizer,
-  /// NOT the folder one: the folder never leaves the app, and this is the name
-  /// the save panel offers.
+  /// The product name is whatever the EDID says, and a slash in it would reach
+  /// the save panel as a path.
   public static func exportFileName(for report: CheckupReport) -> String {
     let model = report.identity.productName.isEmpty ? "Display" : report.identity.productName
     return "Candela Checkup \(safeFileName(model)) \(day(report.startedAt)).candela-checkup.json"

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -21,9 +21,13 @@ public actor Arm64DDCService: DDCWriting {
 
   public func write(command: UInt8, value: UInt16) async -> Bool {
     // start/end pair also exposes the per-transaction duration (~30 ms).
-    dragPerfLog.log("ddc.write.start value=\(value)")
+    // `.info`, not the default level: a drag submits these at up to 60 Hz and
+    // the default level persists every one to disk. Not `.debug` either, which
+    // `log show` cannot see at all, and the app-regression harness parses
+    // `ddc.write.end` out of a `log show --info --debug` window.
+    dragPerfLog.info("ddc.write.start value=\(value)")
     let ok = Arm64DDC.write(service: box.service, command: command, value: value)
-    dragPerfLog.log("ddc.write.end value=\(value) ok=\(ok)")
+    dragPerfLog.info("ddc.write.end value=\(value) ok=\(ok)")
     return ok
   }
 

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -21,10 +21,8 @@ public actor Arm64DDCService: DDCWriting {
 
   public func write(command: UInt8, value: UInt16) async -> Bool {
     // start/end pair also exposes the per-transaction duration (~30 ms).
-    // `.info`, not the default level: a drag submits these at up to 60 Hz and
-    // the default level persists every one to disk. Not `.debug` either, which
-    // `log show` cannot see at all, and the app-regression harness parses
-    // `ddc.write.end` out of a `log show --info --debug` window.
+    // `.info`: the default level persists every one of these to disk at drag
+    // rate, and `.debug` is invisible to the `log show` the regression rig parses.
     dragPerfLog.info("ddc.write.start value=\(value)")
     let ok = Arm64DDC.write(service: box.service, command: command, value: value)
     dragPerfLog.info("ddc.write.end value=\(value) ok=\(ok)")

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayRotation.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayRotation.swift
@@ -62,6 +62,12 @@ public enum RotationRefusal: Sendable, Equatable {
   /// `ModeReapplyPolicy` already defers on; `ArrangementPlan` refuses the same
   /// display by another route.
   case mirrored
+  /// The display is running a size the app renders for it, which is a mirror
+  /// pairing onto a virtual display. Mechanically a slave, so it is refused for
+  /// `mirrored`'s reason, but it gets its own case because the user mirrored
+  /// nothing: naming the other display would name one they do not have, and the
+  /// way out is the size control rather than a mirroring control.
+  case synthesizedSize
 }
 
 /// A rotation that policy has approved. Carries `from` because the revert path
@@ -86,13 +92,18 @@ public enum RotationDecision: Sendable, Equatable {
 /// The whole decision, in one pure function, for the same reason
 /// `MirrorTopologyPolicy` is one: it is the part worth testing exhaustively, and
 /// it must not be able to drift from what the UI claims.
+///
+/// `isSynthesizedSize` arrives as a flag rather than being derived here: the
+/// pairing lives in `MirrorTopology`, which this decision does not take, and a
+/// caller that has to state it cannot silently inherit the raw mirroring answer.
 public enum RotationPolicy {
   public static func decide(
     display: CGDirectDisplayID,
     to requested: DisplayRotation,
     in displays: [ConfiguredDisplay],
     currentRotation: DisplayRotation?,
-    isSupported: Bool
+    isSupported: Bool,
+    isSynthesizedSize: Bool
   ) -> RotationDecision {
     guard isSupported else { return .refused(.unavailable) }
     guard let entry = displays.first(where: { $0.id == display }) else {
@@ -100,6 +111,10 @@ public enum RotationPolicy {
     }
     // Ahead of the angle questions: a slave's reported angle is readable and a
     // request against it looks ordinary, which is how this reached the apply.
+    // The synthesis arm first, because such a display is also a raw slave and
+    // the mirroring answer would send the user looking for a display they never
+    // paired.
+    if isSynthesizedSize { return .refused(.synthesizedSize) }
     guard !entry.isMirrorSlave else { return .refused(.mirrored) }
     guard let current = currentRotation else { return .refused(.unreadable) }
     guard current != requested else { return .refused(.unchanged(current)) }

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayRotation.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayRotation.swift
@@ -56,6 +56,12 @@ public enum RotationRefusal: Sendable, Equatable {
   /// The requested angle is already the current one. No countdown opens: a no-op
   /// that starts a 30-second timer is a bug, not a courtesy.
   case unchanged(DisplayRotation)
+  /// The display is a mirror SLAVE. Its framebuffer belongs to the display it
+  /// mirrors, so what a rotation of the glass achieves here is not something
+  /// this feature can verify. Refused rather than attempted, on the flag
+  /// `ModeReapplyPolicy` already defers on; `ArrangementPlan` refuses the same
+  /// display by another route.
+  case mirrored
 }
 
 /// A rotation that policy has approved. Carries `from` because the revert path
@@ -89,7 +95,12 @@ public enum RotationPolicy {
     isSupported: Bool
   ) -> RotationDecision {
     guard isSupported else { return .refused(.unavailable) }
-    guard displays.contains(where: { $0.id == display }) else { return .refused(.displayGone) }
+    guard let entry = displays.first(where: { $0.id == display }) else {
+      return .refused(.displayGone)
+    }
+    // Ahead of the angle questions: a slave's reported angle is readable and a
+    // request against it looks ordinary, which is how this reached the apply.
+    guard !entry.isMirrorSlave else { return .refused(.mirrored) }
     guard let current = currentRotation else { return .refused(.unreadable) }
     guard current != requested else { return .refused(.unchanged(current)) }
     return .rotate(RotationRequest(display: display, from: current, to: requested))

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayRotation.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayRotation.swift
@@ -56,17 +56,12 @@ public enum RotationRefusal: Sendable, Equatable {
   /// The requested angle is already the current one. No countdown opens: a no-op
   /// that starts a 30-second timer is a bug, not a courtesy.
   case unchanged(DisplayRotation)
-  /// The display is a mirror SLAVE. Its framebuffer belongs to the display it
-  /// mirrors, so what a rotation of the glass achieves here is not something
-  /// this feature can verify. Refused rather than attempted, on the flag
-  /// `ModeReapplyPolicy` already defers on; `ArrangementPlan` refuses the same
-  /// display by another route.
+  /// A mirror slave's framebuffer belongs to its master, so what a rotation
+  /// achieves cannot be verified. Refused on the flag `ModeReapplyPolicy` defers on.
   case mirrored
-  /// The display is running a size the app renders for it, which is a mirror
-  /// pairing onto a virtual display. Mechanically a slave, so it is refused for
-  /// `mirrored`'s reason, but it gets its own case because the user mirrored
-  /// nothing: naming the other display would name one they do not have, and the
-  /// way out is the size control rather than a mirroring control.
+  /// A rendered size is a mirror pairing onto a virtual display: refused for
+  /// `mirrored`'s reason, but its own case because the user paired nothing and
+  /// the way out is the size control.
   case synthesizedSize
 }
 
@@ -93,9 +88,8 @@ public enum RotationDecision: Sendable, Equatable {
 /// `MirrorTopologyPolicy` is one: it is the part worth testing exhaustively, and
 /// it must not be able to drift from what the UI claims.
 ///
-/// `isSynthesizedSize` arrives as a flag rather than being derived here: the
-/// pairing lives in `MirrorTopology`, which this decision does not take, and a
-/// caller that has to state it cannot silently inherit the raw mirroring answer.
+/// `isSynthesizedSize` is a flag because the pairing lives in `MirrorTopology`,
+/// which this decision does not take.
 public enum RotationPolicy {
   public static func decide(
     display: CGDirectDisplayID,
@@ -109,11 +103,9 @@ public enum RotationPolicy {
     guard let entry = displays.first(where: { $0.id == display }) else {
       return .refused(.displayGone)
     }
-    // Ahead of the angle questions: a slave's reported angle is readable and a
-    // request against it looks ordinary, which is how this reached the apply.
-    // The synthesis arm first, because such a display is also a raw slave and
-    // the mirroring answer would send the user looking for a display they never
-    // paired.
+    // Before the angle checks, which a slave passes. Synthesis first: such a
+    // display is also a raw slave, and the mirroring answer names a display
+    // nobody paired.
     if isSynthesizedSize { return .refused(.synthesizedSize) }
     guard !entry.isMirrorSlave else { return .refused(.mirrored) }
     guard let current = currentRotation else { return .refused(.unreadable) }

--- a/CandelaKit/Sources/CandelaKit/Displays/DisplayDiscovery.swift
+++ b/CandelaKit/Sources/CandelaKit/Displays/DisplayDiscovery.swift
@@ -60,9 +60,8 @@ public enum DisplayDiscovery {
   /// share saved brightness. The fork disambiguated with CGDirectDisplayID at
   /// the cost of stability across ports and reboots.
   ///
-  /// The fallback embeds the panel's serial number, so this value never goes
-  /// into a log at `.public` or into the diagnostics report. Log
-  /// `DisplayLogging.tag(for:)` instead.
+  /// The fallback embeds the panel's serial number, so log
+  /// `DisplayLogging.tag(for:)` instead of this value.
   static func persistenceKey(from service: Arm64DDC.IOregService) -> String {
     if !service.edidUUID.isEmpty {
       return service.edidUUID

--- a/CandelaKit/Sources/CandelaKit/Displays/DisplayDiscovery.swift
+++ b/CandelaKit/Sources/CandelaKit/Displays/DisplayDiscovery.swift
@@ -59,6 +59,10 @@ public enum DisplayDiscovery {
   /// fallback triple collides more easily when the serial is 0, so twins would
   /// share saved brightness. The fork disambiguated with CGDirectDisplayID at
   /// the cost of stability across ports and reboots.
+  ///
+  /// The fallback embeds the panel's serial number, so this value never goes
+  /// into a log at `.public` or into the diagnostics report. Log
+  /// `DisplayLogging.tag(for:)` instead.
   static func persistenceKey(from service: Arm64DDC.IOregService) -> String {
     if !service.edidUUID.isEmpty {
       return service.edidUUID

--- a/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
@@ -27,10 +27,12 @@ public enum OledCareCadence {
   public static let samplingSeconds: Double = Double(
     OledCareCadence.sampling.components.seconds)
 
-  /// A reading counts as live for two sampling intervals: long enough that one
-  /// skipped capture is not reported as a failure, short enough that a dead
-  /// Screen Recording grant stills the measuring dot within two minutes.
-  public static let livenessWindowSeconds: Double = 2 * OledCareCadence.samplingSeconds
+  /// A reading counts as live for two and a half sampling intervals. Exactly two
+  /// put the boundary on top of the next capture's own arrival, so a single late
+  /// or skipped one flipped the dot off; the half interval is the slack that
+  /// takes to survive one miss. Still short enough that a dead Screen Recording
+  /// grant stills the dot inside three minutes.
+  public static let livenessWindowSeconds: Double = 2.5 * OledCareCadence.samplingSeconds
 
   /// The stall warning's window, ten intervals, and deliberately NOT the
   /// liveness window. This one accuses macOS of having dropped the Screen

--- a/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
@@ -11,33 +11,24 @@ public enum OledCareCadence {
   public static let fast: Duration = .milliseconds(100)
   /// The thresholds are minutes, so nothing needs a fast tick to reach them.
   public static let slow: Duration = .seconds(2)
-  /// Nothing enrolled. The loop still has to exist, since an enrollment can
-  /// arrive at any moment, but it has no work to do and no reason to wake 30
-  /// times a minute for the life of the app. `reconcileEnrollment` restarts the
-  /// driver when the idle state ends, so an enrollment does not wait this out.
+  /// Nothing enrolled: the loop has no work, and `reconcileEnrollment` restarts
+  /// it on enrollment so nothing waits this out.
   public static let idle: Duration = .seconds(30)
 
-  /// Telemetry's own cadence: one capture per enrolled display per minute. It
-  /// lives here because three surfaces judge a reading stale against multiples
-  /// of it and each had picked its own number.
+  /// One capture per enrolled display. Kit-owned because the settings panes
+  /// judge staleness against multiples of it.
   public static let sampling: Duration = .seconds(60)
 
-  /// The same interval where the caller reasons in `TimeInterval`. Derived, so
-  /// the two spellings cannot drift.
+  /// Derived, so the two spellings cannot drift.
   public static let samplingSeconds: Double = Double(
     OledCareCadence.sampling.components.seconds)
 
-  /// A reading counts as live for two and a half sampling intervals. Exactly two
-  /// put the boundary on top of the next capture's own arrival, so a single late
-  /// or skipped one flipped the dot off; the half interval is the slack that
-  /// takes to survive one miss. Still short enough that a dead Screen Recording
-  /// grant stills the dot inside three minutes.
+  /// Two and a half intervals: exactly two put the boundary on the next
+  /// capture's arrival, so one late capture flipped the dot off.
   public static let livenessWindowSeconds: Double = 2.5 * OledCareCadence.samplingSeconds
 
-  /// The stall warning's window, ten intervals, and deliberately NOT the
-  /// liveness window. This one accuses macOS of having dropped the Screen
-  /// Recording grant, so it waits until an ordinary run of skipped captures
-  /// cannot explain the silence.
+  /// Not the liveness window: this one accuses macOS of dropping the grant, so
+  /// it waits until skipped captures cannot explain the silence.
   public static let stallWarningSeconds: Double = 10 * OledCareCadence.samplingSeconds
 
   /// Fast whenever a dim is UP BY ANY DELIVERY, or an achieved-state
@@ -47,9 +38,8 @@ public enum OledCareCadence {
   /// lifts a dim the engine believes is up, and that belief needs fast ticks to
   /// be corrected.
   ///
-  /// `anythingEnrolled` defaults to true so that the parameter cannot change a
-  /// caller's answer by being forgotten; the one term that reaches `idle` is the
-  /// one a caller has to state.
+  /// `anythingEnrolled` defaults to true so a caller that forgets it cannot idle
+  /// the loop by accident.
   public static func interval(
     anyOverlayUp: Bool, anyLockDimEngaged: Bool, verificationPending: Bool,
     anythingEnrolled: Bool = true

--- a/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
@@ -11,6 +11,32 @@ public enum OledCareCadence {
   public static let fast: Duration = .milliseconds(100)
   /// The thresholds are minutes, so nothing needs a fast tick to reach them.
   public static let slow: Duration = .seconds(2)
+  /// Nothing enrolled. The loop still has to exist, since an enrollment can
+  /// arrive at any moment, but it has no work to do and no reason to wake 30
+  /// times a minute for the life of the app. `reconcileEnrollment` restarts the
+  /// driver when the idle state ends, so an enrollment does not wait this out.
+  public static let idle: Duration = .seconds(30)
+
+  /// Telemetry's own cadence: one capture per enrolled display per minute. It
+  /// lives here because three surfaces judge a reading stale against multiples
+  /// of it and each had picked its own number.
+  public static let sampling: Duration = .seconds(60)
+
+  /// The same interval where the caller reasons in `TimeInterval`. Derived, so
+  /// the two spellings cannot drift.
+  public static let samplingSeconds: Double = Double(
+    OledCareCadence.sampling.components.seconds)
+
+  /// A reading counts as live for two sampling intervals: long enough that one
+  /// skipped capture is not reported as a failure, short enough that a dead
+  /// Screen Recording grant stills the measuring dot within two minutes.
+  public static let livenessWindowSeconds: Double = 2 * OledCareCadence.samplingSeconds
+
+  /// The stall warning's window, ten intervals, and deliberately NOT the
+  /// liveness window. This one accuses macOS of having dropped the Screen
+  /// Recording grant, so it waits until an ordinary run of skipped captures
+  /// cannot explain the silence.
+  public static let stallWarningSeconds: Double = 10 * OledCareCadence.samplingSeconds
 
   /// Fast whenever a dim is UP BY ANY DELIVERY, or an achieved-state
   /// verification is pending.
@@ -18,9 +44,15 @@ public enum OledCareCadence {
   /// `anyOverlayUp` is the WANT, not the verified presence, on purpose: input
   /// lifts a dim the engine believes is up, and that belief needs fast ticks to
   /// be corrected.
+  ///
+  /// `anythingEnrolled` defaults to true so that the parameter cannot change a
+  /// caller's answer by being forgotten; the one term that reaches `idle` is the
+  /// one a caller has to state.
   public static func interval(
-    anyOverlayUp: Bool, anyLockDimEngaged: Bool, verificationPending: Bool
+    anyOverlayUp: Bool, anyLockDimEngaged: Bool, verificationPending: Bool,
+    anythingEnrolled: Bool = true
   ) -> Duration {
-    anyOverlayUp || anyLockDimEngaged || verificationPending ? fast : slow
+    if anyOverlayUp || anyLockDimEngaged || verificationPending { return fast }
+    return anythingEnrolled ? slow : idle
   }
 }

--- a/CandelaKit/Sources/CandelaKit/OledCare/OwnerHoursAccumulator.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OwnerHoursAccumulator.swift
@@ -9,6 +9,11 @@ import Foundation
 public struct OwnerHours: Equatable, Sendable, Codable {
   public private(set) var secondsByOwner: [String: Double]
   public private(set) var totalSeconds: Double
+  /// Time from owners past `storedOwnerLimit`, kept out of `secondsByOwner`
+  /// entirely so nothing that reads that dictionary can render the fold as an
+  /// app. It is a sibling field an older decoder does not know and skips, which
+  /// is why the schema version does not move for it.
+  public private(set) var foldedSeconds: Double
 
   public static let empty = OwnerHours(secondsByOwner: [:], totalSeconds: 0)
 
@@ -17,13 +22,14 @@ public struct OwnerHours: Equatable, Sendable, Codable {
   /// them would grow the prefs blob without bound.
   static let storedOwnerLimit = 50
 
-  /// Where the owners past `storedOwnerLimit` are folded at encode time, so the
-  /// per-owner seconds still sum to `totalSeconds`.
+  /// Where a build before `foldedSeconds` existed put the fold: INSIDE
+  /// `secondsByOwner`, where a reader that did not know to skip it drew it as
+  /// the heaviest app on the display. Kept as a decode-time migration only, and
+  /// never written again.
   ///
-  /// A macOS file name cannot contain "/", so no process can ever report this
-  /// as its owner name and the bucket cannot absorb a real app's time.
-  /// `topOwners` drops it rather than drawing a row nobody can act on.
-  static let foldedOwnerKey = "other/apps"
+  /// A macOS file name cannot contain "/", so no process can ever have reported
+  /// this as its owner name and the bucket holds nothing but folded time.
+  static let legacyFoldedOwnerKey = "other/apps"
 
   /// Descending by seconds, ties broken by owner name so the view does not
   /// reshuffle between equal-weight renders.
@@ -33,7 +39,6 @@ public struct OwnerHours: Equatable, Sendable, Codable {
   /// screen.
   public func topOwners(limit: Int) -> [(owner: String, hours: Double)] {
     secondsByOwner
-      .filter { $0.key != Self.foldedOwnerKey }
       .sorted { lhs, rhs in
         lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key
       }
@@ -41,18 +46,16 @@ public struct OwnerHours: Equatable, Sendable, Codable {
       .map { (owner: $0.key, hours: $0.value / 3600) }
   }
 
-  /// Keeps the heaviest `storedOwnerLimit` named owners whole and folds the rest
-  /// into `foldedOwnerKey`. Idempotent: an already-folded store re-encodes to
-  /// itself, because the existing bucket is ranked out and then re-added.
-  private static func capped(_ seconds: [String: Double]) -> [String: Double] {
-    var named = seconds
-    var folded = named.removeValue(forKey: foldedOwnerKey) ?? 0
-    guard named.count > storedOwnerLimit else { return seconds }
-
-    let ranked = named.sorted { lhs, rhs in
+  /// Keeps the heaviest `storedOwnerLimit` named owners whole and returns what
+  /// the rest carry, for the caller to add to `foldedSeconds`. Idempotent: a
+  /// store already at or under the limit folds nothing more.
+  private static func capped(_ seconds: [String: Double]) -> (kept: [String: Double], folded: Double) {
+    guard seconds.count > storedOwnerLimit else { return (seconds, 0) }
+    let ranked = seconds.sorted { lhs, rhs in
       lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key
     }
-    var kept = [String: Double](minimumCapacity: storedOwnerLimit + 1)
+    var kept = [String: Double](minimumCapacity: storedOwnerLimit)
+    var folded = 0.0
     for (index, entry) in ranked.enumerated() {
       if index < storedOwnerLimit {
         kept[entry.key] = entry.value
@@ -60,8 +63,7 @@ public struct OwnerHours: Equatable, Sendable, Codable {
         folded += entry.value
       }
     }
-    if folded > 0 { kept[foldedOwnerKey] = folded }
-    return kept
+    return (kept, folded)
   }
 
   fileprivate mutating func add(_ secondsAdded: [String: Double], totalAdded: Double) {
@@ -78,13 +80,19 @@ public struct OwnerHours: Equatable, Sendable, Codable {
     case schemaVersion = "schemaVersion"
     case secondsByOwner = "secondsByOwner"
     case totalSeconds = "totalSeconds"
+    case foldedSeconds = "foldedSeconds"
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
+    // NOT bumped for `foldedSeconds`: the version gates a decoder OUT, and an
+    // older build reading this store is meant to go on working. It skips the key
+    // it does not know, which costs it the folded total and nothing else.
     try container.encode(OledStoreSchema.currentVersion, forKey: .schemaVersion)
-    try container.encode(Self.capped(secondsByOwner), forKey: .secondsByOwner)
+    let capped = Self.capped(secondsByOwner)
+    try container.encode(capped.kept, forKey: .secondsByOwner)
     try container.encode(totalSeconds, forKey: .totalSeconds)
+    try container.encode(foldedSeconds + capped.folded, forKey: .foldedSeconds)
   }
 
   public init(from decoder: Decoder) throws {
@@ -94,15 +102,23 @@ public struct OwnerHours: Equatable, Sendable, Codable {
       throw OledStoreDecodeFailure.unsupportedVersion(
         found: version, supported: OledStoreSchema.currentVersion)
     }
-    self.secondsByOwner = try container.decode([String: Double].self, forKey: .secondsByOwner)
+    var stored = try container.decode([String: Double].self, forKey: .secondsByOwner)
+    // Absent on a store this build has not rewritten yet, and on one written
+    // before the field existed, where the fold sits under the legacy key.
+    // Migrated out here so nothing downstream has to know the key.
+    let carried = try container.decodeIfPresent(Double.self, forKey: .foldedSeconds) ?? 0
+    let legacy = stored.removeValue(forKey: Self.legacyFoldedOwnerKey) ?? 0
+    self.secondsByOwner = stored
     self.totalSeconds = try container.decode(Double.self, forKey: .totalSeconds)
+    self.foldedSeconds = carried + legacy
   }
 
   /// Internal, not private: replaces the memberwise init that adding
   /// `init(from:)` suppressed, and the tests reach it through `@testable`.
-  init(secondsByOwner: [String: Double], totalSeconds: Double) {
+  init(secondsByOwner: [String: Double], totalSeconds: Double, foldedSeconds: Double = 0) {
     self.secondsByOwner = secondsByOwner
     self.totalSeconds = totalSeconds
+    self.foldedSeconds = foldedSeconds
   }
 }
 

--- a/CandelaKit/Sources/CandelaKit/OledCare/OwnerHoursAccumulator.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OwnerHoursAccumulator.swift
@@ -9,26 +9,20 @@ import Foundation
 public struct OwnerHours: Equatable, Sendable, Codable {
   public private(set) var secondsByOwner: [String: Double]
   public private(set) var totalSeconds: Double
-  /// Time from owners past `storedOwnerLimit`, kept out of `secondsByOwner`
-  /// entirely so nothing that reads that dictionary can render the fold as an
-  /// app. It is a sibling field an older decoder does not know and skips, which
-  /// is why the schema version does not move for it.
+  /// Time from owners past `storedOwnerLimit`, kept out of `secondsByOwner` so
+  /// no reader can render the fold as an app. Older decoders skip the key, so
+  /// the schema version does not move for it.
   public private(set) var foldedSeconds: Double
 
   public static let empty = OwnerHours(secondsByOwner: [:], totalSeconds: 0)
 
-  /// How many named owners survive an encode. The store is written every five
-  /// minutes and never forgets an app, so a machine that meets thousands of
-  /// them would grow the prefs blob without bound.
+  /// Owners surviving an encode. The store never forgets an app, so without a
+  /// cap the prefs blob grows without bound.
   static let storedOwnerLimit = 50
 
-  /// Where a build before `foldedSeconds` existed put the fold: INSIDE
-  /// `secondsByOwner`, where a reader that did not know to skip it drew it as
-  /// the heaviest app on the display. Kept as a decode-time migration only, and
-  /// never written again.
-  ///
-  /// A macOS file name cannot contain "/", so no process can ever have reported
-  /// this as its owner name and the bucket holds nothing but folded time.
+  /// Where older builds put the fold, inside `secondsByOwner`, where readers drew
+  /// it as the heaviest app. Migrated out on decode, never written again. The "/"
+  /// makes it impossible as a real process name.
   static let legacyFoldedOwnerKey = "other/apps"
 
   /// Descending by seconds, ties broken by owner name so the view does not
@@ -46,9 +40,8 @@ public struct OwnerHours: Equatable, Sendable, Codable {
       .map { (owner: $0.key, hours: $0.value / 3600) }
   }
 
-  /// Keeps the heaviest `storedOwnerLimit` named owners whole and returns what
-  /// the rest carry, for the caller to add to `foldedSeconds`. Idempotent: a
-  /// store already at or under the limit folds nothing more.
+  /// Idempotent: a store at or under the limit folds nothing, so a rewrite of a
+  /// rewrite does not eat one more owner.
   private static func capped(_ seconds: [String: Double]) -> (kept: [String: Double], folded: Double) {
     guard seconds.count > storedOwnerLimit else { return (seconds, 0) }
     let ranked = seconds.sorted { lhs, rhs in
@@ -85,9 +78,8 @@ public struct OwnerHours: Equatable, Sendable, Codable {
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    // NOT bumped for `foldedSeconds`: the version gates a decoder OUT, and an
-    // older build reading this store is meant to go on working. It skips the key
-    // it does not know, which costs it the folded total and nothing else.
+    // Not bumped for `foldedSeconds`: the version gates older decoders out, and
+    // they only lose the folded total by skipping the key.
     try container.encode(OledStoreSchema.currentVersion, forKey: .schemaVersion)
     let capped = Self.capped(secondsByOwner)
     try container.encode(capped.kept, forKey: .secondsByOwner)
@@ -103,9 +95,8 @@ public struct OwnerHours: Equatable, Sendable, Codable {
         found: version, supported: OledStoreSchema.currentVersion)
     }
     var stored = try container.decode([String: Double].self, forKey: .secondsByOwner)
-    // Absent on a store this build has not rewritten yet, and on one written
-    // before the field existed, where the fold sits under the legacy key.
-    // Migrated out here so nothing downstream has to know the key.
+    // Absent until this build rewrites the store; before the field existed the
+    // fold sat under the legacy key.
     let carried = try container.decodeIfPresent(Double.self, forKey: .foldedSeconds) ?? 0
     let legacy = stored.removeValue(forKey: Self.legacyFoldedOwnerKey) ?? 0
     self.secondsByOwner = stored

--- a/CandelaKit/Sources/CandelaKit/OledCare/OwnerHoursAccumulator.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OwnerHoursAccumulator.swift
@@ -12,6 +12,19 @@ public struct OwnerHours: Equatable, Sendable, Codable {
 
   public static let empty = OwnerHours(secondsByOwner: [:], totalSeconds: 0)
 
+  /// How many named owners survive an encode. The store is written every five
+  /// minutes and never forgets an app, so a machine that meets thousands of
+  /// them would grow the prefs blob without bound.
+  static let storedOwnerLimit = 50
+
+  /// Where the owners past `storedOwnerLimit` are folded at encode time, so the
+  /// per-owner seconds still sum to `totalSeconds`.
+  ///
+  /// A macOS file name cannot contain "/", so no process can ever report this
+  /// as its owner name and the bucket cannot absorb a real app's time.
+  /// `topOwners` drops it rather than drawing a row nobody can act on.
+  static let foldedOwnerKey = "other/apps"
+
   /// Descending by seconds, ties broken by owner name so the view does not
   /// reshuffle between equal-weight renders.
   ///
@@ -20,11 +33,35 @@ public struct OwnerHours: Equatable, Sendable, Codable {
   /// screen.
   public func topOwners(limit: Int) -> [(owner: String, hours: Double)] {
     secondsByOwner
+      .filter { $0.key != Self.foldedOwnerKey }
       .sorted { lhs, rhs in
         lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key
       }
       .prefix(max(0, limit))
       .map { (owner: $0.key, hours: $0.value / 3600) }
+  }
+
+  /// Keeps the heaviest `storedOwnerLimit` named owners whole and folds the rest
+  /// into `foldedOwnerKey`. Idempotent: an already-folded store re-encodes to
+  /// itself, because the existing bucket is ranked out and then re-added.
+  private static func capped(_ seconds: [String: Double]) -> [String: Double] {
+    var named = seconds
+    var folded = named.removeValue(forKey: foldedOwnerKey) ?? 0
+    guard named.count > storedOwnerLimit else { return seconds }
+
+    let ranked = named.sorted { lhs, rhs in
+      lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key
+    }
+    var kept = [String: Double](minimumCapacity: storedOwnerLimit + 1)
+    for (index, entry) in ranked.enumerated() {
+      if index < storedOwnerLimit {
+        kept[entry.key] = entry.value
+      } else {
+        folded += entry.value
+      }
+    }
+    if folded > 0 { kept[foldedOwnerKey] = folded }
+    return kept
   }
 
   fileprivate mutating func add(_ secondsAdded: [String: Double], totalAdded: Double) {
@@ -46,7 +83,7 @@ public struct OwnerHours: Equatable, Sendable, Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(OledStoreSchema.currentVersion, forKey: .schemaVersion)
-    try container.encode(secondsByOwner, forKey: .secondsByOwner)
+    try container.encode(Self.capped(secondsByOwner), forKey: .secondsByOwner)
     try container.encode(totalSeconds, forKey: .totalSeconds)
   }
 

--- a/CandelaKit/Sources/CandelaKit/OledCare/WearSignalTracker.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/WearSignalTracker.swift
@@ -60,6 +60,13 @@ public final class WearSignalTracker {
   private let versionKey: String
   private var slots: [Double]
   private var unwrittenSeconds: Double = 0
+  /// True once a tick has been booked into THIS instance. Constructing a tracker
+  /// is how a pane reads a histogram, so a visit to a settings page that only
+  /// looks at a display would otherwise write an all-zero array over nothing at
+  /// the next sleep or quit. Not `unwrittenSeconds`: that returns to 0 on every
+  /// write-through, so guarding on it alone would stop a real tracker flushing
+  /// its debounced tail at quit.
+  private var hasAccumulated = false
 
   public init(defaults: UserDefaults = .standard, persistenceKey: String) {
     self.defaults = defaults
@@ -113,6 +120,7 @@ public final class WearSignalTracker {
 
     slots[slot] += secondsSinceLastTick
     unwrittenSeconds += secondsSinceLastTick
+    hasAccumulated = true
     if unwrittenSeconds > Self.debounceSeconds { writeThrough() }
   }
 
@@ -184,6 +192,9 @@ public final class WearSignalTracker {
   public func reset() {
     slots = [Double](repeating: 0, count: Self.slotCount)
     unwrittenSeconds = 0
+    // Or the next flush re-creates the keys this just removed, which is what
+    // "leaves no key behind" promises not to happen.
+    hasAccumulated = false
     // Removed rather than zeroed, matching `PanelHoursTracker`: a settings
     // reset should leave no key behind, and every read here treats absence as
     // a fresh histogram.
@@ -191,8 +202,12 @@ public final class WearSignalTracker {
     defaults.removeObject(forKey: versionKey)
   }
 
-  /// The undebounced write, for termination and sleep.
-  public func flush() { writeThrough() }
+  /// The undebounced write, for termination and sleep. A tracker that has booked
+  /// nothing has nothing to say, so it writes nothing: see `hasAccumulated`.
+  public func flush() {
+    guard hasAccumulated else { return }
+    writeThrough()
+  }
 
   private func writeThrough() {
     defaults.set(slots, forKey: secondsKey)

--- a/CandelaKit/Sources/CandelaKit/OledCare/WearSignalTracker.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/WearSignalTracker.swift
@@ -60,12 +60,9 @@ public final class WearSignalTracker {
   private let versionKey: String
   private var slots: [Double]
   private var unwrittenSeconds: Double = 0
-  /// True once a tick has been booked into THIS instance. Constructing a tracker
-  /// is how a pane reads a histogram, so a visit to a settings page that only
-  /// looks at a display would otherwise write an all-zero array over nothing at
-  /// the next sleep or quit. Not `unwrittenSeconds`: that returns to 0 on every
-  /// write-through, so guarding on it alone would stop a real tracker flushing
-  /// its debounced tail at quit.
+  /// Panes read a histogram by constructing a tracker, so without this a look at
+  /// a display wrote an all-zero array at the next quit. Not `unwrittenSeconds`:
+  /// that is 0 after every write-through, and the debounced tail still needs flushing.
   private var hasAccumulated = false
 
   public init(defaults: UserDefaults = .standard, persistenceKey: String) {
@@ -192,8 +189,7 @@ public final class WearSignalTracker {
   public func reset() {
     slots = [Double](repeating: 0, count: Self.slotCount)
     unwrittenSeconds = 0
-    // Or the next flush re-creates the keys this just removed, which is what
-    // "leaves no key behind" promises not to happen.
+    // Or the next flush re-creates the keys removed below.
     hasAccumulated = false
     // Removed rather than zeroed, matching `PanelHoursTracker`: a settings
     // reset should leave no key behind, and every read here treats absence as
@@ -202,8 +198,8 @@ public final class WearSignalTracker {
     defaults.removeObject(forKey: versionKey)
   }
 
-  /// The undebounced write, for termination and sleep. A tracker that has booked
-  /// nothing has nothing to say, so it writes nothing: see `hasAccumulated`.
+  /// The undebounced write, for termination and sleep. Skipped for a tracker
+  /// that booked nothing; see `hasAccumulated`.
   public func flush() {
     guard hasAccumulated else { return }
     writeThrough()

--- a/CandelaKit/Sources/CandelaKit/Provenance/ProvenanceEnvelope.swift
+++ b/CandelaKit/Sources/CandelaKit/Provenance/ProvenanceEnvelope.swift
@@ -78,8 +78,15 @@ public struct ProvenanceEnvelope: Codable, Equatable, Sendable {
     return try decoder.decode(ProvenanceEnvelope.self, from: Data(contentsOf: url))
   }
 
+  /// Named for the panel, not for the user's label: `displayName` carries a
+  /// friendly name someone typed, which is not what the record is about. Same
+  /// sanitizer as a checkup export, since a product name is whatever the EDID
+  /// says and a slash in it would reach the save panel as a path.
   public static func exportFileName(for record: ProvenanceRecord) -> String {
-    let model = record.identity.displayName.isEmpty ? "Display" : record.identity.displayName
-    return "Candela Provenance \(model) \(CheckupStore.day(record.exportedAt)).candela-provenance.json"
+    let model = [record.identity.edid?.productName, record.identity.displayName]
+      .compactMap { $0 }
+      .first { !$0.isEmpty } ?? "Display"
+    return "Candela Provenance \(CheckupStore.safe(model)) "
+      + "\(CheckupStore.day(record.exportedAt)).candela-provenance.json"
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Provenance/ProvenanceEnvelope.swift
+++ b/CandelaKit/Sources/CandelaKit/Provenance/ProvenanceEnvelope.swift
@@ -78,10 +78,8 @@ public struct ProvenanceEnvelope: Codable, Equatable, Sendable {
     return try decoder.decode(ProvenanceEnvelope.self, from: Data(contentsOf: url))
   }
 
-  /// Named for the panel, not for the user's label: `displayName` carries a
-  /// friendly name someone typed, which is not what the record is about. Same
-  /// filename sanitizer as a checkup export, since a product name is whatever
-  /// the EDID says and a slash in it would reach the save panel as a path.
+  /// Named for the panel, not the user's typed label. Same sanitizer as a
+  /// checkup export: a slash in an EDID name would reach the save panel as a path.
   public static func exportFileName(for record: ProvenanceRecord) -> String {
     let model = [record.identity.edid?.productName, record.identity.displayName]
       .compactMap { $0 }

--- a/CandelaKit/Sources/CandelaKit/Provenance/ProvenanceEnvelope.swift
+++ b/CandelaKit/Sources/CandelaKit/Provenance/ProvenanceEnvelope.swift
@@ -80,13 +80,13 @@ public struct ProvenanceEnvelope: Codable, Equatable, Sendable {
 
   /// Named for the panel, not for the user's label: `displayName` carries a
   /// friendly name someone typed, which is not what the record is about. Same
-  /// sanitizer as a checkup export, since a product name is whatever the EDID
-  /// says and a slash in it would reach the save panel as a path.
+  /// filename sanitizer as a checkup export, since a product name is whatever
+  /// the EDID says and a slash in it would reach the save panel as a path.
   public static func exportFileName(for record: ProvenanceRecord) -> String {
     let model = [record.identity.edid?.productName, record.identity.displayName]
       .compactMap { $0 }
       .first { !$0.isEmpty } ?? "Display"
-    return "Candela Provenance \(CheckupStore.safe(model)) "
+    return "Candela Provenance \(CheckupStore.safeFileName(model)) "
       + "\(CheckupStore.day(record.exportedAt)).candela-provenance.json"
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
@@ -496,13 +496,9 @@ public enum DiagnosticsCopy {
     return "Available"
   }
 
-  /// The claim itself, without the verdict prefix or its two causes. Extracted
-  /// so `hdrAvailability` states it once, and kept a separate builder because
-  /// the row it feeds is pinned on the exact sentence.
-  ///
-  /// The menu-bar panel does NOT use this: on a 280 pt row "has no HDR answer"
-  /// reads as the app not knowing, with none of the two causes below to explain
-  /// what it means. The panel names the observation instead.
+  /// The claim without its two causes; the row that uses it is pinned on the
+  /// exact sentence. The menu-bar panel does not use it: alone it reads as the
+  /// app not knowing.
   public static func hdrNoAnswer(app: String) -> String {
     "\(app) has no HDR answer for this display."
   }

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
@@ -491,9 +491,17 @@ public enum DiagnosticsCopy {
       return "Unavailable: macOS did not load the framework \(app) needs for HDR brightness"
     }
     guard supportsHDR else {
-      return "Unavailable: \(app) has no HDR answer for this display. Either it lists no HDR modes, or macOS did not load the framework \(app) asks. From here the two look the same."
+      return "Unavailable: \(hdrNoAnswer(app: app)) Either it lists no HDR modes, or macOS did not load the framework \(app) asks. From here the two look the same."
     }
     return "Available"
+  }
+
+  /// The claim itself, without the diagnostics row's verdict prefix or its two
+  /// causes: the menu-bar panel's greyed HDR button captions itself with this, and a
+  /// 280 pt row has no space for the full sentence. Shared rather than restated so
+  /// the surface a person meets first cannot drift from the one they meet second.
+  public static func hdrNoAnswer(app: String) -> String {
+    "\(app) has no HDR answer for this display."
   }
 
   // MARK: - Right now

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
@@ -496,10 +496,13 @@ public enum DiagnosticsCopy {
     return "Available"
   }
 
-  /// The claim itself, without the diagnostics row's verdict prefix or its two
-  /// causes: the menu-bar panel's greyed HDR button captions itself with this, and a
-  /// 280 pt row has no space for the full sentence. Shared rather than restated so
-  /// the surface a person meets first cannot drift from the one they meet second.
+  /// The claim itself, without the verdict prefix or its two causes. Extracted
+  /// so `hdrAvailability` states it once, and kept a separate builder because
+  /// the row it feeds is pinned on the exact sentence.
+  ///
+  /// The menu-bar panel does NOT use this: on a 280 pt row "has no HDR answer"
+  /// reads as the app not knowing, with none of the two causes below to explain
+  /// what it means. The panel names the observation instead.
   public static func hdrNoAnswer(app: String) -> String {
     "\(app) has no HDR answer for this display."
   }

--- a/CandelaKit/Sources/CandelaKit/Support/DisplayLogging.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DisplayLogging.swift
@@ -1,19 +1,12 @@
 import CryptoKit
 import Foundation
 
-/// A display's persistence key is the EDID UUID when the panel offers one and
-/// the name/manufacturer/serial triple when it does not, so the raw value can
-/// carry the panel's serial number. os_log at `.public` survives into a
-/// sysdiagnose and into anything `log show` collects, and both of those leave
-/// the machine: attached to a bug report, mailed to support, pasted into a
-/// thread, and nobody reads what is in them first. So the key goes out as a tag.
-///
-/// This is NOT a claim that the serial is unprintable anywhere. The diagnostics
-/// page renders both it and the raw key, deliberately: that page is shown to the
-/// person whose display it is, on screen, and copied by a decision they make.
+/// A persistence key without an EDID UUID embeds the panel's serial number, and
+/// `.public` os_log lines leave the machine in sysdiagnoses and bug reports. So
+/// logs carry a hash. The diagnostics page still shows the raw key: that one is
+/// shown on screen and copied by a decision the owner makes.
 public enum DisplayLogging {
-  /// Same key, same tag, every launch: correlating one display's lines across
-  /// sessions is the only reason to log the key at all.
+  /// Stable across launches, so one display's lines correlate across sessions.
   public static func tag(for persistenceKey: String) -> String {
     SHA256.hash(data: Data(persistenceKey.utf8))
       .prefix(4)

--- a/CandelaKit/Sources/CandelaKit/Support/DisplayLogging.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DisplayLogging.swift
@@ -1,0 +1,19 @@
+import CryptoKit
+import Foundation
+
+/// A display's persistence key is the EDID UUID when the panel offers one and
+/// the name/manufacturer/serial triple when it does not, so the raw value can
+/// carry the panel's serial number. os_log at `.public` survives into a
+/// sysdiagnose and into anything `log show` collects, so the key goes out as a
+/// tag instead: the diagnostics report already refuses to carry a serial value,
+/// and the log honours the same contract.
+public enum DisplayLogging {
+  /// Same key, same tag, every launch: correlating one display's lines across
+  /// sessions is the only reason to log the key at all.
+  public static func tag(for persistenceKey: String) -> String {
+    SHA256.hash(data: Data(persistenceKey.utf8))
+      .prefix(4)
+      .map { String(format: "%02x", $0) }
+      .joined()
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/DisplayLogging.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DisplayLogging.swift
@@ -4,9 +4,13 @@ import Foundation
 /// A display's persistence key is the EDID UUID when the panel offers one and
 /// the name/manufacturer/serial triple when it does not, so the raw value can
 /// carry the panel's serial number. os_log at `.public` survives into a
-/// sysdiagnose and into anything `log show` collects, so the key goes out as a
-/// tag instead: the diagnostics report already refuses to carry a serial value,
-/// and the log honours the same contract.
+/// sysdiagnose and into anything `log show` collects, and both of those leave
+/// the machine: attached to a bug report, mailed to support, pasted into a
+/// thread, and nobody reads what is in them first. So the key goes out as a tag.
+///
+/// This is NOT a claim that the serial is unprintable anywhere. The diagnostics
+/// page renders both it and the raw key, deliberately: that page is shown to the
+/// person whose display it is, on screen, and copied by a decision they make.
 public enum DisplayLogging {
   /// Same key, same tag, every launch: correlating one display's lines across
   /// sessions is the only reason to log the key at all.

--- a/CandelaKit/Tests/CandelaKitTests/AudioRoutingPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AudioRoutingPolicyTests.swift
@@ -3,13 +3,24 @@ import Testing
 
 @Suite("Audio routing policy")
 struct AudioRoutingPolicyTests {
-  // MARK: - Name normalization (fork DisplayManager.normalizedName)
+  // MARK: - Name normalization
 
-  @Test func normalizationStripsParensSpacesAndDigits() {
-    #expect(AudioRoutingPolicy.normalizedName("MAG 341C (2)") == "MAGC")
-    #expect(AudioRoutingPolicy.normalizedName("MAG341C") == "MAGC")
-    #expect(AudioRoutingPolicy.normalizedName("LG UltraFine 27") == "LGUltraFine")
+  @Test func normalizationDropsTheDuplicateSuffixAndKeepsDigits() {
+    #expect(AudioRoutingPolicy.normalizedName("MAG 341C (2)") == "MAG341C")
+    #expect(AudioRoutingPolicy.normalizedName("MAG341C") == "MAG341C")
+    #expect(AudioRoutingPolicy.normalizedName("LG UltraFine 27") == "LGUltraFine27")
     #expect(AudioRoutingPolicy.normalizedName("") == "")
+  }
+
+  /// The digit strip this replaced turned every "MAG n41C" into "MAGC", so a
+  /// press aimed at one panel of a family could land on its sibling.
+  @Test func sameFamilyPanelsDoNotCollide() {
+    #expect(AudioRoutingPolicy.displayMatchesDevice(
+      deviceName: "MAG 341C (2)", rawDisplayName: "MAG341C", nameOverride: ""
+    ))
+    #expect(!AudioRoutingPolicy.displayMatchesDevice(
+      deviceName: "MAG 271C", rawDisplayName: "MAG 341C", nameOverride: ""
+    ))
   }
 
   @Test func matchingComparesNormalizedForms() {
@@ -23,7 +34,7 @@ struct AudioRoutingPolicyTests {
 
   @Test func overrideWinsOverTheRawDisplayName() {
     #expect(AudioRoutingPolicy.displayMatchesDevice(
-      deviceName: "USB DAC 2", rawDisplayName: "MAG341C", nameOverride: "USB DAC"
+      deviceName: "USB DAC (2)", rawDisplayName: "MAG341C", nameOverride: "USB DAC"
     ))
     // Empty override falls back to the raw name, not to "matches everything".
     #expect(!AudioRoutingPolicy.displayMatchesDevice(

--- a/CandelaKit/Tests/CandelaKitTests/AudioRoutingPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AudioRoutingPolicyTests.swift
@@ -12,6 +12,42 @@ struct AudioRoutingPolicyTests {
     #expect(AudioRoutingPolicy.normalizedName("") == "")
   }
 
+  /// The counter suffix is all digits, so a parenthesized word survives: people
+  /// name two devices "(left)" and "(right)", and collapsing those to one name
+  /// sends both displays' volume keys wherever the match landed first.
+  @Test func aParenthesizedWordIsPartOfTheNameAndOnlyACounterIsDropped() {
+    #expect(AudioRoutingPolicy.normalizedName("Desk (left)") == "Deskleft")
+    #expect(AudioRoutingPolicy.normalizedName("Desk (right)") == "Deskright")
+    #expect(
+      AudioRoutingPolicy.normalizedName("Desk (left)")
+        != AudioRoutingPolicy.normalizedName("Desk (right)")
+    )
+    #expect(!AudioRoutingPolicy.displayMatchesDevice(
+      deviceName: "Desk (left)", rawDisplayName: "Desk (right)", nameOverride: ""
+    ))
+    // Mixed contents are not a counter either.
+    #expect(AudioRoutingPolicy.normalizedName("Studio (2b)") == "Studio2b")
+    #expect(AudioRoutingPolicy.normalizedName("Studio ()") == "Studio")
+    // CoreAudio's counter is ASCII. `isNumber` alone is true of every numeric
+    // scalar Unicode has, so a device named with Eastern Arabic digits lost its
+    // group and collided with the neighbour it was named apart from.
+    #expect(AudioRoutingPolicy.normalizedName("Desk (٢)") == "Desk٢")
+    #expect(
+      AudioRoutingPolicy.normalizedName("Desk (٢)")
+        != AudioRoutingPolicy.normalizedName("Desk (٣)")
+    )
+  }
+
+  /// A model name can end in a number, so a bare trailing digit group stays: the
+  /// two sizes of one product line are different displays.
+  @Test func aBareTrailingNumberIsPartOfTheModelName() {
+    #expect(AudioRoutingPolicy.normalizedName("UltraFine 27") == "UltraFine27")
+    #expect(AudioRoutingPolicy.normalizedName("UltraFine 32") == "UltraFine32")
+    #expect(!AudioRoutingPolicy.displayMatchesDevice(
+      deviceName: "UltraFine 27", rawDisplayName: "UltraFine 32", nameOverride: ""
+    ))
+  }
+
   /// The digit strip this replaced turned every "MAG n41C" into "MAGC", so a
   /// press aimed at one panel of a family could land on its sibling.
   @Test func sameFamilyPanelsDoNotCollide() {

--- a/CandelaKit/Tests/CandelaKitTests/AudioRoutingPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AudioRoutingPolicyTests.swift
@@ -12,9 +12,7 @@ struct AudioRoutingPolicyTests {
     #expect(AudioRoutingPolicy.normalizedName("") == "")
   }
 
-  /// The counter suffix is all digits, so a parenthesized word survives: people
-  /// name two devices "(left)" and "(right)", and collapsing those to one name
-  /// sends both displays' volume keys wherever the match landed first.
+  /// Only an all-digit group is a counter: "(left)" and "(right)" are two devices.
   @Test func aParenthesizedWordIsPartOfTheNameAndOnlyACounterIsDropped() {
     #expect(AudioRoutingPolicy.normalizedName("Desk (left)") == "Deskleft")
     #expect(AudioRoutingPolicy.normalizedName("Desk (right)") == "Deskright")
@@ -28,9 +26,8 @@ struct AudioRoutingPolicyTests {
     // Mixed contents are not a counter either.
     #expect(AudioRoutingPolicy.normalizedName("Studio (2b)") == "Studio2b")
     #expect(AudioRoutingPolicy.normalizedName("Studio ()") == "Studio")
-    // CoreAudio's counter is ASCII. `isNumber` alone is true of every numeric
-    // scalar Unicode has, so a device named with Eastern Arabic digits lost its
-    // group and collided with the neighbour it was named apart from.
+    // CoreAudio's counter is ASCII; `isNumber` alone would drop Eastern Arabic
+    // digits too.
     #expect(AudioRoutingPolicy.normalizedName("Desk (٢)") == "Desk٢")
     #expect(
       AudioRoutingPolicy.normalizedName("Desk (٢)")
@@ -38,8 +35,7 @@ struct AudioRoutingPolicyTests {
     )
   }
 
-  /// A model name can end in a number, so a bare trailing digit group stays: the
-  /// two sizes of one product line are different displays.
+  /// A bare trailing number is part of the model name.
   @Test func aBareTrailingNumberIsPartOfTheModelName() {
     #expect(AudioRoutingPolicy.normalizedName("UltraFine 27") == "UltraFine27")
     #expect(AudioRoutingPolicy.normalizedName("UltraFine 32") == "UltraFine32")
@@ -48,8 +44,7 @@ struct AudioRoutingPolicyTests {
     ))
   }
 
-  /// The digit strip this replaced turned every "MAG n41C" into "MAGC", so a
-  /// press aimed at one panel of a family could land on its sibling.
+  /// The old digit strip turned every "MAG n41C" into "MAGC".
   @Test func sameFamilyPanelsDoNotCollide() {
     #expect(AudioRoutingPolicy.displayMatchesDevice(
       deviceName: "MAG 341C (2)", rawDisplayName: "MAG341C", nameOverride: ""

--- a/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
@@ -29,8 +29,22 @@ struct CheckupStoreTests {
 
   @Test func exportFileNameCarriesModelAndDate() {
     let name = CheckupStore.exportFileName(for: report(started: 800_000_000))
-    #expect(name.hasPrefix("Candela Checkup DELL U2725QE 2026-05-09"))
+    #expect(name.hasPrefix("Candela Checkup DELL_U2725QE 2026-05-09"))
     #expect(name.hasSuffix(".candela-checkup.json"))
+  }
+
+  /// A product name is whatever the panel's EDID says. A slash in it would
+  /// reach the save panel as a path separator.
+  @Test func exportFileNameSanitizesTheModel() {
+    var hostile = report(started: 800_000_000)
+    hostile.identity = CheckupDisplayIdentity(
+      identityKey: "k1", vendorID: 1, modelID: 2, serial: nil, manufactureWeek: nil,
+      manufactureYear: nil, nativePixelWidth: 1, nativePixelHeight: 1, maxRefreshHz: nil,
+      supportsPQEOTF: false, supportsHDRGammaEOTF: false, productName: "AW/34: DW")
+    let name = CheckupStore.exportFileName(for: hostile)
+    #expect(!name.contains("/"))
+    #expect(!name.contains(":"))
+    #expect(name.hasPrefix("Candela Checkup AW_34__DW 2026-05-09"))
   }
 
   @Test func theBookingGridIsUniformAtTheFieldLuminance() {

--- a/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
@@ -27,8 +27,7 @@ struct CheckupStoreTests {
     #expect(try store.load(url: newer).validate())
   }
 
-  /// The display's own name, spaces and all: this is what the save panel offers,
-  /// so it reads the way the display is written on its own box.
+  /// Spaces kept: this is what the save panel offers.
   @Test func exportFileNameCarriesModelAndDate() {
     let name = CheckupStore.exportFileName(for: report(started: 800_000_000))
     #expect(name.hasPrefix("Candela Checkup DELL U2725QE 2026-05-09"))
@@ -50,8 +49,7 @@ struct CheckupStoreTests {
     #expect(name.hasPrefix("Candela Checkup AW_34_ DW 2026-05-09"))
   }
 
-  /// A leading dot would hide the exported file in Finder, and a person looking
-  /// for what they just saved would not find it.
+  /// A leading dot would hide the export in Finder.
   @Test func exportFileNameNeverStartsTheModelWithADot() {
     #expect(CheckupStore.safeFileName(".hidden") == "_hidden")
     #expect(CheckupStore.safeFileName("DELL U2725QE") == "DELL U2725QE")

--- a/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
@@ -27,9 +27,11 @@ struct CheckupStoreTests {
     #expect(try store.load(url: newer).validate())
   }
 
+  /// The display's own name, spaces and all: this is what the save panel offers,
+  /// so it reads the way the display is written on its own box.
   @Test func exportFileNameCarriesModelAndDate() {
     let name = CheckupStore.exportFileName(for: report(started: 800_000_000))
-    #expect(name.hasPrefix("Candela Checkup DELL_U2725QE 2026-05-09"))
+    #expect(name.hasPrefix("Candela Checkup DELL U2725QE 2026-05-09"))
     #expect(name.hasSuffix(".candela-checkup.json"))
   }
 
@@ -44,7 +46,15 @@ struct CheckupStoreTests {
     let name = CheckupStore.exportFileName(for: hostile)
     #expect(!name.contains("/"))
     #expect(!name.contains(":"))
-    #expect(name.hasPrefix("Candela Checkup AW_34__DW 2026-05-09"))
+    // The two path characters go; the space between them does not.
+    #expect(name.hasPrefix("Candela Checkup AW_34_ DW 2026-05-09"))
+  }
+
+  /// A leading dot would hide the exported file in Finder, and a person looking
+  /// for what they just saved would not find it.
+  @Test func exportFileNameNeverStartsTheModelWithADot() {
+    #expect(CheckupStore.safeFileName(".hidden") == "_hidden")
+    #expect(CheckupStore.safeFileName("DELL U2725QE") == "DELL U2725QE")
   }
 
   @Test func theBookingGridIsUniformAtTheFieldLuminance() {

--- a/CandelaKit/Tests/CandelaKitTests/DiagnosticsCopyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DiagnosticsCopyTests.swift
@@ -392,6 +392,19 @@ struct DiagnosticsCopyTests {
         == "Unavailable: macOS did not load the framework Candela needs for HDR brightness")
   }
 
+  /// The menu-bar panel captions its greyed HDR button with this, and the row above
+  /// opens with it. Pinned as one string so the short surface cannot start blaming
+  /// the display while the long one still does not.
+  @Test func theShortHDRSentenceIsTheOpeningOfTheLongOne() {
+    #expect(
+      DiagnosticsCopy.hdrNoAnswer(app: Self.app)
+        == "Candela has no HDR answer for this display.")
+    #expect(
+      DiagnosticsCopy.hdrAvailability(
+        displayServicesAvailable: true, supportsHDR: false, app: Self.app)
+        .contains(DiagnosticsCopy.hdrNoAnswer(app: Self.app)))
+  }
+
   // MARK: - Verdict
 
   /// The arms are an ORDER, not a set, and testing each with the others neutral
@@ -836,6 +849,7 @@ struct DiagnosticsCopyTests {
       DiagnosticsCopy.mirroring(isMirrorSlave: true, isSynthesized: true),
       DiagnosticsCopy.hdrState(engaged: true),
       DiagnosticsCopy.hdrState(engaged: false),
+      DiagnosticsCopy.hdrNoAnswer(app: app),
       DiagnosticsCopy.writeGate(isSending: true),
       DiagnosticsCopy.writeGate(isSending: false),
       DiagnosticsCopy.nativeBrightness(isAvailable: true, app: app),

--- a/CandelaKit/Tests/CandelaKitTests/DisplayLoggingTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayLoggingTests.swift
@@ -36,9 +36,22 @@ struct DisplayLoggingTests {
       != DisplayLogging.tag(for: Self.tripleKey))
   }
 
+  /// Over a 12-character serial the assertion below could not fail: an
+  /// 8-character tag cannot contain it however the tag is built, so a truncating
+  /// implementation that leaked the key outright would still pass. A two-letter
+  /// key is short enough to fit, and the tag is asserted against every prefix of
+  /// it, which is what a truncating implementation would produce.
   @Test func tagCarriesNeitherTheSerialNorTheKey() {
-    let tag = DisplayLogging.tag(for: Self.tripleKey)
-    #expect(!tag.contains(Self.serial))
-    #expect(!tag.contains("MSIMAG341C"))
+    #expect(!DisplayLogging.tag(for: Self.tripleKey).contains(Self.serial))
+    #expect(!DisplayLogging.tag(for: Self.tripleKey).contains("MSIMAG341C"))
+
+    // Lowercase hex, so the assertions below are not passing on a case
+    // mismatch the tag alphabet makes free.
+    let short = "ab"
+    let tag = DisplayLogging.tag(for: short)
+    for length in 1...short.count {
+      #expect(tag != String(short.prefix(length)))
+      #expect(!tag.hasPrefix(String(short.prefix(length))))
+    }
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/DisplayLoggingTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayLoggingTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import CandelaKit
+
+@Suite("Display logging tags")
+struct DisplayLoggingTests {
+  /// The serial-bearing fallback shape `DisplayDiscovery.persistenceKey` builds
+  /// when the EDID carries no UUID.
+  private static let serial = "ABC123456789"
+  private static let tripleKey = "MSIMAG341C-MSI-\(serial)"
+  private static let uuidKey = "4C2E9A11-0000-0000-0000-000000000001"
+
+  @Test func tagIsEightHexCharacters() {
+    let tag = DisplayLogging.tag(for: Self.tripleKey)
+    #expect(tag.count == 8)
+    #expect(tag.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+  }
+
+  /// Pinned, not just self-consistent: a tag that changed between builds would
+  /// break the one thing it is for, correlating a display's lines across
+  /// sessions.
+  @Test func tagIsPinnedToTheKeyBytes() {
+    #expect(DisplayLogging.tag(for: Self.tripleKey) == "cee121a0")
+    #expect(DisplayLogging.tag(for: Self.uuidKey) == "8b0f6bee")
+    #expect(DisplayLogging.tag(for: "") == "e3b0c442")
+  }
+
+  @Test func sameKeyGivesTheSameTag() {
+    #expect(DisplayLogging.tag(for: Self.tripleKey) == DisplayLogging.tag(for: Self.tripleKey))
+  }
+
+  @Test func differentKeysGiveDifferentTags() {
+    #expect(DisplayLogging.tag(for: Self.tripleKey) != DisplayLogging.tag(for: Self.uuidKey))
+    // One character apart, so a truncating or prefix-only scheme fails here.
+    #expect(DisplayLogging.tag(for: "MSIMAG341C-MSI-ABC123456788")
+      != DisplayLogging.tag(for: Self.tripleKey))
+  }
+
+  @Test func tagCarriesNeitherTheSerialNorTheKey() {
+    let tag = DisplayLogging.tag(for: Self.tripleKey)
+    #expect(!tag.contains(Self.serial))
+    #expect(!tag.contains("MSIMAG341C"))
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/DisplayLoggingTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayLoggingTests.swift
@@ -16,9 +16,8 @@ struct DisplayLoggingTests {
     #expect(tag.allSatisfy { $0.isHexDigit && !$0.isUppercase })
   }
 
-  /// Pinned, not just self-consistent: a tag that changed between builds would
-  /// break the one thing it is for, correlating a display's lines across
-  /// sessions.
+  /// Pinned: a tag that changed between builds could not correlate a display
+  /// across sessions.
   @Test func tagIsPinnedToTheKeyBytes() {
     #expect(DisplayLogging.tag(for: Self.tripleKey) == "cee121a0")
     #expect(DisplayLogging.tag(for: Self.uuidKey) == "8b0f6bee")
@@ -36,17 +35,13 @@ struct DisplayLoggingTests {
       != DisplayLogging.tag(for: Self.tripleKey))
   }
 
-  /// Over a 12-character serial the assertion below could not fail: an
-  /// 8-character tag cannot contain it however the tag is built, so a truncating
-  /// implementation that leaked the key outright would still pass. A two-letter
-  /// key is short enough to fit, and the tag is asserted against every prefix of
-  /// it, which is what a truncating implementation would produce.
+  /// An 8-char tag cannot contain a 12-char serial however it is built, so the
+  /// short key is what makes a truncating leak fail here.
   @Test func tagCarriesNeitherTheSerialNorTheKey() {
     #expect(!DisplayLogging.tag(for: Self.tripleKey).contains(Self.serial))
     #expect(!DisplayLogging.tag(for: Self.tripleKey).contains("MSIMAG341C"))
 
-    // Lowercase hex, so the assertions below are not passing on a case
-    // mismatch the tag alphabet makes free.
+    // Lowercase, so a case mismatch cannot make these pass.
     let short = "ab"
     let tag = DisplayLogging.tag(for: short)
     for length in 1...short.count {

--- a/CandelaKit/Tests/CandelaKitTests/DisplayRotationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayRotationTests.swift
@@ -5,12 +5,15 @@ import Testing
 
 @Suite("Display rotation")
 struct DisplayRotationTests {
-  private func display(_ id: CGDirectDisplayID, builtIn: Bool = false) -> ConfiguredDisplay {
+  private func display(
+    _ id: CGDirectDisplayID, builtIn: Bool = false, mirroring: CGDirectDisplayID? = nil
+  ) -> ConfiguredDisplay {
     ConfiguredDisplay(
       id: id,
       identity: DisplayConfigIdentity(vendor: 0x3669, model: 0x3DD0, serial: 0, isBuiltIn: builtIn),
       name: "Display \(id)",
-      isBuiltIn: builtIn
+      isBuiltIn: builtIn,
+      mirrorsDisplay: mirroring ?? kCGNullDirectDisplay
     )
   }
 
@@ -79,6 +82,27 @@ struct DisplayRotationTests {
       currentRotation: .standard, isSupported: true
     )
     #expect(decision == .refused(.displayGone))
+  }
+
+  /// The refusal the policy had the flag for and never read: a slave's pixels
+  /// come from its master, and the request looks ordinary right up to the apply.
+  ///
+  /// The MASTER of the same set is untouched, which is the half that makes this
+  /// a carve-out rather than a blanket "anything mirrored is off limits": it
+  /// owns the framebuffer, so its glass is its own to turn.
+  @Test func aMirrorSlaveIsRefusedWhileItsMasterIsStillRotatable() {
+    let set = [display(1), display(2, mirroring: 1)]
+    #expect(RotationPolicy.decide(
+      display: 2, to: .ninety, in: set, currentRotation: .standard, isSupported: true
+    ) == .refused(.mirrored))
+    #expect(RotationPolicy.decide(
+      display: 1, to: .ninety, in: set, currentRotation: .standard, isSupported: true
+    ) == .rotate(RotationRequest(display: 1, from: .standard, to: .ninety)))
+    // And a standalone display is unchanged by the new guard.
+    #expect(RotationPolicy.decide(
+      display: 2, to: .ninety, in: [display(1), display(2)],
+      currentRotation: .standard, isSupported: true
+    ) == .rotate(RotationRequest(display: 2, from: .standard, to: .ninety)))
   }
 
   /// A missing current angle reaching the policy: no readable current angle means no honest "from"

--- a/CandelaKit/Tests/CandelaKitTests/DisplayRotationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayRotationTests.swift
@@ -60,7 +60,7 @@ struct DisplayRotationTests {
   @Test func aRotationToADifferentAngleIsApprovedAndCarriesBothEnds() {
     let decision = RotationPolicy.decide(
       display: 2, to: .ninety, in: [display(1), display(2)],
-      currentRotation: .standard, isSupported: true
+      currentRotation: .standard, isSupported: true, isSynthesizedSize: false
     )
     #expect(decision == .rotate(RotationRequest(display: 2, from: .standard, to: .ninety)))
   }
@@ -71,7 +71,7 @@ struct DisplayRotationTests {
   @Test func rotatingToTheAngleItIsAlreadyAtIsRefusedRatherThanApplied() {
     let decision = RotationPolicy.decide(
       display: 2, to: .twoSeventy, in: [display(2)],
-      currentRotation: .twoSeventy, isSupported: true
+      currentRotation: .twoSeventy, isSupported: true, isSynthesizedSize: false
     )
     #expect(decision == .refused(.unchanged(.twoSeventy)))
   }
@@ -79,7 +79,7 @@ struct DisplayRotationTests {
   @Test func aDisplayThatIsNotInTheListIsRefusedAsGone() {
     let decision = RotationPolicy.decide(
       display: 9, to: .ninety, in: [display(1), display(2)],
-      currentRotation: .standard, isSupported: true
+      currentRotation: .standard, isSupported: true, isSynthesizedSize: false
     )
     #expect(decision == .refused(.displayGone))
   }
@@ -93,16 +93,34 @@ struct DisplayRotationTests {
   @Test func aMirrorSlaveIsRefusedWhileItsMasterIsStillRotatable() {
     let set = [display(1), display(2, mirroring: 1)]
     #expect(RotationPolicy.decide(
-      display: 2, to: .ninety, in: set, currentRotation: .standard, isSupported: true
+      display: 2, to: .ninety, in: set, currentRotation: .standard,
+      isSupported: true, isSynthesizedSize: false
     ) == .refused(.mirrored))
     #expect(RotationPolicy.decide(
-      display: 1, to: .ninety, in: set, currentRotation: .standard, isSupported: true
+      display: 1, to: .ninety, in: set, currentRotation: .standard,
+      isSupported: true, isSynthesizedSize: false
     ) == .rotate(RotationRequest(display: 1, from: .standard, to: .ninety)))
     // And a standalone display is unchanged by the new guard.
     #expect(RotationPolicy.decide(
       display: 2, to: .ninety, in: [display(1), display(2)],
-      currentRotation: .standard, isSupported: true
+      currentRotation: .standard, isSupported: true, isSynthesizedSize: false
     ) == .rotate(RotationRequest(display: 2, from: .standard, to: .ninety)))
+  }
+
+  /// A display running a size this app renders sets the raw mirroring flag, so
+  /// without its own arm it would be refused as mirroring and told to look for a
+  /// display it is showing. Same set membership, two different answers, decided
+  /// by the flag the caller states.
+  @Test func aDisplayShowingARenderedSizeIsRefusedForThatRatherThanForMirroring() {
+    let set = [display(1), display(2, mirroring: 1)]
+    #expect(RotationPolicy.decide(
+      display: 2, to: .ninety, in: set, currentRotation: .standard,
+      isSupported: true, isSynthesizedSize: true
+    ) == .refused(.synthesizedSize))
+    #expect(RotationPolicy.decide(
+      display: 2, to: .ninety, in: set, currentRotation: .standard,
+      isSupported: true, isSynthesizedSize: false
+    ) == .refused(.mirrored))
   }
 
   /// A missing current angle reaching the policy: no readable current angle means no honest "from"
@@ -110,7 +128,7 @@ struct DisplayRotationTests {
   @Test func aDisplayWhoseAngleCannotBeReadIsRefusedAsUnreadable() {
     let decision = RotationPolicy.decide(
       display: 2, to: .ninety, in: [display(2)],
-      currentRotation: nil, isSupported: true
+      currentRotation: nil, isSupported: true, isSynthesizedSize: false
     )
     #expect(decision == .refused(.unreadable))
   }
@@ -121,14 +139,15 @@ struct DisplayRotationTests {
     for current in [DisplayRotation.standard, .ninety] {
       let decision = RotationPolicy.decide(
         display: 2, to: .ninety, in: [display(2)],
-        currentRotation: current, isSupported: false
+        currentRotation: current, isSupported: false, isSynthesizedSize: false
       )
       #expect(decision == .refused(.unavailable))
     }
     // Even for a display that is not there: unavailable is the truthful answer,
     // and "which display" is not a question worth asking of a dead API.
     #expect(RotationPolicy.decide(
-      display: 9, to: .ninety, in: [], currentRotation: nil, isSupported: false
+      display: 9, to: .ninety, in: [], currentRotation: nil, isSupported: false,
+      isSynthesizedSize: false
     ) == .refused(.unavailable))
   }
 

--- a/CandelaKit/Tests/CandelaKitTests/DisplayRotationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayRotationTests.swift
@@ -84,12 +84,8 @@ struct DisplayRotationTests {
     #expect(decision == .refused(.displayGone))
   }
 
-  /// The refusal the policy had the flag for and never read: a slave's pixels
-  /// come from its master, and the request looks ordinary right up to the apply.
-  ///
-  /// The MASTER of the same set is untouched, which is the half that makes this
-  /// a carve-out rather than a blanket "anything mirrored is off limits": it
-  /// owns the framebuffer, so its glass is its own to turn.
+  /// A slave's pixels come from its master, so it is refused; the master owns
+  /// the framebuffer and stays rotatable.
   @Test func aMirrorSlaveIsRefusedWhileItsMasterIsStillRotatable() {
     let set = [display(1), display(2, mirroring: 1)]
     #expect(RotationPolicy.decide(
@@ -100,17 +96,15 @@ struct DisplayRotationTests {
       display: 1, to: .ninety, in: set, currentRotation: .standard,
       isSupported: true, isSynthesizedSize: false
     ) == .rotate(RotationRequest(display: 1, from: .standard, to: .ninety)))
-    // And a standalone display is unchanged by the new guard.
+    // A standalone display is unaffected.
     #expect(RotationPolicy.decide(
       display: 2, to: .ninety, in: [display(1), display(2)],
       currentRotation: .standard, isSupported: true, isSynthesizedSize: false
     ) == .rotate(RotationRequest(display: 2, from: .standard, to: .ninety)))
   }
 
-  /// A display running a size this app renders sets the raw mirroring flag, so
-  /// without its own arm it would be refused as mirroring and told to look for a
-  /// display it is showing. Same set membership, two different answers, decided
-  /// by the flag the caller states.
+  /// A rendered size sets the raw mirroring flag, so without its own arm it would
+  /// be refused as mirroring. Same set, two answers, decided by the caller's flag.
   @Test func aDisplayShowingARenderedSizeIsRefusedForThatRatherThanForMirroring() {
     let set = [display(1), display(2, mirroring: 1)]
     #expect(RotationPolicy.decide(

--- a/CandelaKit/Tests/CandelaKitTests/HDRCapabilityProbeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/HDRCapabilityProbeTests.swift
@@ -1,0 +1,54 @@
+import Testing
+@testable import CandelaKit
+
+/// `supportsHDR` false reads the same for "asked, no HDR modes" and for "not asked
+/// yet", so anything that captions the greyed HDR button needs a second fact: whether
+/// the capability refresh has answered at all. Without it the panel calls an HDR
+/// display incapable for as long as the first refresh takes.
+@MainActor
+@Suite("HDR capability probe")
+struct HDRCapabilityProbeTests {
+  /// The init refresh is queued on the main actor and this test never suspends, so
+  /// the reading is the pre-refresh one by construction, not by luck.
+  @Test func theProbeHasNotLandedBeforeTheFirstRefresh() {
+    let h = Harness(hdrSupported: true)
+    #expect(h.controller.hdrCapabilityProbed == false)
+    #expect(h.controller.supportsHDR == false)
+  }
+
+  @Test func aRefreshThatFindsNoHDRCountsAsAnAnswer() async {
+    let h = Harness(hdrSupported: false)
+    await h.prime()
+    #expect(h.controller.hdrCapabilityProbed)
+    #expect(h.controller.supportsHDR == false)
+  }
+
+  @Test func aRefreshThatFindsHDRCountsToo() async {
+    let h = Harness(hdrSupported: true)
+    await h.prime()
+    #expect(h.controller.hdrCapabilityProbed)
+    #expect(h.controller.supportsHDR)
+  }
+
+  /// A different panel on the same port: the old verdict is not a fact about the new
+  /// display, so the caption goes quiet until the reconfiguration's refresh answers.
+  @Test func aPanelSwapRetractsTheAnswer() async {
+    let h = Harness(hdrSupported: true)
+    await h.prime()
+    #expect(h.controller.hdrCapabilityProbed)
+
+    h.controller.rebind(writer: h.ddc, panelIdentity: "a-different-panel")
+    #expect(h.controller.hdrCapabilityProbed == false)
+  }
+
+  /// Rebinding the SAME panel is the every-pass case (`AppModel.performRefresh` runs
+  /// it on wake, reconfiguration and menu open), and dropping the answer there would
+  /// blank the caption several times a session.
+  @Test func aPlainRebindKeepsTheAnswer() async {
+    let h = Harness(hdrSupported: false)
+    await h.prime()
+
+    h.controller.rebind(writer: h.ddc, panelIdentity: nil)
+    #expect(h.controller.hdrCapabilityProbed)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/HDRCapabilityProbeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/HDRCapabilityProbeTests.swift
@@ -1,10 +1,8 @@
 import Testing
 @testable import CandelaKit
 
-/// `supportsHDR` false reads the same for "asked, no HDR modes" and for "not asked
-/// yet", so anything that captions the greyed HDR button needs a second fact: whether
-/// the capability refresh has answered at all. Without it the panel calls an HDR
-/// display incapable for as long as the first refresh takes.
+/// `supportsHDR` false reads the same for "no HDR modes" and "not asked yet", so
+/// a caption on the greyed button needs to know whether the refresh answered.
 @MainActor
 @Suite("HDR capability probe")
 struct HDRCapabilityProbeTests {
@@ -30,8 +28,7 @@ struct HDRCapabilityProbeTests {
     #expect(h.controller.supportsHDR)
   }
 
-  /// A different panel on the same port: the old verdict is not a fact about the new
-  /// display, so the caption goes quiet until the reconfiguration's refresh answers.
+  /// A different panel on the same port: the old verdict is not a fact about it.
   @Test func aPanelSwapRetractsTheAnswer() async {
     let h = Harness(hdrSupported: true)
     await h.prime()
@@ -41,9 +38,8 @@ struct HDRCapabilityProbeTests {
     #expect(h.controller.hdrCapabilityProbed == false)
   }
 
-  /// Rebinding the SAME panel is the every-pass case (`AppModel.performRefresh` runs
-  /// it on wake, reconfiguration and menu open), and dropping the answer there would
-  /// blank the caption several times a session.
+  /// A same-panel rebind happens on every refresh pass; dropping the answer
+  /// there would blank the caption several times a session.
   @Test func aPlainRebindKeepsTheAnswer() async {
     let h = Harness(hdrSupported: false)
     await h.prime()

--- a/CandelaKit/Tests/CandelaKitTests/LockDimTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/LockDimTests.swift
@@ -408,12 +408,16 @@ struct LockDimTests {
   }
 
   /// Three settings surfaces each picked their own staleness number, one of them
-  /// disagreeing with its own comment. Both windows are multiples of the
+  /// disagreeing with its own comment. Both windows are derived from the
   /// sampling interval now, and the stall warning's copy says "over 10 minutes".
+  ///
+  /// The liveness window sits BETWEEN captures rather than on one: at exactly
+  /// two intervals a single skipped capture put the dot out.
   @Test func stalenessWindowsAreMultiplesOfTheSamplingInterval() {
     #expect(OledCareCadence.sampling == .seconds(60))
     #expect(OledCareCadence.samplingSeconds == 60)
-    #expect(OledCareCadence.livenessWindowSeconds == 120)
+    #expect(OledCareCadence.livenessWindowSeconds == 150)
+    #expect(OledCareCadence.livenessWindowSeconds > 2 * OledCareCadence.samplingSeconds)
     #expect(OledCareCadence.stallWarningSeconds == 600)
   }
 

--- a/CandelaKit/Tests/CandelaKitTests/LockDimTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/LockDimTests.swift
@@ -380,10 +380,8 @@ struct LockDimTests {
     #expect(OledCareCadence.fast == .milliseconds(100))
   }
 
-  /// With nothing enrolled the tick returns at its empty guard, so the 2 s
-  /// wakeup bought a user who never opted in nothing at all. A pending
-  /// verification still outranks the idle cadence: those entries outlive the
-  /// state that issued them.
+  /// A pending verification outranks the idle cadence: those entries outlive
+  /// the state that issued them.
   @Test func nothingEnrolledIdlesTheLoopUnlessAVerificationIsPending() {
     #expect(
       OledCareCadence.interval(
@@ -397,7 +395,7 @@ struct LockDimTests {
         anythingEnrolled: false
       ) == OledCareCadence.fast
     )
-    // An enrolled display is still the 2 s cadence, untouched by the new term.
+    // An enrolled display keeps the slow cadence.
     #expect(
       OledCareCadence.interval(
         anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
@@ -407,12 +405,9 @@ struct LockDimTests {
     #expect(OledCareCadence.idle == .seconds(30))
   }
 
-  /// Three settings surfaces each picked their own staleness number, one of them
-  /// disagreeing with its own comment. Both windows are derived from the
-  /// sampling interval now, and the stall warning's copy says "over 10 minutes".
-  ///
-  /// The liveness window sits BETWEEN captures rather than on one: at exactly
-  /// two intervals a single skipped capture put the dot out.
+  /// Both windows derive from the sampling interval; the stall warning's copy
+  /// says "over 10 minutes". The liveness window sits between captures: at
+  /// exactly two intervals one skipped capture put the dot out.
   @Test func stalenessWindowsAreMultiplesOfTheSamplingInterval() {
     #expect(OledCareCadence.sampling == .seconds(60))
     #expect(OledCareCadence.samplingSeconds == 60)

--- a/CandelaKit/Tests/CandelaKitTests/LockDimTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/LockDimTests.swift
@@ -380,6 +380,43 @@ struct LockDimTests {
     #expect(OledCareCadence.fast == .milliseconds(100))
   }
 
+  /// With nothing enrolled the tick returns at its empty guard, so the 2 s
+  /// wakeup bought a user who never opted in nothing at all. A pending
+  /// verification still outranks the idle cadence: those entries outlive the
+  /// state that issued them.
+  @Test func nothingEnrolledIdlesTheLoopUnlessAVerificationIsPending() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        anythingEnrolled: false
+      ) == OledCareCadence.idle
+    )
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: true,
+        anythingEnrolled: false
+      ) == OledCareCadence.fast
+    )
+    // An enrolled display is still the 2 s cadence, untouched by the new term.
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        anythingEnrolled: true
+      ) == OledCareCadence.slow
+    )
+    #expect(OledCareCadence.idle == .seconds(30))
+  }
+
+  /// Three settings surfaces each picked their own staleness number, one of them
+  /// disagreeing with its own comment. Both windows are multiples of the
+  /// sampling interval now, and the stall warning's copy says "over 10 minutes".
+  @Test func stalenessWindowsAreMultiplesOfTheSamplingInterval() {
+    #expect(OledCareCadence.sampling == .seconds(60))
+    #expect(OledCareCadence.samplingSeconds == 60)
+    #expect(OledCareCadence.livenessWindowSeconds == 120)
+    #expect(OledCareCadence.stallWarningSeconds == 600)
+  }
+
   /// The engine can no longer ask for a lock-dim OVERLAY at all. The delivery
   /// ruling is structural rather than a convention the coordinator honours.
   @Test func theOverlayLayerCannotProduceALockDim() {

--- a/CandelaKit/Tests/CandelaKitTests/OwnerHoursAccumulatorTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/OwnerHoursAccumulatorTests.swift
@@ -164,4 +164,43 @@ struct OwnerHoursAccumulatorTests {
 
     #expect(try JSONDecoder().decode(OwnerHours.self, from: legacyData) == acc.hours)
   }
+
+  // MARK: - The encode-time owner cap
+
+  private func sixtyOwners() -> OwnerHours {
+    var seconds: [String: Double] = [:]
+    for index in 0..<60 { seconds[String(format: "App%02d", index)] = Double(index + 1) }
+    return OwnerHours(secondsByOwner: seconds, totalSeconds: seconds.values.reduce(0, +))
+  }
+
+  /// The store is rewritten every five minutes and never forgets an app, so
+  /// without a cap the prefs blob grows for the life of the machine. The fold
+  /// keeps the per-owner seconds summing to the total.
+  @Test func encodingKeepsTheHeaviestOwnersAndFoldsTheRest() throws {
+    let hours = sixtyOwners()
+    let decoded = try JSONDecoder().decode(OwnerHours.self, from: JSONEncoder().encode(hours))
+
+    #expect(decoded.secondsByOwner.count == OwnerHours.storedOwnerLimit + 1)
+    // App00...App09 carry 1 through 10 seconds, so they are the ten dropped.
+    let dropped = (1...10).reduce(0.0) { $0 + Double($1) }
+    #expect(abs(decoded.secondsByOwner[OwnerHours.foldedOwnerKey]! - dropped) < 0.0001)
+    #expect(decoded.secondsByOwner["App59"] == 60)
+    #expect(decoded.totalSeconds == hours.totalSeconds)
+    #expect(abs(decoded.secondsByOwner.values.reduce(0, +) - hours.totalSeconds) < 0.0001)
+  }
+
+  /// Every five-minute write re-encodes what the last one wrote, so a fold that
+  /// was not idempotent would eat one more owner on every save.
+  @Test func anAlreadyFoldedStoreReEncodesToItself() throws {
+    let once = try JSONDecoder().decode(OwnerHours.self, from: JSONEncoder().encode(sixtyOwners()))
+    let twice = try JSONDecoder().decode(OwnerHours.self, from: JSONEncoder().encode(once))
+    #expect(twice == once)
+  }
+
+  /// The bucket is a storage detail, and its key is not a name any app can have.
+  @Test func theFoldedBucketNeverReachesTheOwnerList() {
+    let hours = OwnerHours(
+      secondsByOwner: [OwnerHours.foldedOwnerKey: 7200, "Slack": 3600], totalSeconds: 10800)
+    #expect(hours.topOwners(limit: 5).map(\.owner) == ["Slack"])
+  }
 }

--- a/CandelaKit/Tests/CandelaKitTests/OwnerHoursAccumulatorTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/OwnerHoursAccumulatorTests.swift
@@ -173,14 +173,13 @@ struct OwnerHoursAccumulatorTests {
     return OwnerHours(secondsByOwner: seconds, totalSeconds: seconds.values.reduce(0, +))
   }
 
-  /// The store is rewritten every five minutes and never forgets an app, so
-  /// without a cap the prefs blob grows for the life of the machine. The fold
-  /// keeps the per-owner seconds plus the folded field summing to the total.
+  /// Without a cap the prefs blob grows for the life of the machine. Kept plus
+  /// folded must still sum to the total.
   @Test func encodingKeepsTheHeaviestOwnersAndFoldsTheRest() throws {
     let hours = sixtyOwners()
     let decoded = try JSONDecoder().decode(OwnerHours.self, from: JSONEncoder().encode(hours))
 
-    // Exactly the limit: the fold is a field of its own, not a 51st owner.
+    // Exactly the limit: the fold is a field of its own, not an extra owner.
     #expect(decoded.secondsByOwner.count == OwnerHours.storedOwnerLimit)
     // App00...App09 carry 1 through 10 seconds, so they are the ten dropped.
     let dropped = (1...10).reduce(0.0) { $0 + Double($1) }
@@ -193,9 +192,8 @@ struct OwnerHoursAccumulatorTests {
     )
   }
 
-  /// A store written before the fold had a field of its own carries it under an
-  /// owner key, and a build that did not filter that key drew it as the heaviest
-  /// app on the display. It is migrated out on decode and never written back.
+  /// Older stores carry the fold under an owner key, which drew as the heaviest
+  /// app. Migrated out on decode, never written back.
   @Test func aLegacyFoldedBucketIsMigratedOutOfTheOwnerList() throws {
     let legacy: [String: Any] = [
       "schemaVersion": OledStoreSchema.currentVersion,
@@ -217,16 +215,16 @@ struct OwnerHoursAccumulatorTests {
     #expect(owners["other/apps"] == nil)
   }
 
-  /// Every five-minute write re-encodes what the last one wrote, so a fold that
-  /// was not idempotent would eat one more owner on every save.
+  /// Each write re-encodes the last, so a non-idempotent fold eats one more
+  /// owner per save.
   @Test func anAlreadyFoldedStoreReEncodesToItself() throws {
     let once = try JSONDecoder().decode(OwnerHours.self, from: JSONEncoder().encode(sixtyOwners()))
     let twice = try JSONDecoder().decode(OwnerHours.self, from: JSONEncoder().encode(once))
     #expect(twice == once)
   }
 
-  /// The fold is a storage detail and lives outside the owner map, so the owner
-  /// list needs no filter to keep it off screen: there is nothing there to skip.
+  /// The fold lives outside the owner map, so the list needs no filter to keep
+  /// it off screen.
   @Test func theFoldedBucketNeverReachesTheOwnerList() {
     let hours = OwnerHours(
       secondsByOwner: ["Slack": 3600], totalSeconds: 10800, foldedSeconds: 7200)

--- a/CandelaKit/Tests/CandelaKitTests/OwnerHoursAccumulatorTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/OwnerHoursAccumulatorTests.swift
@@ -175,18 +175,46 @@ struct OwnerHoursAccumulatorTests {
 
   /// The store is rewritten every five minutes and never forgets an app, so
   /// without a cap the prefs blob grows for the life of the machine. The fold
-  /// keeps the per-owner seconds summing to the total.
+  /// keeps the per-owner seconds plus the folded field summing to the total.
   @Test func encodingKeepsTheHeaviestOwnersAndFoldsTheRest() throws {
     let hours = sixtyOwners()
     let decoded = try JSONDecoder().decode(OwnerHours.self, from: JSONEncoder().encode(hours))
 
-    #expect(decoded.secondsByOwner.count == OwnerHours.storedOwnerLimit + 1)
+    // Exactly the limit: the fold is a field of its own, not a 51st owner.
+    #expect(decoded.secondsByOwner.count == OwnerHours.storedOwnerLimit)
     // App00...App09 carry 1 through 10 seconds, so they are the ten dropped.
     let dropped = (1...10).reduce(0.0) { $0 + Double($1) }
-    #expect(abs(decoded.secondsByOwner[OwnerHours.foldedOwnerKey]! - dropped) < 0.0001)
+    #expect(abs(decoded.foldedSeconds - dropped) < 0.0001)
     #expect(decoded.secondsByOwner["App59"] == 60)
     #expect(decoded.totalSeconds == hours.totalSeconds)
-    #expect(abs(decoded.secondsByOwner.values.reduce(0, +) - hours.totalSeconds) < 0.0001)
+    #expect(
+      abs(decoded.secondsByOwner.values.reduce(0, +) + decoded.foldedSeconds - hours.totalSeconds)
+        < 0.0001
+    )
+  }
+
+  /// A store written before the fold had a field of its own carries it under an
+  /// owner key, and a build that did not filter that key drew it as the heaviest
+  /// app on the display. It is migrated out on decode and never written back.
+  @Test func aLegacyFoldedBucketIsMigratedOutOfTheOwnerList() throws {
+    let legacy: [String: Any] = [
+      "schemaVersion": OledStoreSchema.currentVersion,
+      "secondsByOwner": ["other/apps": 7200.0, "Slack": 3600.0],
+      "totalSeconds": 10800.0,
+    ]
+    let data = try JSONSerialization.data(withJSONObject: legacy)
+    let decoded = try JSONDecoder().decode(OwnerHours.self, from: data)
+
+    #expect(decoded.secondsByOwner == ["Slack": 3600])
+    #expect(decoded.foldedSeconds == 7200)
+    #expect(decoded.totalSeconds == 10800)
+    #expect(decoded.topOwners(limit: 5).map(\.owner) == ["Slack"])
+
+    // And it does not come back on the next write.
+    let rewritten = try JSONSerialization.jsonObject(
+      with: JSONEncoder().encode(decoded)) as? [String: Any]
+    let owners = try #require(rewritten?["secondsByOwner"] as? [String: Double])
+    #expect(owners["other/apps"] == nil)
   }
 
   /// Every five-minute write re-encodes what the last one wrote, so a fold that
@@ -197,10 +225,11 @@ struct OwnerHoursAccumulatorTests {
     #expect(twice == once)
   }
 
-  /// The bucket is a storage detail, and its key is not a name any app can have.
+  /// The fold is a storage detail and lives outside the owner map, so the owner
+  /// list needs no filter to keep it off screen: there is nothing there to skip.
   @Test func theFoldedBucketNeverReachesTheOwnerList() {
     let hours = OwnerHours(
-      secondsByOwner: [OwnerHours.foldedOwnerKey: 7200, "Slack": 3600], totalSeconds: 10800)
+      secondsByOwner: ["Slack": 3600], totalSeconds: 10800, foldedSeconds: 7200)
     #expect(hours.topOwners(limit: 5).map(\.owner) == ["Slack"])
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/ProvenanceEnvelopeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ProvenanceEnvelopeTests.swift
@@ -119,7 +119,7 @@ struct ProvenanceEnvelopeTests {
   @Test func exportFileNameCarriesModelAndDay() throws {
     let e = try envelope()
     #expect(ProvenanceEnvelope.exportFileName(for: e.record)
-      == "Candela Provenance DELL_U2725QE 2026-05-09.candela-provenance.json")
+      == "Candela Provenance DELL U2725QE 2026-05-09.candela-provenance.json")
   }
 
   /// The panel's own model wins over whatever the user called the display, and
@@ -139,7 +139,7 @@ struct ProvenanceEnvelopeTests {
         hardware: sample.identity.hardware),
       hours: sample.hours, exposure: sample.exposure, checkups: sample.checkups)
     let name = ProvenanceEnvelope.exportFileName(for: record)
-    #expect(name == "Candela Provenance AW_34__DW 2026-05-09.candela-provenance.json")
+    #expect(name == "Candela Provenance AW_34_ DW 2026-05-09.candela-provenance.json")
     #expect(!name.contains("Ryder"))
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/ProvenanceEnvelopeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ProvenanceEnvelopeTests.swift
@@ -122,9 +122,7 @@ struct ProvenanceEnvelopeTests {
       == "Candela Provenance DELL U2725QE 2026-05-09.candela-provenance.json")
   }
 
-  /// The panel's own model wins over whatever the user called the display, and
-  /// a product name that could split a path is sanitized the way a checkup
-  /// export sanitizes it.
+  /// The panel's model wins over the user's label, sanitized like a checkup export.
   @Test func exportFileNamePrefersTheModelAndSanitizesIt() throws {
     let sample = ProvenanceRecordTests.sampleRecord()
     let record = ProvenanceRecord(

--- a/CandelaKit/Tests/CandelaKitTests/ProvenanceEnvelopeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ProvenanceEnvelopeTests.swift
@@ -115,9 +115,31 @@ struct ProvenanceEnvelopeTests {
     #expect(try CheckupStore(directory: dir).load(url: url).validate())
   }
 
+  /// With no EDID read, the display's name is all there is to fall back on.
   @Test func exportFileNameCarriesModelAndDay() throws {
     let e = try envelope()
     #expect(ProvenanceEnvelope.exportFileName(for: e.record)
-      == "Candela Provenance DELL U2725QE 2026-05-09.candela-provenance.json")
+      == "Candela Provenance DELL_U2725QE 2026-05-09.candela-provenance.json")
+  }
+
+  /// The panel's own model wins over whatever the user called the display, and
+  /// a product name that could split a path is sanitized the way a checkup
+  /// export sanitizes it.
+  @Test func exportFileNamePrefersTheModelAndSanitizesIt() throws {
+    let sample = ProvenanceRecordTests.sampleRecord()
+    let record = ProvenanceRecord(
+      exportedAt: sample.exportedAt, appBuild: sample.appBuild, macOSBuild: sample.macOSBuild,
+      identity: ProvenanceIdentity(
+        persistenceKey: sample.identity.persistenceKey,
+        displayName: "Ryder's desk",
+        edid: CheckupDisplayIdentity(
+          identityKey: "k1", vendorID: 1, modelID: 2, serial: nil, manufactureWeek: nil,
+          manufactureYear: nil, nativePixelWidth: 1, nativePixelHeight: 1, maxRefreshHz: nil,
+          supportsPQEOTF: false, supportsHDRGammaEOTF: false, productName: "AW/34: DW"),
+        hardware: sample.identity.hardware),
+      hours: sample.hours, exposure: sample.exposure, checkups: sample.checkups)
+    let name = ProvenanceEnvelope.exportFileName(for: record)
+    #expect(name == "Candela Provenance AW_34__DW 2026-05-09.candela-provenance.json")
+    #expect(!name.contains("Ryder"))
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/ProvenanceSummaryTextTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ProvenanceSummaryTextTests.swift
@@ -135,7 +135,7 @@ struct ProvenanceSummaryTextTests {
       Runs: 1
       Not observed: 1
       Observed: 2
-      2026-05-09: 1 observed, 1 refused, 0 not observed on this panel class, 0 self-reported, control detected at 4 px
+      2026-05-09: 1 observed, 1 refused, 0 not observed, 0 self-reported, control detected at 4 px
       """
     #expect(ProvenanceSummaryText.render(try Self.fullRecord()) == expected)
   }

--- a/CandelaKit/Tests/CandelaKitTests/WearSignalTrackerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/WearSignalTrackerTests.swift
@@ -165,6 +165,53 @@ struct WearSignalTrackerTests {
     #expect(second.secondsByBucket()[4] == 120)
   }
 
+  /// Constructing a tracker is how a settings pane READS a display's histogram,
+  /// so a visit to the Health pane creates one for a display nothing is
+  /// measuring. Flushing that at sleep or quit wrote an all-zero array and
+  /// created the key.
+  @Test func aTrackerThatBookedNothingWritesNothingAtFlush() {
+    let defaults = InMemoryDefaults()
+    tracker(defaults).flush()
+    #expect(defaults.object(forKey: "oledWearSeconds.panel-a") == nil)
+    #expect(defaults.object(forKey: "oledWearSchema.panel-a") == nil)
+  }
+
+  @Test func oneAccumulatedSecondIsEnoughToFlush() {
+    let defaults = InMemoryDefaults()
+    let t = tracker(defaults)
+    t.noteTick(dimState: .active, effectiveLevel: 0.8, secondsSinceLastTick: 1)
+    t.flush()
+    #expect(defaults.object(forKey: "oledWearSeconds.panel-a") != nil)
+    #expect(tracker(defaults).totalSeconds == 1)
+  }
+
+  /// The guard is accumulation, never `unwrittenSeconds`: a tracker past its
+  /// debounce has written through and holds nothing unwritten, and it still has
+  /// to flush at quit or every later tick's tail is lost.
+  @Test func aTrackerWrittenThroughAndThenIdleStillFlushes() {
+    let defaults = InMemoryDefaults()
+    let t = tracker(defaults)
+    // Past `debounceSeconds`, so `noteTick` itself wrote through.
+    t.noteTick(dimState: .active, effectiveLevel: 0.8, secondsSinceLastTick: 90)
+    defaults.removeObject(forKey: "oledWearSeconds.panel-a")
+    t.flush()
+    #expect(defaults.object(forKey: "oledWearSeconds.panel-a") != nil)
+    #expect(tracker(defaults).totalSeconds == 90)
+  }
+
+  /// A tracker kept alive past a reset must not re-create the keys the reset
+  /// removed, which is the whole of `resetLeavesNoKeyBehind`'s promise.
+  @Test func aFlushAfterAResetLeavesNoKeyBehind() {
+    let defaults = InMemoryDefaults()
+    let t = tracker(defaults)
+    t.noteTick(dimState: .active, effectiveLevel: 0.8, secondsSinceLastTick: 60)
+    t.flush()
+    t.reset()
+    t.flush()
+    #expect(defaults.object(forKey: "oledWearSeconds.panel-a") == nil)
+    #expect(defaults.object(forKey: "oledWearSchema.panel-a") == nil)
+  }
+
   @Test func displaysDoNotShareAHistogram() {
     let defaults = InMemoryDefaults()
     let a = tracker(defaults, "panel-a")

--- a/CandelaKit/Tests/CandelaKitTests/WearSignalTrackerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/WearSignalTrackerTests.swift
@@ -165,10 +165,8 @@ struct WearSignalTrackerTests {
     #expect(second.secondsByBucket()[4] == 120)
   }
 
-  /// Constructing a tracker is how a settings pane READS a display's histogram,
-  /// so a visit to the Health pane creates one for a display nothing is
-  /// measuring. Flushing that at sleep or quit wrote an all-zero array and
-  /// created the key.
+  /// A pane reads a histogram by constructing a tracker; flushing that at quit
+  /// wrote an all-zero array and created the key.
   @Test func aTrackerThatBookedNothingWritesNothingAtFlush() {
     let defaults = InMemoryDefaults()
     tracker(defaults).flush()
@@ -185,9 +183,8 @@ struct WearSignalTrackerTests {
     #expect(tracker(defaults).totalSeconds == 1)
   }
 
-  /// The guard is accumulation, never `unwrittenSeconds`: a tracker past its
-  /// debounce has written through and holds nothing unwritten, and it still has
-  /// to flush at quit or every later tick's tail is lost.
+  /// Guarded on accumulation, not `unwrittenSeconds`: a written-through tracker
+  /// holds nothing unwritten and still owes its tail at quit.
   @Test func aTrackerWrittenThroughAndThenIdleStillFlushes() {
     let defaults = InMemoryDefaults()
     let t = tracker(defaults)
@@ -199,8 +196,7 @@ struct WearSignalTrackerTests {
     #expect(tracker(defaults).totalSeconds == 90)
   }
 
-  /// A tracker kept alive past a reset must not re-create the keys the reset
-  /// removed, which is the whole of `resetLeavesNoKeyBehind`'s promise.
+  /// A tracker alive past a reset must not re-create the keys the reset removed.
   @Test func aFlushAfterAResetLeavesNoKeyBehind() {
     let defaults = InMemoryDefaults()
     let t = tracker(defaults)

--- a/project.yml
+++ b/project.yml
@@ -70,7 +70,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.rydersel.Candela
-        MARKETING_VERSION: "1.0.1"
+        MARKETING_VERSION: "1.0.2"
         # One number, not two: the build number is the version. Sparkle compares
         # CFBundleVersion, so every shipped build needs its own value, and a
         # direct-download app has no reason to hide a rebuild behind an

--- a/tools/hardware-pass/ax.sh
+++ b/tools/hardware-pass/ax.sh
@@ -27,7 +27,7 @@
 # (measured 2026-09-01: both cases read as the settings window being gone).
 # axprobe reaches INTO them, which is how Keep is pressed. Any window that can
 # be open beside settings belongs on this list.
-BIND='set cands to (every window whose name does not start with "Candela Gamma Activity Enforcer" and name does not start with "Candela OLED Care Overlay" and name does not start with "Display resolution" and name does not start with "Display orientation" and name does not start with "Display mirroring" and name does not start with "Candela Checkup" and name is not "Display Health" and name is not "Heat Map" and name is not "Candela Setup")
+BIND='set cands to (every window whose name does not start with "Candela Gamma Activity Enforcer" and name does not start with "Candela OLED Care Overlay" and name does not start with "Candela Window Shade" and name does not start with "Display resolution" and name does not start with "Display orientation" and name does not start with "Display mirroring" and name does not start with "Candela Checkup" and name is not "Display Health" and name is not "Heat Map" and name is not "Candela Setup")
     if (count of cands) is not 1 then
       set seen to ""
       repeat with x in windows

--- a/tools/hardware-pass/axlabel.swift
+++ b/tools/hardware-pass/axlabel.swift
@@ -98,7 +98,7 @@ guard AXUIElementCopyAttributeValue(
 // AXApplication, both titled "Candela". They survive any title-based exclusion,
 // and walking one walks the whole application tree, so every line printed would
 // come from somewhere other than the window this claims to be reading.
-let decoys = ["Candela Gamma Activity Enforcer", "Candela OLED Care Overlay"]
+let decoys = ["Candela Gamma Activity Enforcer", "Candela OLED Care Overlay", "Candela Window Shade"]
 let settings = windows.first { window in
   guard string(window, kAXRoleAttribute as String) == "AXWindow" else { return false }
   let name = string(window, kAXTitleAttribute as String)

--- a/tools/hardware-pass/axprobe.swift
+++ b/tools/hardware-pass/axprobe.swift
@@ -108,7 +108,7 @@ guard AXUIElementCopyAttributeValue(
 // "Candela " prefix: the settings window is normally named for its current pane
 // but was measured reporting "Candela Settings", and a prefix rule throws the
 // real window away exactly then.
-let decoys = ["Candela Gamma Activity Enforcer", "Candela OLED Care Overlay"]
+let decoys = ["Candela Gamma Activity Enforcer", "Candela OLED Care Overlay", "Candela Window Shade"]
 
 // Filter to real windows FIRST. Measured 2026-08-18 with the settings window
 // closed: AXWindows on this app answers with two elements whose AXRole is


### PR DESCRIPTION
Fixes across the menu bar panel, Settings, Health and Protection, Checkup, Setup and the engine, each verified on both externals (the MSI MAG 341C OLED and the Dell U2725QE) before this was opened. One commit per surface; the last two are the accessibility labels and the cross-surface corrections.

Closes #38, closes #39, closes #40, closes #41, closes #42, closes #43, closes #44, closes #45.

## Menu bar panel
- The HDR button ends the panel's tracking session before it toggles, so it responds on the click instead of firing every queued click when the panel closes. Same for the Accessibility banner's Open Settings link.
- A display with no HDR modes carries a caption under its greyed HDR button once the capability probe has answered; an HDR-engaged display keeps its exit button live regardless.
- The hidden-display hint names the pane that holds the switch, and the empty states say why a DisplayLink, AirPlay or Sidecar display is absent.
- The menu-bar symbol fills while Keep Display Awake holds its assertion.
- The volume feedback check reads the system setting through UserDefaults and keeps one audio player.

## Settings
- Cancel holds Return in both per-display reset alerts.
- The two app-wide enablers on Advanced stay live under a per-display block, and the HDR caption scopes itself to this display's hardware settings.
- The Sound card says "Off" and names the switch when a Candela setting is the cause; the greyed volume slider carries its reason as a caption and in its accessibility label.
- Removing a virtual display confirms first; the size caption reads the engine's bounds per axis including the Retina limit; the Custom item appears only when no preset matches.
- The window title follows a rename through a leaf view that owns the only shell-level read of the prefs revision.
- Sidebar and back shortcuts are named in tooltips; All Sizes has an empty state; Checkup refreshes only the scoped display on activation.
- Reset All carries the automatic-update-checks choice across the domain wipe and refreshes the About mirror.
- Every themed switch and text field publishes its visible title as its accessibility label, pinned by a bundle test that reproduces the measurement.

## Health and Protection
- The Heat Map's Right now lens no longer promises a reading it cannot produce; each lens has its own legend.
- The static-region row names the held-screen case and shows a note while an assertion is held.
- The Measurement card says when the scoped display is not enrolled.
- Delete History names both kept counts.
- A wear tracker that booked nothing writes nothing; per-app hours fold into a sibling field an older build ignores.
- The care driver parks at thirty seconds with nothing enrolled and restarts on the first enrollment; the liveness window tolerates one skipped capture.

## Checkup and Setup
- Unanswered fields record as not observed; a mark reported after a missed control rides beside the inconclusive grade; the summary line drops the panel-class claim.
- The window opens with a placeholder and is centred first; the summary has Done beside Export; the plan page says the display will go dark per resolution and rate; a field that could not be shown says what was observed.
- Exports are named after the model through a filename-specific sanitizer.
- Skip on a first-run Setup still shows the landing callout; the canvas pauses while the window is not key or is occluded.

## Engine and display configuration
- Drag-path DDC logging moves to info level, which the regression harness still reads from `log show --info --debug`.
- Audio-device matching drops only an all-digit duplicate suffix.
- Log lines carry an eight-character digest of the persistence key instead of the key.
- Quit waits per live virtual-display slot with a floor of four seconds, and the settle nap fires when either the lock-dim release or the full-range restore submitted a write.
- The synthesis teardown reached from the mirror hotkey refuses a refused gate; Reset All waits up to two seconds for a mirroring, rotation or arrangement change and re-checks that no sequence began meanwhile.
- Rotation refuses a mirror slave, and a display showing a rendered size refuses with its own reason; a rendered size is refused up front when both slots are taken; the mode coordinator stops the previous countdown before adopting a preview.

## Verification
Engine suite 2333 tests, app suite 533 tests, both green. Release build passes the debug-marker and signing gates. Deployed to `/Applications` and verified on the rig: HDR toggle, DDC writes after the deploy, both reset alerts, the Sound and hero captions, the Advanced caption under HDR, all Heat Map states, the held-assertion note, a rename round-trip, the Dell's HDR caption reason, checkup open and close, quit timing, and the accessibility labels on the live build. By hand: the panel closing on the HDR click, the hover caption, the Keep Display Awake symbol, the virtual display confirmation, Reset All with update checks off, rendered-size rotation, and quit while lock-dimmed. Also on this branch: the hardware-pass drivers exclude the software-dimming shade window, and the Debug panel dump prints the HDR probe state.
