### PR TITLE
app: an update's relaunch opens Settings on About

### DIFF
--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -639,6 +639,11 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       if isFirstRun {
         presentOnboarding()
       }
+      // Here rather than at the top of launch for the same reason as the setup
+      // flow: the window's display rows derive over the discovered list.
+      if UpdateRelaunch.consume() {
+        SettingsOpener.open(at: .pane(.about))
+      }
       // Virtual display launch prelude: normalize the slot prefs, log
       // any orphan from a previous instance, and recreate the recreate-at-launch
       // slots (skipped in Safe Mode). Non-blocking; creation runs on the model's

--- a/Candela/App/UpdateRelaunch.swift
+++ b/Candela/App/UpdateRelaunch.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Sparkle
+
+/// Sparkle's "Install and Relaunch" brings a menu-bar app back with no window,
+/// which looks like an update that never happened. The exiting process marks
+/// the relaunch on disk; the next launch consumes the mark and opens About.
+enum UpdateRelaunch {
+  static let defaultsKey = "openSettingsAfterUpdateRelaunch"
+
+  static func mark(in defaults: UserDefaults = .standard) {
+    defaults.set(true, forKey: defaultsKey)
+  }
+
+  static func consume(in defaults: UserDefaults = .standard) -> Bool {
+    guard defaults.bool(forKey: defaultsKey) else { return false }
+    defaults.removeObject(forKey: defaultsKey)
+    return true
+  }
+}
+
+/// Sparkle calls the hook on the main thread right before it terminates the
+/// app for the relaunch; everything else stays Sparkle's default.
+final class UpdateRelaunchDelegate: NSObject, SPUUpdaterDelegate {
+  func updaterWillRelaunchApplication(_: SPUUpdater) {
+    UpdateRelaunch.mark()
+  }
+}

--- a/Candela/App/UpdaterModel.swift
+++ b/Candela/App/UpdaterModel.swift
@@ -14,6 +14,8 @@ import Sparkle
 @MainActor @Observable
 final class UpdaterModel {
   @ObservationIgnored private let controller: SPUStandardUpdaterController
+  // Sparkle holds its delegate weakly, so the model owns it.
+  @ObservationIgnored private let relaunchDelegate = UpdateRelaunchDelegate()
 
   /// False while a check or install is in flight; drives the button's
   /// disabled state. Mirrored from Sparkle's KVO-compliant property.
@@ -31,7 +33,7 @@ final class UpdaterModel {
     // checks are enabled. The `--vd-engage` helper never reaches here: it exits
     // inside CandelaMain before any app machinery is built.
     controller = SPUStandardUpdaterController(
-      startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil
+      startingUpdater: true, updaterDelegate: relaunchDelegate, userDriverDelegate: nil
     )
     automaticallyChecksForUpdates = controller.updater.automaticallyChecksForUpdates
     lastUpdateCheckDate = controller.updater.lastUpdateCheckDate

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -142,6 +142,12 @@ struct SettingsRootView: View {
     // LINGERS after the pop. With no dependency that changes with the path,
     // `updateNSView` never fires for a push and cannot re-hide it.
     .background(SettingsWindowConfigurator(title: currentTitle, navigationToken: currentPathDepth))
+    .onAppear {
+      if let pending = SettingsOpener.pendingSelection {
+        SettingsOpener.pendingSelection = nil
+        selection = pending
+      }
+    }
     // Debug screenshot hook: the window has no URL scheme and cannot be driven
     // by clicking without an Accessibility grant, so a capture run names its
     // destination through an env var and this adopts it once, where the
@@ -972,6 +978,15 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
 /// and puts the window back behind the frontmost app (measured).
 @MainActor
 enum SettingsOpener {
+  /// Set before `open()`: the window comes up inside that call and its
+  /// `onAppear` reads this once, so a later assignment misses it.
+  static var pendingSelection: SettingsDestination?
+
+  static func open(at destination: SettingsDestination) {
+    pendingSelection = destination
+    open()
+  }
+
   static func open() {
     // The gear button lives inside the panel's menu tracking session, and no
     // window can take focus while one runs. `PanelMenu` is the one holder,

--- a/CandelaAppTests/UpdateRelaunchTests.swift
+++ b/CandelaAppTests/UpdateRelaunchTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Testing
+
+@Suite("Update relaunch mark")
+struct UpdateRelaunchTests {
+  let defaults = UserDefaults(suiteName: "update-relaunch-tests-\(UUID().uuidString)")!
+
+  @Test func aPlainLaunchConsumesNothing() {
+    #expect(UpdateRelaunch.consume(in: defaults) == false)
+  }
+
+  @Test func aMarkedRelaunchIsConsumedExactlyOnce() {
+    UpdateRelaunch.mark(in: defaults)
+    #expect(UpdateRelaunch.consume(in: defaults) == true)
+    #expect(UpdateRelaunch.consume(in: defaults) == false)
+    #expect(defaults.object(forKey: UpdateRelaunch.defaultsKey) == nil)
+  }
+}


### PR DESCRIPTION
Closes #49

## Why

Sparkle's Install and Relaunch brought the app back with nothing on screen. A menu-bar app with no window relaunching silently looks exactly like an update that never happened.

## What

- The updater delegate marks the relaunch on disk just before the old process exits.
- The next launch consumes the mark once, after the display refresh, and opens Settings on About, where the version line names the running build.
- `SettingsOpener` gains `open(at:)` and a pending destination the root view adopts, so a launch-time route exists outside the debug capture hook.
- A plain launch, a reopen and the first run are unchanged.

## Verification

- `make test-app` passes with the new suite (mark is consumed exactly once; a plain launch consumes nothing).
- Release build deployed to /Applications. With the mark set, the relaunch opened Settings on About in front of other apps. A plain relaunch opened nothing. The mark was gone after the consuming launch.
- Sparkle actually calling the delegate on Install and Relaunch needs a release newer than the installed one, so that step waits for the next update; the issue carries `needs-hardware` until it runs.