### PR TITLE
Reduce idle work while keeping brightness controls fresh

### DIFF
--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -91,13 +91,9 @@ final class AccessibilityPermission {
   /// The argument decides only the re-stamp below; the cadence re-reads the modes.
   func reevaluateBackstop(requiresAccessibility: Bool) {
     guard isMonitoring else { return }
-    // The needed-and-absent state BEGINS here when a mode write brings the tap
-    // back on a rig that had the poll stood down, so the hunt is re-stamped
-    // rather than read from a grant that went missing hours ago: the user is at
-    // System Settings making the grant right now, which is the one moment the
-    // fast cadence exists for. A nil `scheduledInterval` is that stood-down
-    // state, the only one the cadence answers with no timer at all.
-    if requiresAccessibility, !isGranted, scheduledInterval == nil {
+    // Re-stamp the hunt: someone turning a key family on with no grant is at
+    // System Settings about to make it, however long the grant has been missing.
+    if requiresAccessibility, !isGranted {
       missingSince = ProcessInfo.processInfo.systemUptime
     }
     scheduleBackstop()

--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -50,10 +50,16 @@ final class AccessibilityPermission {
     guard !isGranted else { return }
     // Deliberately the unmanaged constant, not a string literal.
     let promptKey = kAXTrustedCheckOptionPrompt.takeRetainedValue() as String
+    let granted = AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary)
+    // Only where the prompt actually went up. A false answer IS the prompt being
+    // shown, and its button opens the Accessibility list; a true answer showed
+    // nothing and sent nobody anywhere, so the clock has no reason to move (and
+    // `applyGranted` clears it below in any case).
+    if !granted { reevaluateBackstop(after: .sentToSystemSettings) }
     // Through `applyGranted`, not a bare assignment: if this call observes the
     // grant already present, the transition still has to reach `onChange` or the
     // tap never starts and `recheck` sees no change to report.
-    applyGranted(AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary))
+    applyGranted(granted)
   }
 
   /// Calls `onChange` on every TRANSITION, grant and revocation both. Never fires
@@ -80,7 +86,11 @@ final class AccessibilityPermission {
     scheduleBackstop()
   }
 
-  static func openSystemSettings() {
+  /// Opens the Accessibility list, and reopens the hunt on the way: this is the
+  /// route to the grant, so the backstop has to be at the hunting cadence when the
+  /// user comes back rather than resting at thirty seconds.
+  func openSystemSettings() {
+    reevaluateBackstop(after: .sentToSystemSettings)
     NSWorkspace.shared.open(
       URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
     )

--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -86,14 +86,31 @@ final class AccessibilityPermission {
     )
   }
 
-  /// Key modes changed. Called in both directions: nothing else stands the timer
+  /// The tap was re-armed. Every pref carrying the re-arm reaches here, most of them
+  /// nothing to do with keys (a DDC availability switch, an audio-routing override),
+  /// and so does the settings reset, which is the route that leaves an all-custom rig
+  /// wanting the tap with no timer running.
+  func noteTapRearmed() {
+    reevaluateBackstop(after: .tapRearmed)
+  }
+
+  /// A key mode was written. Called in both directions: nothing else stands the timer
   /// down when the last key family goes off, or re-arms it when one comes back.
-  /// The argument decides only the re-stamp below; the cadence re-reads the modes.
-  func reevaluateBackstop(requiresAccessibility: Bool) {
+  func noteKeyModesChanged() {
+    reevaluateBackstop(after: .keyModesWritten)
+  }
+
+  /// Both doors take this path with the same state; the EDGE is the whole difference,
+  /// and the policy is what turns it into "reopen the hunt clock" or "leave it".
+  private func reevaluateBackstop(after edge: AccessibilityBackstopPolicy.Edge) {
     guard isMonitoring else { return }
-    // Re-stamp the hunt: someone turning a key family on with no grant is at
-    // System Settings about to make it, however long the grant has been missing.
-    if requiresAccessibility, !isGranted {
+    if AccessibilityBackstopPolicy.reopensHunt(
+      edge: edge,
+      granted: isGranted,
+      // Read live, like the cadence below: the settings reset restores key-mode
+      // defaults without coming back through a caller that could report them.
+      requiresAccessibility: Self.storedModesRequireGrant()
+    ) {
       missingSince = ProcessInfo.processInfo.systemUptime
     }
     scheduleBackstop()

--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -14,13 +14,19 @@ import Observation
 /// keys die and nothing in the UI would say so.
 ///
 /// The undocumented `com.apple.accessibility.api` distributed notification is
-/// the fast path; a poll backstops it at 2 s while the grant is missing, 10 s
-/// while it is held.
+/// the fast path; a poll backstops it when that notification is missed or lands
+/// before TCC has settled. `AccessibilityBackstopPolicy` owns the cadence.
 @MainActor @Observable
 final class AccessibilityPermission {
   private(set) var isGranted: Bool
 
   @ObservationIgnored private var pollTimer: Timer?
+  /// Cadence `pollTimer` was armed at, so a tick can tell whether it still applies.
+  /// nil means no timer.
+  @ObservationIgnored private var scheduledInterval: TimeInterval?
+  /// Uptime, not wall clock: a clock change must not shorten or extend the hunt.
+  @ObservationIgnored private var missingSince: TimeInterval?
+  @ObservationIgnored private var lastNotification: TimeInterval?
   @ObservationIgnored private var onChange: (@MainActor (Bool) -> Void)?
   @ObservationIgnored private var notificationObserver: (any NSObjectProtocol)?
   /// Gates `scheduleBackstop()`: `promptIfNeeded()` can flip the grant before
@@ -32,7 +38,10 @@ final class AccessibilityPermission {
   private static let accessibilityAPIChanged = NSNotification.Name("com.apple.accessibility.api")
 
   init() {
-    isGranted = AXIsProcessTrustedWithOptions(nil)
+    let granted = AXIsProcessTrustedWithOptions(nil)
+    isGranted = granted
+    // A launch with no grant starts the hunt at launch.
+    missingSince = granted ? nil : ProcessInfo.processInfo.systemUptime
   }
 
   /// Shows the system Accessibility prompt when the grant is missing. No NSAlert:
@@ -61,8 +70,9 @@ final class AccessibilityPermission {
       forName: Self.accessibilityAPIChanged, object: nil, queue: nil
     ) { [weak self] _ in
       // TCC needs a moment to settle: reading immediately can still return the
-      // pre-change answer. The backstop covers us if it does.
+      // pre-change answer. The backstop covers that, so the hunt reopens before the read.
       Task { @MainActor in
+        self?.noteNotification()
         try? await Task.sleep(for: .milliseconds(100))
         self?.recheck()
       }
@@ -76,10 +86,51 @@ final class AccessibilityPermission {
     )
   }
 
-  /// (Re)arms the backstop poll at the cadence the current state calls for.
+  /// Key modes changed. Called in both directions: nothing else stands the timer
+  /// down when the last key family goes off, or re-arms it when one comes back.
+  /// The argument decides only the re-stamp below; the cadence re-reads the modes.
+  func reevaluateBackstop(requiresAccessibility: Bool) {
+    guard isMonitoring else { return }
+    // The needed-and-absent state BEGINS here when a mode write brings the tap
+    // back on a rig that had the poll stood down, so the hunt is re-stamped
+    // rather than read from a grant that went missing hours ago: the user is at
+    // System Settings making the grant right now, which is the one moment the
+    // fast cadence exists for. A nil `scheduledInterval` is that stood-down
+    // state, the only one the cadence answers with no timer at all.
+    if requiresAccessibility, !isGranted, scheduledInterval == nil {
+      missingSince = ProcessInfo.processInfo.systemUptime
+    }
+    scheduleBackstop()
+  }
+
+  private func noteNotification() {
+    lastNotification = ProcessInfo.processInfo.systemUptime
+    guard isMonitoring else { return }
+    scheduleBackstop()
+  }
+
+  private func desiredInterval() -> TimeInterval? {
+    let now = ProcessInfo.processInfo.systemUptime
+    return AccessibilityBackstopPolicy.interval(
+      granted: isGranted,
+      // Read live: the settings reset restores key-mode defaults without coming back here.
+      requiresAccessibility: Self.storedModesRequireGrant(),
+      secondsSinceMissingBegan: missingSince.map { now - $0 } ?? 0,
+      secondsSinceNotification: lastNotification.map { now - $0 }
+    )
+  }
+
+  /// (Re)arms the backstop poll at the cadence the current state calls for, or
+  /// stands it down entirely.
   private func scheduleBackstop() {
     pollTimer?.invalidate()
-    let interval: TimeInterval = isGranted ? 10 : 2
+    pollTimer = nil
+    scheduledInterval = desiredInterval()
+    guard let interval = scheduledInterval else {
+      // No key routes through the tap, so nothing reads the grant but the diagnostics
+      // report, whose line may lag until the next notification or mode write.
+      return
+    }
     // `.common` mode is load-bearing, so this is `Timer(timeInterval:)` plus an
     // explicit `RunLoop.main.add`, not `Timer.scheduledTimer`: a menu tracking
     // session holds the run loop in event-tracking mode, and a default-mode timer
@@ -95,16 +146,21 @@ final class AccessibilityPermission {
     RunLoop.main.add(timer, forMode: .common)
   }
 
-  /// Never invalidates the timer on success; latching is the defect this
-  /// tracking exists to prevent.
+  /// Never stops polling on success; latching is the defect this tracking exists
+  /// to prevent.
   private func recheck() {
     applyGranted(AXIsProcessTrustedWithOptions(nil))
+    // Both windows expire between ticks and `applyGranted` reschedules only on a
+    // transition, so the cadence is re-derived here every tick.
+    if isMonitoring, desiredInterval() != scheduledInterval {
+      scheduleBackstop()
+    }
   }
 
   private func applyGranted(_ granted: Bool) {
     guard granted != isGranted else { return }
     isGranted = granted
-    // Cadence follows the new state (2 s hunting, 10 s holding).
+    missingSince = granted ? nil : ProcessInfo.processInfo.systemUptime
     if isMonitoring {
       scheduleBackstop()
     }
@@ -113,6 +169,14 @@ final class AccessibilityPermission {
 }
 
 extension AccessibilityPermission {
+  /// The stored key modes' answer to whether the CGEvent tap is wanted at all.
+  static func storedModesRequireGrant() -> Bool {
+    let prefs = DisplayPrefs(persistenceKey: "app")
+    return KeyModePolicy.requiresAccessibility(
+      brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
+    )
+  }
+
   /// Whether a missing grant is worth telling the user about right now.
   ///
   /// Not simply `!isGranted`: custom shortcuts are Carbon hotkeys and need no
@@ -121,9 +185,6 @@ extension AccessibilityPermission {
   /// banner has to as well.
   var isWarningWarranted: Bool {
     guard !isGranted else { return false }
-    let prefs = DisplayPrefs(persistenceKey: "app")
-    return KeyModePolicy.requiresAccessibility(
-      brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
-    )
+    return Self.storedModesRequireGrant()
   }
 }

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -520,11 +520,20 @@ final class AppModel {
     lastArmedTapConfig = config
   }
 
-  /// No tap can run: the grant is gone, or the start failed. Diagnostics must
-  /// report "the media-key tap is not running", not the config of a tap that no
-  /// longer exists. A tap stopped because there is nothing to watch is NOT this;
-  /// that state records the empty config instead.
+  /// No tap can run: grant gone, or the start failed. Retryable: the next edge
+  /// that wants keys tries again. A tap stopped for lack of keys is not this; that
+  /// records the empty config.
   func noteTapDisarmed() {
+    lastArmedTapConfig = nil
+  }
+
+  /// The one failure a retry cannot clear: this macOS version does not answer the
+  /// CGEvent fields the decode reads. Without the latch every reconfigure and menu
+  /// close would retry and re-log the error. Never cleared.
+  private(set) var isTapPermanentlyUnavailable = false
+
+  func noteTapPermanentlyUnavailable() {
+    isTapPermanentlyUnavailable = true
     lastArmedTapConfig = nil
   }
 
@@ -1577,21 +1586,21 @@ final class AppModel {
     )
   }
 
-  /// A consumer appearing (a surface opening, brightness sync turned on) must not
-  /// wait out the idle interval already in flight, which is up to 10 seconds on
-  /// mains and 30 on battery.
-  ///
-  /// Rebuilding is the whole mechanism: the cancel drops the sleeping task and the
-  /// fresh `run()` ticks before it sleeps at all, so the value is current the moment
-  /// the surface draws. Waking the sleep instead would need a signal channel into
-  /// the actor, and slicing the sleep would put back the once-a-second timer this
-  /// work exists to remove.
-  ///
-  /// Cheap and main-actor-synchronous: it maps the live display list and starts a
-  /// task. Safe to call from inside a menu tracking session for that reason, which
-  /// is where the panel's open edge arrives.
+  /// A new consumer (a surface opening, sync turned on) must not wait out the idle
+  /// interval in flight, up to 30 s on battery. A fresh `run()` ticks before it
+  /// sleeps, so rebuilding is the wake-up. Not the panel's route: menu tracking
+  /// starves the main actor, so the rebuilt job would land after the panel closed.
   func notePollConsumerAppeared() {
     restartPoller()
+  }
+
+  /// Snaps every native display's published brightness onto its live value before
+  /// a surface draws. Synchronous: the panel's open edge runs inside menu tracking,
+  /// which starves anything that hops. No-op off the native path, so never DDC.
+  func refreshNativeBrightnessForSurface() {
+    for state in allControlledStates {
+      state.controller.syncFromNativeBeforeStep()
+    }
   }
 
   /// Rebuilds the native-brightness poll job for the current display set. Control
@@ -1658,12 +1667,8 @@ final class AppModel {
       isEpochCurrent: { [displayManager] in
         displayManager.isEpochCurrent(displayManager.currentEpoch())
       },
-      // Both read live on every tick rather than captured here, so a pref write or
-      // a surface opening changes the cadence without restarting the job. Restarting
-      // it is what would be dangerous: an external entering HDR reaches the native
-      // path through no call of ours, and only a RUNNING poller notices.
-      // The SAME predicate the fan-out is gated on below, reset latch included: a
-      // consumer that is refusing to consume is not a consumer.
+      // Read live every tick, never captured. Same predicate the fan-out is gated
+      // on, reset latch included: a consumer refusing to consume is not a consumer.
       isSyncEnabled: { [appPrefs, resettingOffMain] in
         appPrefs.enableBrightnessSync && !resettingOffMain.withLock { $0 }
       },

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -456,15 +456,23 @@ final class AppModel {
   /// refuse the second click.
   private(set) var isResetting = false
 
+  /// `isResetting` for the poll job's cadence closure, which runs off the main
+  /// actor. Written wherever the observable is, and nowhere else.
+  @ObservationIgnored private let resettingOffMain = OSAllocatedUnfairLock(initialState: false)
+
   /// Claims the latch. False means a reset is already running and this one must
   /// not start.
   func beginReset() -> Bool {
     guard !isResetting else { return false }
     isResetting = true
+    resettingOffMain.withLock { $0 = true }
     return true
   }
 
-  func endReset() { isResetting = false }
+  func endReset() {
+    isResetting = false
+    resettingOffMain.withLock { $0 = false }
+  }
 
   /// Per-display VCP 0x62 verdict from the capabilities string. Observable,
   /// so the panel's volume slider enables live the moment a probe lands. An ABSENT
@@ -838,9 +846,12 @@ final class AppModel {
     }
   }
 
+  // All three key paths read native first: published state can be an idle poll
+  // interval stale, and a step from it jumps a Control Center move back.
   func stepBrightnessAllExternal(isUp: Bool, isFine: Bool) -> [(id: CGDirectDisplayID, name: String, newValue: Double)] {
     keyEnabledStates(displays).map { state in
-      (state.id, state.display.name, state.controller.step(isUp: isUp, isFine: isFine))
+      state.controller.syncFromNativeBeforeStep()
+      return (state.id, state.display.name, state.controller.step(isUp: isUp, isFine: isFine))
     }
   }
 
@@ -857,6 +868,7 @@ final class AppModel {
       // `isDisabled` filters the loop body: a resolved-but-disabled display
       // steps nothing and shows no HUD.
       guard let slot, !keyEnabledStates([slot]).isEmpty else { return nil }
+      slot.controller.syncFromNativeBeforeStep()
       return (slot.id, slot.display.name,
               slot.controller.step(isUp: isUp, isFine: isFine))
     }
@@ -867,6 +879,7 @@ final class AppModel {
   /// online.
   func stepBrightnessBuiltIn(isUp: Bool, isFine: Bool) -> (id: CGDirectDisplayID, name: String, newValue: Double)? {
     guard let builtIn, !keyEnabledStates([builtIn]).isEmpty else { return nil }
+    builtIn.controller.syncFromNativeBeforeStep()
     return (builtIn.id, builtIn.display.name,
             builtIn.controller.step(isUp: isUp, isFine: isFine))
   }
@@ -1222,6 +1235,10 @@ final class AppModel {
   /// must never outlive the pass that dropped it.
   @ObservationIgnored private var pollerTask: Task<Void, Never>?
 
+  /// Whether a surface showing a brightness value is on screen; one of the
+  /// poller's cadence signals.
+  let surfaceVisibility = SurfaceVisibility()
+
   deinit {
     pollerTask?.cancel()
   }
@@ -1560,6 +1577,23 @@ final class AppModel {
     )
   }
 
+  /// A consumer appearing (a surface opening, brightness sync turned on) must not
+  /// wait out the idle interval already in flight, which is up to 10 seconds on
+  /// mains and 30 on battery.
+  ///
+  /// Rebuilding is the whole mechanism: the cancel drops the sleeping task and the
+  /// fresh `run()` ticks before it sleeps at all, so the value is current the moment
+  /// the surface draws. Waking the sleep instead would need a signal channel into
+  /// the actor, and slicing the sleep would put back the once-a-second timer this
+  /// work exists to remove.
+  ///
+  /// Cheap and main-actor-synchronous: it maps the live display list and starts a
+  /// task. Safe to call from inside a menu tracking session for that reason, which
+  /// is where the panel's open edge arrives.
+  func notePollConsumerAppeared() {
+    restartPoller()
+  }
+
   /// Rebuilds the native-brightness poll job for the current display set. Control
   /// Center and ambient changes bypass us entirely, so looking is the only way to
   /// stay in sync on the native path.
@@ -1570,6 +1604,8 @@ final class AppModel {
       return
     }
     let states = allControlledStates
+    // The built-in must not vote on the cadence; see `Target.isExternal`.
+    let externalIDs = Set(displays.map(\.id))
     let targets = states.map { state -> BrightnessPoller.Target in
       let controller = state.controller
       return BrightnessPoller.Target(
@@ -1610,7 +1646,8 @@ final class AppModel {
             )
           }
         },
-        isConverging: { controller.isConvergingFromExternal() }
+        isConverging: { controller.isConvergingFromExternal() },
+        isExternal: externalIDs.contains(state.id)
       )
     }
     let poller = BrightnessPoller(
@@ -1620,8 +1657,38 @@ final class AppModel {
       // suspended (mid-reconfigure burst or asleep): the poller's skip rule.
       isEpochCurrent: { [displayManager] in
         displayManager.isEpochCurrent(displayManager.currentEpoch())
-      }
+      },
+      // Both read live on every tick rather than captured here, so a pref write or
+      // a surface opening changes the cadence without restarting the job. Restarting
+      // it is what would be dangerous: an external entering HDR reaches the native
+      // path through no call of ours, and only a RUNNING poller notices.
+      // The SAME predicate the fan-out is gated on below, reset latch included: a
+      // consumer that is refusing to consume is not a consumer.
+      isSyncEnabled: { [appPrefs, resettingOffMain] in
+        appPrefs.enableBrightnessSync && !resettingOffMain.withLock { $0 }
+      },
+      isSurfaceVisible: { [surfaceVisibility] in surfaceVisibility.isVisible }
     )
     pollerTask = Task { await poller.run() }
   }
+}
+
+/// Whether a Candela surface showing a brightness value is on screen.
+///
+/// Lock-backed, not main-actor: the poller reads it off the main actor, and the
+/// panel writes it from inside a menu tracking session, where a hop would land
+/// after the menu closed.
+final class SurfaceVisibility: Sendable {
+  private struct State {
+    var isPanelOpen = false
+    var isSettingsVisible = false
+  }
+
+  private let state = OSAllocatedUnfairLock(initialState: State())
+
+  var isVisible: Bool { state.withLock { $0.isPanelOpen || $0.isSettingsVisible } }
+
+  func setPanelOpen(_ open: Bool) { state.withLock { $0.isPanelOpen = open } }
+
+  func setSettingsVisible(_ visible: Bool) { state.withLock { $0.isSettingsVisible = visible } }
 }

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -500,19 +500,22 @@ final class AppModel {
   /// rather than reporting them unenumerated.
   private(set) var hardwareFacts: [String: DisplayHardwareFacts] = [:]
 
-  /// The `WatchConfig` most recently ARMED, not the one most recently computed.
-  /// Those differ exactly when a rearm failed, which is the case the row exists
-  /// for. Recorded at the arm site in `StatusItemController`, never at the compute
-  /// site here.
+  /// The `WatchConfig` most recently COMMITTED to, not the one most recently
+  /// computed; they differ exactly when a rearm failed. Recorded in
+  /// `StatusItemController`, never here.
+  ///
+  /// Empty is not nil. Empty: the app watches nothing on purpose, so no tap exists.
+  /// nil: no tap could be built, the one state diagnostics calls "not running".
   private(set) var lastArmedTapConfig: MediaKeyEventTap.WatchConfig?
 
   func noteTapArmed(_ config: MediaKeyEventTap.WatchConfig) {
     lastArmedTapConfig = config
   }
 
-  /// The tap was torn down (a revoked grant). Diagnostics must report "the
-  /// media-key tap is not running", not the config of a tap that no longer
-  /// exists.
+  /// No tap can run: the grant is gone, or the start failed. Diagnostics must
+  /// report "the media-key tap is not running", not the config of a tap that no
+  /// longer exists. A tap stopped because there is nothing to watch is NOT this;
+  /// that state records the empty config instead.
   func noteTapDisarmed() {
     lastArmedTapConfig = nil
   }

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -1594,12 +1594,26 @@ final class AppModel {
     restartPoller()
   }
 
-  /// Snaps every native display's published brightness onto its live value before
-  /// a surface draws. Synchronous: the panel's open edge runs inside menu tracking,
-  /// which starves anything that hops. No-op off the native path, so never DDC.
+  /// Adopts every native display's live brightness before a surface draws, through
+  /// the same route the poller takes: published, persisted, and fanned out to the
+  /// other displays when sync is on. Synchronous: the panel's open edge runs inside
+  /// menu tracking, which starves anything that hops. No-op off the native path, so
+  /// never DDC.
   func refreshNativeBrightnessForSurface() {
-    for state in allControlledStates {
-      state.controller.syncFromNativeBeforeStep()
+    let controllers = allControlledStates.map(\.controller)
+    // Every display is read before anything is written, so a fan-out cannot land on
+    // a display this pass has not looked at yet and be read back as a move of its own.
+    let adopted = controllers.compactMap { controller -> (BrightnessController, Double)? in
+      let delta = controller.adoptNativeForSurface()
+      return delta == 0 ? nil : (controller, delta)
+    }
+    for (source, delta) in adopted {
+      // The poller's own gate, reset latch included: a fan-out during a reset keeps
+      // that display's queue busy and the reset then gives up on restoring its HDR.
+      BrightnessSync.fanOut(
+        delta: delta, from: source, to: controllers,
+        isEnabled: appPrefs.enableBrightnessSync && !isResetting
+      )
     }
   }
 

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -303,9 +303,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // hotkeys and need no grant, so an all-custom rig must not be shown a TCC
       // prompt it can only refuse.
       let prefs = DisplayPrefs(persistenceKey: "app")
-      guard KeyModePolicy.requiresAccessibility(
+      let required = KeyModePolicy.requiresAccessibility(
         brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
-      ) else { return }
+      )
+      // Ahead of the guard: the backstop must hear a key family going off as well
+      // as coming on, and nothing else reports either edge.
+      self?.model.accessibility.reevaluateBackstop(requiresAccessibility: required)
+      guard required else { return }
       self?.model.accessibility.promptIfNeeded()
     }
     settingsActions.updateStatusItem = { [weak self] in self?.updateStatusItemVisibility() }

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -1413,6 +1413,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // Computed once and recorded only on success: `lastArmedTapConfig` is what is
     // actually being watched, and a config that failed to arm is not that.
     let config = model.tapConfig
+    // An empty tap still costs three threads for nothing. The empty config, not a
+    // disarm, keeps diagnostics on "watching nothing" and the restart edge visible.
+    guard !config.watchedKeys.isEmpty else {
+      mediaKeyTap.stop()
+      model.noteTapArmed(config)
+      return
+    }
     do {
       try mediaKeyTap.start(config: config)
       model.noteTapArmed(config)
@@ -1425,18 +1432,44 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
         fields the media-key decode reads; media keys are off until Candela is updated
         """
       )
+      // A failed start is not "watching nothing": the keys are dead and the
+      // diagnostics row must say so. It also stops the refresh path retrying a
+      // start that cannot succeed, on every menu close, forever.
+      model.noteTapDisarmed()
     } catch {
       log.error("media-key tap failed to start: \(error); keys disabled until relaunch")
+      model.noteTapDisarmed()
     }
   }
 
-  /// Re-arms or disarms brightness keys after display topology changes (the
-  /// fork's `updateMediaKeyTap`). No-op unless the tap is running.
+  /// Re-arms, re-configures or tears down the tap after the watched-key set can
+  /// have changed (the fork's `updateMediaKeyTap`). The edge comes from the last
+  /// committed set, never `mediaKeyTap.isRunning`: an emergency teardown leaves
+  /// that flag true.
   private func refreshTapConfig() {
-    guard let mediaKeyTap, mediaKeyTap.isRunning else { return }
+    guard let mediaKeyTap else { return }
     let config = model.tapConfig
-    mediaKeyTap.update(config: config)
-    model.noteTapArmed(config)
+    switch TapLifecyclePolicy.action(
+      previous: model.lastArmedTapConfig?.watchedKeys,
+      next: config.watchedKeys,
+      grantHeld: model.accessibility.isGranted
+    ) {
+    case .start:
+      startMediaKeyTap()
+    case .stop:
+      // Not `noteTapDisarmed`: the keys are released on purpose, which is a
+      // different answer from a tap that cannot run.
+      mediaKeyTap.stop()
+      model.noteTapArmed(config)
+    case .reconfigure:
+      mediaKeyTap.update(config: config)
+      model.noteTapArmed(config)
+    case .nothing:
+      // The stored config is left alone, so in the watching-nothing state the
+      // alternate-brightness-key flag inside it can go stale. Nothing reads that
+      // flag while no tap exists, and the next start recomputes the whole config.
+      break
+    }
   }
 
   /// Filled while a keep-awake assertion is held: it suppresses every OLED care

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -118,6 +118,9 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
   /// Sleep/wake observation tokens: block-based observers stay registered only
   /// while retained. Never removed, app-lifetime.
   private var sleepWakeObservers: [any NSObjectProtocol] = []
+  /// Belt on the panel-open flag: AppKit's end-of-tracking signal, held like the
+  /// tokens above.
+  private var menuTrackingObserver: (any NSObjectProtocol)?
   /// Startup/wake DDC restore choreography. `startupAction` is app-level
   /// but read through DisplayPrefs like every other engine pref, and under safe
   /// mode through a prefs object whose getter reports `.doNothing`, which
@@ -193,6 +196,16 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     statusItem = item
     updateStatusItemImage()
     trackKeepAwake()
+
+    // A panel-open flag left true is a poller that never slows down, so the end of
+    // tracking clears it as well as `menuDidClose`. AppKit posts this for every
+    // session end, including the `cancelTracking` routes below.
+    menuTrackingObserver = NotificationCenter.default.addObserver(
+      forName: NSMenu.didEndTrackingNotification, object: menu, queue: .main
+    ) { [weak self] _ in
+      // A hop is safe here: the tracking session has just ended.
+      Task { @MainActor in self?.model.surfaceVisibility.setPanelOpen(false) }
+    }
 
     // Panel controls that have to end this tracking session reach it through
     // here: the gear button (a window cannot take focus while it runs) and
@@ -1012,18 +1025,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     return false
   }
 
-  /// The panel is a consumer of every polled brightness value, so the poller has
-  /// to be told while it is on screen. Set synchronously, not through a task hop:
-  /// menu tracking starves main-actor work, so a hop would land only once the menu
-  /// had closed again.
-  ///
-  /// The restart is what makes the panel's first frame current: the flag alone
-  /// changes only the NEXT interval, and the idle one already in flight can be 10
-  /// seconds long. The built-in's row is the one that shows it, since Control
-  /// Center and ambient light move that value with nothing of ours involved.
+  /// The panel consumes every polled value. Set synchronously: menu tracking
+  /// starves main-actor work, so a hop would land after the menu closed. The flag
+  /// changes only the NEXT interval, so the first frame takes a direct read; a
+  /// rebuilt poll job would adopt after the panel closed, for the same reason.
   func menuWillOpen(_: NSMenu) {
     model.surfaceVisibility.setPanelOpen(true)
-    model.notePollConsumerAppeared()
+    model.refreshNativeBrightnessForSurface()
   }
 
   func menuDidClose(_: NSMenu) {
@@ -1429,6 +1437,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
 
   private func startMediaKeyTap() {
     guard let mediaKeyTap else { return }
+    // Every start route stops here rather than failing and logging again.
+    guard !model.isTapPermanentlyUnavailable else { return }
     // Computed once and recorded only on success: `lastArmedTapConfig` is what is
     // actually being watched, and a config that failed to arm is not that.
     let config = model.tapConfig
@@ -1451,12 +1461,12 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
         fields the media-key decode reads; media keys are off until Candela is updated
         """
       )
-      // A failed start is not "watching nothing": the keys are dead and the
-      // diagnostics row must say so. It also stops the refresh path retrying a
-      // start that cannot succeed, on every menu close, forever.
-      model.noteTapDisarmed()
+      // No later edge may retry a start that cannot succeed.
+      model.noteTapPermanentlyUnavailable()
     } catch {
-      log.error("media-key tap failed to start: \(error); keys disabled until relaunch")
+      // Transient, usually a port refused while TCC was still settling: the next
+      // edge that wants keys tries again.
+      log.error("media-key tap failed to start: \(error); retried on the next edge")
       model.noteTapDisarmed()
     }
   }
@@ -1471,7 +1481,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     switch TapLifecyclePolicy.action(
       previous: model.lastArmedTapConfig?.watchedKeys,
       next: config.watchedKeys,
-      grantHeld: model.accessibility.isGranted
+      grantHeld: model.accessibility.isGranted,
+      permanentlyUnavailable: model.isTapPermanentlyUnavailable
     ) {
     case .start:
       startMediaKeyTap()
@@ -1484,9 +1495,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       mediaKeyTap.update(config: config)
       model.noteTapArmed(config)
     case .nothing:
-      // The stored config is left alone, so in the watching-nothing state the
-      // alternate-brightness-key flag inside it can go stale. Nothing reads that
-      // flag while no tap exists, and the next start recomputes the whole config.
+      // The stored config can carry a stale alternate-brightness flag while no tap
+      // exists; nothing reads it, and the next start recomputes the whole config.
       break
     }
   }

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -1513,6 +1513,10 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     case .reconfigure:
       mediaKeyTap.update(config: config)
       model.noteTapArmed(config)
+    case .recordEmpty:
+      // Nothing to stop: no tap was ever armed. Recording the empty set is what
+      // separates keys released on purpose from a tap that could not run.
+      model.noteTapArmed(config)
     case .nothing:
       // The stored config can carry a stale alternate-brightness flag while no tap
       // exists; nothing reads it, and the next start recomputes the whole config.

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -1012,7 +1012,22 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     return false
   }
 
+  /// The panel is a consumer of every polled brightness value, so the poller has
+  /// to be told while it is on screen. Set synchronously, not through a task hop:
+  /// menu tracking starves main-actor work, so a hop would land only once the menu
+  /// had closed again.
+  ///
+  /// The restart is what makes the panel's first frame current: the flag alone
+  /// changes only the NEXT interval, and the idle one already in flight can be 10
+  /// seconds long. The built-in's row is the one that shows it, since Control
+  /// Center and ambient light move that value with nothing of ours involved.
+  func menuWillOpen(_: NSMenu) {
+    model.surfaceVisibility.setPanelOpen(true)
+    model.notePollConsumerAppeared()
+  }
+
   func menuDidClose(_: NSMenu) {
+    model.surfaceVisibility.setPanelOpen(false)
     // Re-discover displays and re-read hardware once tracking has ended and
     // the run loop is back in default mode, so the next open starts fresh.
     Task {

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -203,8 +203,11 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     menuTrackingObserver = NotificationCenter.default.addObserver(
       forName: NSMenu.didEndTrackingNotification, object: menu, queue: .main
     ) { [weak self] _ in
-      // A hop is safe here: the tracking session has just ended.
-      Task { @MainActor in self?.model.surfaceVisibility.setPanelOpen(false) }
+      // Delivered on the main queue, so the flag is cleared in this turn rather
+      // than in a task the next open could outrun: menu tracking starves
+      // main-actor task execution, and a reopen inside that window would have its
+      // fresh `menuWillOpen` flag cleared by the previous session's late hop.
+      MainActor.assumeIsolated { self?.model.surfaceVisibility.setPanelOpen(false) }
     }
 
     // Panel controls that have to end this tracking session reach it through
@@ -308,6 +311,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // every mode write through the seam. Static because the manager instance is
       // private here and the KeyboardShortcuts registry is global.
       ShortcutManager.syncRegistration()
+      // Here as well as in `recheckPermissions`, which the settings reset does not
+      // call: a reset from an all-custom ungranted rig restores the media-key
+      // defaults, so the tap becomes wanted with no timer left to notice the grant
+      // arriving. The door WITHOUT the hunt re-stamp, because most prefs that re-arm
+      // the tap say nothing about whether anyone is at System Settings; the key-mode
+      // write below is the one that does.
+      self?.model.accessibility.noteTapRearmed()
     }
     settingsActions.recheckPermissions = { [weak self] in
       // The fork computes this and never calls it, so changing a
@@ -315,14 +325,10 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // change actually made the CGEvent tap wanted. Custom shortcuts are Carbon
       // hotkeys and need no grant, so an all-custom rig must not be shown a TCC
       // prompt it can only refuse.
-      let prefs = DisplayPrefs(persistenceKey: "app")
-      let required = KeyModePolicy.requiresAccessibility(
-        brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
-      )
-      // Ahead of the guard: the backstop must hear a key family going off as well
-      // as coming on, and nothing else reports either edge.
-      self?.model.accessibility.reevaluateBackstop(requiresAccessibility: required)
-      guard required else { return }
+      // Ahead of the guard: the backstop must hear a key family going off as well as
+      // coming on. This is the edge that reopens the hunt, and the only one.
+      self?.model.accessibility.noteKeyModesChanged()
+      guard AccessibilityPermission.storedModesRequireGrant() else { return }
       self?.model.accessibility.promptIfNeeded()
     }
     settingsActions.updateStatusItem = { [weak self] in self?.updateStatusItemVisibility() }
@@ -1447,6 +1453,19 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     guard !config.watchedKeys.isEmpty else {
       mediaKeyTap.stop()
       model.noteTapArmed(config)
+      return
+    }
+    // The tracked grant is refreshed by a poll, so a revocation made in System
+    // Settings and followed by a plug-in inside that window would run `tapCreate`
+    // while TCC is still committing the delete, which is the wedge the emergency
+    // teardown's settle closure waits out. One live read costs nothing here (no
+    // options, so it can never prompt) and it is only taken on a start edge.
+    // Not the policy input: the tracked flag stays what decides the lifecycle.
+    guard AXIsProcessTrustedWithOptions(nil) else {
+      // `.info` rather than `.error`: an expected decline, and the only observable
+      // that separates it from a start nobody attempted. The next edge retries.
+      log.info("media-key tap not started: the Accessibility grant reads false right now")
+      model.noteTapDisarmed()
       return
     }
     do {

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -186,7 +186,10 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// content for a whole sampling slot reads as burn-in, the symptom the feature
   /// exists to prevent. The poll under it is a measured 0.46 ms, and it only
   /// runs while a mask is on screen.
-  private static let nominationGeometryInterval: Duration = .seconds(1)
+  ///
+  /// Derived, never a second literal: the driver ticks at `windowFollow` while a
+  /// mask is up, and a throttle above that tick silently halves the follow rate.
+  private static let nominationGeometryInterval: Duration = OledCareCadence.windowFollow
   /// "At most every few minutes, plus at termination" (spec §4). A defaults
   /// write per sample would put one on a permanent 60 s timer per panel for a
   /// value that is only ever read by a settings view.

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -114,9 +114,9 @@ final class OledCareCoordinator: CheckupCareHolding {
     /// `.active` is exactly when detection dimming runs.
     var assertionHeld = false
     /// The current nomination in PANEL space. The LUMINANCE half changes only
-    /// when a new sample lands; the WINDOW half is re-read on the fast loop
-    /// while a nomination is displayed (`refreshNominationGeometry`), so a moved
-    /// window sheds its dim in about a second. Nil means "nothing qualifies",
+    /// when a new sample lands; the WINDOW half is re-read once a second while a
+    /// nomination is displayed (`refreshNominationGeometry`), so a moved window
+    /// sheds its dim in about a second. Nil means "nothing qualifies",
     /// deliberately distinguishable from an all-zero mask: the render then keeps
     /// the cheaper scalar path.
     var nominatedMask: OverlayMask?
@@ -164,10 +164,10 @@ final class OledCareCoordinator: CheckupCareHolding {
     var lockDimRamp: Task<Void, Never>?
   }
 
-  /// Poll cadence: slow while every enrolled display is `.active`/`.suspended`;
-  /// fast while any dim is up by any delivery (the restore latency gate is
-  /// 100 ms) or a verification is pending. The predicate and both
-  /// durations live in `OledCareCadence`, under test.
+  /// Poll cadence: fast while a dim input should lift is up by any delivery or a
+  /// verification is pending; the window-follow second while a nomination mask is
+  /// on screen with no such dim; slow otherwise. `OledCareCadence` owns the
+  /// predicates and durations, under test.
   /// After this much CONTINUOUS settling the signal is ignored: the entry gate
   /// exists for a transition window measured in seconds, not for a latch that
   /// never cleared.
@@ -1035,10 +1035,11 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// entries outlive the state that issued them.
   private func cadence() -> Duration {
     OledCareCadence.interval(
-      anyOverlayUp: states.values.contains { $0.lastAppliedAlpha != nil },
+      anyOverlayUp: anyOverlayDimUp(),
       anyLockDimEngaged: states.values.contains(where: \.lockDimEngaged),
       verificationPending: states.values.contains(where: \.needsVerify)
         || !pendingRemovalVerifications.isEmpty,
+      nominationDisplayed: anyNominationDisplayed(),
       anythingEnrolled: !states.isEmpty
     )
   }
@@ -1046,7 +1047,26 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// Dims that input can lift. A pending verification also runs the fast
   /// cadence but gives an input event nothing to do.
   private func anyDimUp() -> Bool {
-    states.values.contains { $0.lastAppliedAlpha != nil || $0.lockDimEngaged }
+    anyOverlayDimUp() || states.values.contains(where: \.lockDimEngaged)
+  }
+
+  /// An overlay that is up BECAUSE the display is dimmed, as opposed to detection
+  /// dimming's mask on an `.active` display, which no input clears. `tick()`
+  /// assigns `dimStates` before the driver asks, so this is this tick's verdict.
+  /// A display that departed mid-debounce reads as no dim; its teardown
+  /// verification rides the pending-removal list, which runs fast on its own.
+  private func anyOverlayDimUp() -> Bool {
+    states.contains { key, state in
+      state.lastAppliedAlpha != nil && dimStates[key]?.liftsOnInput == true
+    }
+  }
+
+  /// A nomination actually reaching the panel: a mask kept current under a
+  /// mirror-set suspension renders nothing. Over-reports a dimmed display whose
+  /// nomination is not composed (blackout, display sleep under a uniform dim),
+  /// harmlessly, since every one of those states takes the fast term first.
+  private func anyNominationDisplayed() -> Bool {
+    states.values.contains { $0.nominatedMask != nil && $0.lastAppliedAlpha != nil }
   }
 
   // MARK: - Event-driven restore

--- a/Candela/Onboarding/OnboardingWindowController.swift
+++ b/Candela/Onboarding/OnboardingWindowController.swift
@@ -102,7 +102,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     let permission = model.accessibility
     flow.onCommit = { router.route($0) }
     flow.onRequestAccessibility = { permission.promptIfNeeded() }
-    flow.onOpenAccessibilitySettings = { AccessibilityPermission.openSystemSettings() }
+    flow.onOpenAccessibilitySettings = { permission.openSystemSettings() }
     // The request and nothing else. The return value means "already
     // granted", not "granted now" (it is false when the dialog was merely
     // shown), so nothing may gate on it; the telemetry pref itself is written

--- a/Candela/Panel/PanelView.swift
+++ b/Candela/Panel/PanelView.swift
@@ -332,7 +332,7 @@ struct PanelView: View {
         // open behind the frontmost app. Queued: `endTracking` only asks the
         // session to end, and a synchronous open still runs inside it.
         PanelMenu.endTracking()
-        Task { @MainActor in AccessibilityPermission.openSystemSettings() }
+        Task { @MainActor in model.accessibility.openSystemSettings() }
       }
       .buttonStyle(.link)
       .font(.system(size: 12))

--- a/Candela/Settings/KeyboardPane.swift
+++ b/Candela/Settings/KeyboardPane.swift
@@ -80,7 +80,7 @@ struct KeyboardPane: View {
         // The page's one action while the grant is missing, so it takes the
         // primary style. Trailing ellipsis: it opens another app (buttons.md).
         Button("Open System Settings…") {
-          AccessibilityPermission.openSystemSettings()
+          model.accessibility.openSystemSettings()
         }
         .buttonStyle(SettingsPrimaryButtonStyle())
         .accessibilityLabel("Open System Settings…")

--- a/Candela/Settings/SettingsActions.swift
+++ b/Candela/Settings/SettingsActions.swift
@@ -95,6 +95,7 @@ final class SettingsActions {
       // must not put the DDC bus to work on every timeout tweak.
       model.oledCare.reapplyAfterPrefChange(persistenceKey: persistenceKey)
     }
+    if effects.contains(.restartBrightnessPoll) { model?.notePollConsumerAppeared() }
     if effects.contains(.syncVirtualDisplays) {
       // Converge live virtual displays to the slot prefs. The model hops
       // off the main actor itself; nothing here blocks.

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -50,10 +50,10 @@ struct SettingsRootView: View {
 
   @Environment(AppModel.self) private var model
 
-  /// Whether this window is on screen, for the brightness poller's cadence. A
-  /// CLOSED settings window reports `.inactive` here, since the window object
-  /// outlives the close, and so does one sitting behind another app: the same
-  /// answer for the poller's purposes, because nobody is reading the sliders.
+  /// Whether this window is on screen, for the poller's cadence. A CLOSED window
+  /// reports `.inactive` (the object outlives the close), as does one behind
+  /// another app. Looser than the canvas's `.key` threshold on purpose: a window
+  /// behind another Candela window still shows its values.
   @Environment(\.controlActiveState) private var activeState
 
   private func noteSettingsVisible(_ visible: Bool) {

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -50,11 +50,27 @@ struct SettingsRootView: View {
 
   @Environment(AppModel.self) private var model
 
-  /// Whether this window is on screen, for the poller's cadence. A CLOSED window
-  /// reports `.inactive` (the object outlives the close), as does one behind
-  /// another app. Looser than the canvas's `.key` threshold on purpose: a window
-  /// behind another Candela window still shows its values.
+  /// The FALLBACK visibility signal, and only that. Every window of a
+  /// non-frontmost app reports `.inactive`, so on its own this reads a settings
+  /// page open beside another app as closed, and the poller then serves a hero
+  /// slider that is on screen at the idle interval.
   @Environment(\.controlActiveState) private var activeState
+
+  /// What the hosting window says about itself: on screen and not fully covered.
+  /// nil until a window has attached, which is the whole window in which the
+  /// activation fallback speaks.
+  @State private var windowVisibility: Bool?
+
+  /// The window's own answer wherever there is one.
+  static func isSettingsOnScreen(
+    windowVisibility: Bool?, activeState: ControlActiveState
+  ) -> Bool {
+    windowVisibility ?? (activeState != .inactive)
+  }
+
+  private var isOnScreen: Bool {
+    Self.isSettingsOnScreen(windowVisibility: windowVisibility, activeState: activeState)
+  }
 
   private func noteSettingsVisible(_ visible: Bool) {
     model.surfaceVisibility.setSettingsVisible(visible)
@@ -114,9 +130,9 @@ struct SettingsRootView: View {
     .preferredColorScheme(.dark)
     // The window is a poll consumer while up; becoming visible also restarts the
     // job so the first frame is not a slow interval stale.
-    .onAppear { noteSettingsVisible(activeState != .inactive) }
-    .onChange(of: activeState) { _, state in
-      noteSettingsVisible(state != .inactive)
+    .onAppear { noteSettingsVisible(isOnScreen) }
+    .onChange(of: isOnScreen) { _, visible in
+      noteSettingsVisible(visible)
     }
     // Belt on the flag: a consumer left true is a poller that never slows down.
     .onDisappear { model.surfaceVisibility.setSettingsVisible(false) }
@@ -166,7 +182,8 @@ struct SettingsRootView: View {
       SettingsWindowTitleHost(
         displayKey: presentation.displayKey,
         fallbackTitle: selectedPaneTitle,
-        navigationToken: currentPathDepth))
+        navigationToken: currentPathDepth,
+        onWindowVisibility: { windowVisibility = $0 }))
     .onAppear {
       if let pending = SettingsOpener.pendingSelection {
         SettingsOpener.pendingSelection = nil
@@ -761,11 +778,17 @@ private struct SettingsWindowTitleHost: View {
   /// Also covers the same-frame race where the key has left the connected states.
   let fallbackTitle: String
   let navigationToken: Int
+  /// Passed straight through: the configurator is where the hosting window is
+  /// already reached, so the visibility signal needs no second window route.
+  let onWindowVisibility: @MainActor (Bool) -> Void
 
   @Environment(AppModel.self) private var model
 
   var body: some View {
-    SettingsWindowConfigurator(title: title, navigationToken: navigationToken)
+    SettingsWindowConfigurator(
+      title: title,
+      navigationToken: navigationToken,
+      onWindowVisibility: onWindowVisibility)
   }
 
   private var title: String {
@@ -814,20 +837,25 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
   /// contract promptly. Measured: a push flips `titleVisibility` back to visible
   /// and draws the window title at the leading edge.
   let navigationToken: Int
+  /// Reports whether the window is on screen and not fully covered. Called only
+  /// on a change, and never from inside a SwiftUI update pass.
+  let onWindowVisibility: @MainActor (Bool) -> Void
 
   func makeNSView(context: Context) -> NSView {
     let coordinator = context.coordinator
+    coordinator.reportVisibility = onWindowVisibility
     coordinator.desiredTitle = title
     let view = WindowAttachedView()
     // The view has no window during `makeNSView`, and asking again after a
     // `DispatchQueue.main.async` hop answered nil whenever the hop lost the
     // race, with nothing to retry it.
-    view.onAttach = { [weak coordinator] window in coordinator?.apply(to: window) }
+    view.onAttach = { [weak coordinator] window in coordinator?.attach(to: window) }
     return view
   }
 
   func updateNSView(_ view: NSView, context: Context) {
     let coordinator = context.coordinator
+    coordinator.reportVisibility = onWindowVisibility
     coordinator.desiredTitle = title
     if let window = view.window { coordinator.apply(to: window) }
   }
@@ -860,13 +888,23 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
   /// only hides the disagreement, and the frame where AppKit wins the race
   /// still shows a window named for a pane that is not on screen.
   final class Coordinator {
-    // Nonisolated storage so `deinit` can remove the observer: a `@MainActor`
+    // Nonisolated storage so `deinit` can remove the observers: a `@MainActor`
     // property is unreachable from a nonisolated deinit under Swift 6.
-    // `removeObserver` is thread-safe, and both properties are only ever
-    // WRITTEN from `apply(to:)`, which is main-actor.
+    // `removeObserver` is thread-safe, and every property below is only ever
+    // WRITTEN from a main-actor method of this class.
     private var observer: NSObjectProtocol?
+    /// The occlusion and close observations, held apart from the update-pass one
+    /// so all three come down together with the window they watch.
+    private var visibilityObservers: [NSObjectProtocol] = []
     private weak var observedWindow: NSWindow?
     private var title = ""
+    /// Last value handed out, so the update-pass belt below can re-assert the
+    /// answer every pass without waking SwiftUI for a value it already has.
+    private var reportedVisibility: Bool?
+
+    /// Replaced on every update, so a report lands on the live view rather than
+    /// the one that was on screen when the window attached.
+    @MainActor var reportVisibility: @MainActor (Bool) -> Void = { _ in }
 
     /// Re-applied to the window the moment it changes, so a dropped write
     /// cannot outlive one update.
@@ -893,6 +931,32 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
     /// coordinator alive.
     private struct WeakCoordinatorBox: @unchecked Sendable {
       weak var coordinator: Coordinator?
+    }
+
+    /// The window has arrived: assert the contract at once, and report the
+    /// visibility on a hop. `viewDidMoveToWindow` runs inside the SwiftUI update
+    /// pass that attached the view, and a state write there is undefined; the
+    /// hop costs one run-loop turn, during which the activation fallback answers.
+    @MainActor func attach(to window: NSWindow) {
+      apply(to: window)
+      Task { @MainActor [weak self] in
+        guard let self, let window = self.observedWindow else { return }
+        self.report(self.isOnScreen(window))
+      }
+    }
+
+    /// Whether anyone can see this window: on screen, and not fully covered by
+    /// an opaque window in front of it. `isVisible` is the ordered-out half, and
+    /// it is not redundant: occlusion is tracked for windows on screen, so a
+    /// window that has gone away is not a state to read as visible.
+    @MainActor private func isOnScreen(_ window: NSWindow) -> Bool {
+      window.isVisible && window.occlusionState.contains(.visible)
+    }
+
+    @MainActor private func report(_ visible: Bool) {
+      guard reportedVisibility != visible else { return }
+      reportedVisibility = visible
+      reportVisibility(visible)
     }
 
     @MainActor func apply(to window: NSWindow) {
@@ -984,6 +1048,8 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
     @MainActor private func observe(_ window: NSWindow) {
       guard observedWindow !== window else { return }
       if let observer { NotificationCenter.default.removeObserver(observer) }
+      for observer in visibilityObservers { NotificationCenter.default.removeObserver(observer) }
+      visibilityObservers = []
       observedWindow = window
       let box = WeakWindowBox(window: window)
       let owner = WeakCoordinatorBox(coordinator: self)
@@ -996,12 +1062,36 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
           guard let coordinator = owner.coordinator, let window = box.window else { return }
           coordinator.apply(to: window)
           coordinator.restoreMinimumSize(on: window)
+          // The belt on the way back IN. A window ordered back on screen is
+          // updated, whatever the occlusion notification did or did not post,
+          // and a stale `false` here is a hero slider served at the idle
+          // interval. Deduplicated, so a per-pass call is not a per-pass write.
+          coordinator.report(coordinator.isOnScreen(window))
         }
       }
+      visibilityObservers.append(
+        NotificationCenter.default.addObserver(
+          forName: NSWindow.didChangeOcclusionStateNotification, object: window, queue: .main
+        ) { _ in
+          MainActor.assumeIsolated {
+            guard let coordinator = owner.coordinator, let window = box.window else { return }
+            coordinator.report(coordinator.isOnScreen(window))
+          }
+        })
+      // The belt on the way OUT: a closing window is not promised to post an
+      // occlusion change, and it stops being updated, so neither route above can
+      // be trusted to say it has gone. `willClose` always arrives.
+      visibilityObservers.append(
+        NotificationCenter.default.addObserver(
+          forName: NSWindow.willCloseNotification, object: window, queue: .main
+        ) { _ in
+          MainActor.assumeIsolated { owner.coordinator?.report(false) }
+        })
     }
 
     deinit {
       if let observer { NotificationCenter.default.removeObserver(observer) }
+      for observer in visibilityObservers { NotificationCenter.default.removeObserver(observer) }
     }
   }
 }

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -50,6 +50,17 @@ struct SettingsRootView: View {
 
   @Environment(AppModel.self) private var model
 
+  /// Whether this window is on screen, for the brightness poller's cadence. A
+  /// CLOSED settings window reports `.inactive` here, since the window object
+  /// outlives the close, and so does one sitting behind another app: the same
+  /// answer for the poller's purposes, because nobody is reading the sliders.
+  @Environment(\.controlActiveState) private var activeState
+
+  private func noteSettingsVisible(_ visible: Bool) {
+    model.surfaceVisibility.setSettingsVisible(visible)
+    if visible { model.notePollConsumerAppeared() }
+  }
+
   var body: some View {
     ZStack {
       // One canvas for the life of the window, so a selection change moves the
@@ -101,6 +112,14 @@ struct SettingsRootView: View {
     // Dark-only: every colour comes from the theme layer and none of
     // them has a light-appearance answer.
     .preferredColorScheme(.dark)
+    // The window is a poll consumer while up; becoming visible also restarts the
+    // job so the first frame is not a slow interval stale.
+    .onAppear { noteSettingsVisible(activeState != .inactive) }
+    .onChange(of: activeState) { _, state in
+      noteSettingsVisible(state != .inactive)
+    }
+    // Belt on the flag: a consumer left true is a poller that never slows down.
+    .onDisappear { model.surfaceVisibility.setSettingsVisible(false) }
     // The cross-link navigation seam, wired here because this view
     // owns the selection and re-wired per appearance so a reopened window binds
     // to the live view identity.

--- a/Candela/Settings/Theme/SettingsCanvas.swift
+++ b/Candela/Settings/Theme/SettingsCanvas.swift
@@ -3,25 +3,36 @@ import SwiftUI
 /// The drifting glow ground under every settings page, tinted per destination.
 ///
 /// The window keeps ONE canvas alive across every selection so the light moves
-/// rather than cutting to a new one. Reduce Motion holds it at its first
-/// frame.
+/// rather than cutting to a new one. Reduce Motion holds it at its first frame.
+/// Anything short of a key window holds the frame it froze on instead, so the
+/// drift resumes where it stopped rather than jumping.
 struct SettingsCanvas: View {
   var accent: Color
   var secondary: Color
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.controlActiveState) private var activeState
+
+  /// Off-key time is discounted from the drift clock, so coming back resumes the
+  /// motion instead of jumping it forward.
+  @State private var offKeySince: Date?
+  @State private var offKeyTotal: TimeInterval = 0
 
   var body: some View {
     ZStack {
       Color(red: 0.035, green: 0.035, blue: 0.06)
       if reduceMotion {
         blobs(at: 0)
-      } else {
+      } else if activeState == .key {
         // 12 fps: a blob centre moves about a third of a point per frame, and
         // each frame costs two full-window Gaussian blurs.
         TimelineView(.animation(minimumInterval: 1.0 / 12.0)) { context in
-          blobs(at: context.date.timeIntervalSinceReferenceDate)
+          blobs(at: drift(at: context.date))
         }
+      } else {
+        // A CLOSED window lands here too: the object outlives the close and used
+        // to pay for two blurs 12 times a second forever.
+        blobs(at: drift(at: offKeySince ?? .now))
       }
       RadialGradient(
         colors: [.clear, Color.black.opacity(0.5)],
@@ -30,6 +41,19 @@ struct SettingsCanvas: View {
     }
     .ignoresSafeArea()
     .accessibilityHidden(true)
+    .onAppear { if activeState != .key, offKeySince == nil { offKeySince = .now } }
+    .onChange(of: activeState) { _, state in
+      if state == .key {
+        if let since = offKeySince { offKeyTotal += Date.now.timeIntervalSince(since) }
+        offKeySince = nil
+      } else if offKeySince == nil {
+        offKeySince = .now
+      }
+    }
+  }
+
+  private func drift(at date: Date) -> TimeInterval {
+    date.timeIntervalSinceReferenceDate - offKeyTotal
   }
 
   private func blobs(at time: TimeInterval) -> some View {

--- a/Candela/Settings/Theme/SettingsCanvas.swift
+++ b/Candela/Settings/Theme/SettingsCanvas.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 /// The drifting glow ground under every settings page, tinted per destination.
+/// The Heat Map window draws it too, as its own window's ground.
 ///
 /// The window keeps ONE canvas alive across every selection so the light moves
 /// rather than cutting to a new one. Reduce Motion holds it at its first frame.
-/// Anything short of a key window holds the frame it froze on instead, so the
-/// drift resumes where it stopped rather than jumping.
+/// A non-key window holds the frame it froze on, so the drift resumes where it
+/// stopped. Stricter than the poller's consumer threshold on purpose: only the
+/// focused window has to pay for 12 frames a second.
 struct SettingsCanvas: View {
   var accent: Color
   var secondary: Color

--- a/CandelaAppTests/SettingsActionsFanOutTests.swift
+++ b/CandelaAppTests/SettingsActionsFanOutTests.swift
@@ -1,0 +1,67 @@
+import CandelaKit
+import Testing
+
+// The app half of the propagation seam: `PrefPropagation` decides which effects a
+// pref carries and the engine suite pins that table; this asserts `SettingsActions`
+// actually runs them. `.restartBrightnessPoll` rebuilds a job nothing here can
+// read, so it is a hardware leg: turn sync on with nothing open and watch an
+// external follow the built-in without waiting out the slow interval.
+@Suite("Settings actions fan-out") @MainActor
+struct SettingsActionsFanOutTests {
+  private final class Counts {
+    var rearmTap = 0
+    var recheckPermissions = 0
+    var updateStatusItem = 0
+  }
+
+  private func makeActions(_ model: AppModel) -> (SettingsActions, Counts) {
+    let counts = Counts()
+    let actions = SettingsActions(model: model)
+    actions.rearmTap = { counts.rearmTap += 1 }
+    actions.recheckPermissions = { counts.recheckPermissions += 1 }
+    actions.updateStatusItem = { counts.updateStatusItem += 1 }
+    return (actions, counts)
+  }
+
+  @Test func aKeyModeWriteRearmsTheTapAndRechecksTheGrant() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    actions.prefDidChange(.keyboardBrightness)
+    #expect(counts.rearmTap == 1)
+    #expect(counts.recheckPermissions == 1)
+    #expect(counts.updateStatusItem == 0)
+  }
+
+  /// The control: a presentation-only pref must reach neither the tap nor the
+  /// permission check, or the assertions above pass for everything.
+  @Test func aPresentationPrefReachesNeitherOfThem() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    actions.prefDidChange(.showContrast)
+    #expect(counts.rearmTap == 0)
+    #expect(counts.recheckPermissions == 0)
+  }
+
+  /// A batch fans out the UNION, which is no single member's row.
+  @Test func aBatchFansOutEveryMembersEffects() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    actions.prefsDidChange([.keyboardBrightness, .hideDisplay])
+    #expect(counts.rearmTap == 1)
+    #expect(counts.recheckPermissions == 1)
+    #expect(counts.updateStatusItem == 1)
+  }
+
+  /// Turning brightness sync on carries the poll restart and nothing that writes
+  /// hardware. What is observable here is that it goes through the seam at all and
+  /// invalidates the surfaces; the restart itself is the hardware leg above.
+  @Test func turningSyncOnGoesThroughTheSeam() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    let before = model.prefsRevision
+    actions.prefDidChange(.enableBrightnessSync)
+    #expect(model.prefsRevision > before)
+    #expect(counts.rearmTap == 0)
+    #expect(counts.recheckPermissions == 0)
+  }
+}

--- a/CandelaAppTests/SettingsVisibilitySignalTests.swift
+++ b/CandelaAppTests/SettingsVisibilitySignalTests.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Testing
+
+/// The settings window's poll-consumer signal.
+///
+/// The window's own answer wins wherever there is one; activation is the fallback
+/// for the moment before a window has attached, and on its own it cannot tell a
+/// settings page open beside another app from a closed one (every window of a
+/// non-frontmost app reports `.inactive`).
+///
+/// The occlusion observation that produces the window's answer is AppKit window
+/// lifecycle no bundle test reaches. Its hardware leg: leave Settings open beside
+/// another frontmost app, move brightness in Control Center, and watch the hero
+/// slider follow within about a second rather than at the next slow tick.
+@Suite("Settings visibility signal") @MainActor
+struct SettingsVisibilitySignalTests {
+  private func onScreen(_ windowVisibility: Bool?, _ activeState: ControlActiveState) -> Bool {
+    SettingsRootView.isSettingsOnScreen(
+      windowVisibility: windowVisibility, activeState: activeState)
+  }
+
+  /// The finding this shape exists for.
+  @Test func aWindowThatSaysItIsOnScreenIsOnScreenWhileTheAppIsBehindAnother() {
+    #expect(onScreen(true, .inactive))
+  }
+
+  /// The other direction, and the one that pays for itself: a fully covered or
+  /// closed window is off screen however active the app is.
+  @Test func aWindowThatSaysItIsCoveredIsOffScreenHoweverActiveTheAppIs() {
+    #expect(onScreen(false, .key) == false)
+    #expect(onScreen(false, .active) == false)
+    #expect(onScreen(false, .inactive) == false)
+  }
+
+  /// Until a window has attached there is nothing to ask, so activation answers.
+  @Test func activationAnswersOnlyWhileNoWindowHasAttached() {
+    #expect(onScreen(nil, .key))
+    #expect(onScreen(nil, .active))
+    #expect(onScreen(nil, .inactive) == false)
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -601,10 +601,8 @@ public final class BrightnessController: PendingWireDraining {
     return value
   }
 
-  /// Quantization noise on a native read: Control Center's slider granularity plus
-  /// the float round-trip through DisplayServices. Same size and same reason as the
-  /// poller's echo tolerance; anything smaller is not a move somebody made.
-  private static let nativeReadNoise = 0.008
+  /// Shared with the poller's echo discard: both measure the same quantization noise.
+  private static let nativeReadNoise = BrightnessPoller.defaultTolerance
 
   /// Snaps published state onto the panel's live native value before a `step()`.
   /// The poller's idle cadence can leave that state tens of seconds stale, and a

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -604,17 +604,32 @@ public final class BrightnessController: PendingWireDraining {
   /// Shared with the poller's echo discard: both measure the same quantization noise.
   private static let nativeReadNoise = BrightnessPoller.defaultTolerance
 
+  /// The guarded native read both freshness routes take. Nil means there is nothing
+  /// to publish: no read is trustworthy right now, or published state already agrees
+  /// with the glass.
+  private func freshNativeRead() -> Double? {
+    // Under a temporary dim the read is our own write; folding it in corrupts what
+    // `endTemporaryDim` restores.
+    guard isNativeActive(), temporaryDimFactor == nil else { return nil }
+    // Mid-reconfigure and asleep, display state is being rebuilt and every read is
+    // suspect. The poller skips its whole tick on this same gate.
+    guard isWireOpen else { return nil }
+    // A key repeat can outrun the drain: with our own write still queued the panel
+    // has not moved yet, so reading here would snap published state back to the
+    // value the previous press just left and the repeat would re-step from it.
+    guard issuedGeneration <= coalescer.completedThrough() else { return nil }
+    guard let read = backends.readNative?(displayID) else { return nil }
+    let clamped = min(max(Double(read), 0), 1)
+    guard abs(clamped - brightness) > Self.nativeReadNoise else { return nil }
+    return clamped
+  }
+
   /// Snaps published state onto the panel's live native value before a `step()`.
   /// The poller's idle cadence can leave that state tens of seconds stale, and a
   /// step from it jumps a Control Center move back. Native path only, so never the
   /// DDC wire. No persist: the `step()` that follows writes the final value.
   public func syncFromNativeBeforeStep() {
-    // Under a temporary dim the read is our own write; folding it in corrupts what
-    // `endTemporaryDim` restores.
-    guard isNativeActive(), temporaryDimFactor == nil else { return }
-    guard let read = backends.readNative?(displayID) else { return }
-    let clamped = min(max(Double(read), 0), 1)
-    guard abs(clamped - brightness) > Self.nativeReadNoise else { return }
+    guard let clamped = freshNativeRead() else { return }
     brightness = clamped
     // Retire any adoption queued from an earlier poll tick; it describes an older read.
     echo.withLock { state in
@@ -622,6 +637,39 @@ public final class BrightnessController: PendingWireDraining {
       state.generation &+= 1
       state.converging = false
     }
+  }
+
+  /// The same read for a SURFACE about to draw (the menu-bar panel opening), which
+  /// has no `step()` behind it to write the value down.
+  ///
+  /// Takes the poller's adoption route rather than a bare snap: publish, persist,
+  /// and return the delta so the caller can fan it out to the other displays when
+  /// brightness sync is on. A bare snap published a value the store never saw and
+  /// stamped the echo slot with it, so the poller then discarded the panel's real
+  /// value as an echo of ours and the store kept a stale number for the launch
+  /// restore to write back to the glass.
+  ///
+  /// It snaps where `adoptExternal` eases: the easing exists so a continuous
+  /// Control Center drag does not step the other displays in jumps, and a surface
+  /// opening is one discrete event whose first frame has to be right.
+  ///
+  /// Returns 0 when nothing was adopted, the panel opening being the common case.
+  @discardableResult
+  public func adoptNativeForSurface() -> Double {
+    // A convergence in flight belongs to the poller, which lands it within a few
+    // ticks; ending it here would stop it fanning the rest of the move out.
+    guard !isConvergingFromExternal() else { return 0 }
+    guard let clamped = freshNativeRead() else { return 0 }
+    let previous = brightness
+    brightness = clamped
+    persist(clamped)
+    // Retire any adoption queued from an earlier poll tick; it describes an older read.
+    echo.withLock { state in
+      state.value = clamped
+      state.generation &+= 1
+      state.converging = false
+    }
+    return clamped - previous
   }
 
   // MARK: - Path selection
@@ -2352,6 +2400,15 @@ actor BrightnessWriteCoalescer {
     )
 
   private var completedGeneration: UInt64 = 0
+  /// Lock-backed mirror of `completedGeneration`, for readers that cannot suspend:
+  /// the freshness read runs on the key path, where an executor hop into this actor
+  /// would land after the key repeat it exists to protect.
+  ///
+  /// It mirrors the COMPLETED counter and not `appliedGeneration` because a failed
+  /// or epoch-skipped write never advances the applied one, so a reader gating on
+  /// that would stay gated for the rest of the session on a display whose wire went
+  /// quiet.
+  private nonisolated let completedMirror = OSAllocatedUnfairLock<UInt64>(initialState: 0)
   /// The highest generation that actually reached hardware, was skipped because
   /// its exact target was already there, or was superseded by a newer write
   /// that did one of those. Compare it against the submitter's own counter to
@@ -2458,6 +2515,11 @@ actor BrightnessWriteCoalescer {
   /// See `appliedGeneration`. Read AFTER a `waitUntilCompleted` for the
   /// generation in question, or it answers about a queue still in flight.
   func appliedThrough() -> UInt64 { appliedGeneration }
+
+  /// The highest generation the queue has finished with, applied or skipped, read
+  /// without an executor hop. `submissionMark`-style comparison against the
+  /// submitter's own counter answers "is a write of ours still in the queue".
+  nonisolated func completedThrough() -> UInt64 { completedMirror.withLock { $0 } }
 
   func waitUntilCompleted(through generation: UInt64) async {
     guard generation > completedGeneration else { return }
@@ -2572,6 +2634,8 @@ actor BrightnessWriteCoalescer {
 
   private func complete(_ generation: UInt64) {
     completedGeneration = max(completedGeneration, generation)
+    let completed = completedGeneration
+    completedMirror.withLock { $0 = completed }
     resumeSatisfiedWaiters()
   }
 

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -621,6 +621,9 @@ public final class BrightnessController: PendingWireDraining {
     guard let read = backends.readNative?(displayID) else { return nil }
     let clamped = min(max(Double(read), 0), 1)
     guard abs(clamped - brightness) > Self.nativeReadNoise else { return nil }
+    // The display moved outside our write path. A step back to the last successful
+    // target must reach hardware, even if a surface adopts this read before the key.
+    coalescer.resetDuplicateState()
     return clamped
   }
 

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -601,6 +601,31 @@ public final class BrightnessController: PendingWireDraining {
     return value
   }
 
+  /// Quantization noise on a native read: Control Center's slider granularity plus
+  /// the float round-trip through DisplayServices. Same size and same reason as the
+  /// poller's echo tolerance; anything smaller is not a move somebody made.
+  private static let nativeReadNoise = 0.008
+
+  /// Snaps published state onto the panel's live native value before a `step()`.
+  /// The poller's idle cadence can leave that state tens of seconds stale, and a
+  /// step from it jumps a Control Center move back. Native path only, so never the
+  /// DDC wire. No persist: the `step()` that follows writes the final value.
+  public func syncFromNativeBeforeStep() {
+    // Under a temporary dim the read is our own write; folding it in corrupts what
+    // `endTemporaryDim` restores.
+    guard isNativeActive(), temporaryDimFactor == nil else { return }
+    guard let read = backends.readNative?(displayID) else { return }
+    let clamped = min(max(Double(read), 0), 1)
+    guard abs(clamped - brightness) > Self.nativeReadNoise else { return }
+    brightness = clamped
+    // Retire any adoption queued from an earlier poll tick; it describes an older read.
+    echo.withLock { state in
+      state.value = clamped
+      state.generation &+= 1
+      state.converging = false
+    }
+  }
+
   // MARK: - Path selection
 
   /// The four-way fork contract, decided synchronously from cached state:

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPollCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPollCadence.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// How often the native poller looks, decided fresh on every tick.
+///
+/// Never STOPPED while a display exists: an external entering HDR flips onto the
+/// native path through no call of ours, and only a running poller notices. An
+/// idle rig pays a longer interval, never no poller.
+public enum BrightnessPollCadence: Sendable, Equatable, CaseIterable {
+  /// A value is moving: chase it, as the fork did.
+  case fast
+  /// Something is consuming the value right now.
+  case idle
+  /// Nothing is consuming it, on mains.
+  case slowIdle
+  /// Nothing is consuming it, on battery.
+  case batterySlowIdle
+
+  /// For the log line that makes the cadence readable from outside the process.
+  public var name: String {
+    switch self {
+    case .fast: "fast"
+    case .idle: "idle"
+    case .slowIdle: "slow"
+    case .batterySlowIdle: "slow-on-battery"
+    }
+  }
+
+  /// `isExternalNativeActive` ignores the built-in on purpose: it is always native
+  /// and would pin every laptop to the short interval. Its only consumer with no
+  /// surface open is a brightness key, which takes its own read before stepping.
+  /// `isOnBattery` is an autoclosure: the power-source read costs something and
+  /// only the slow branch needs it.
+  public static func choose(
+    isMoving: Bool,
+    isSyncEnabled: Bool,
+    isSurfaceVisible: Bool,
+    isExternalNativeActive: Bool,
+    isOnBattery: @autoclosure () -> Bool
+  ) -> BrightnessPollCadence {
+    if isMoving { return .fast }
+    if isSyncEnabled || isSurfaceVisible || isExternalNativeActive { return .idle }
+    return isOnBattery() ? .batterySlowIdle : .slowIdle
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
@@ -65,13 +65,14 @@ public actor BrightnessPoller {
   /// Last cadence reported to the log, so a steady state costs no lines.
   private var lastLoggedCadence: BrightnessPollCadence?
 
-  /// `tolerance` covers Control Center's slider quantization plus the float
-  /// round-trip through DisplayServices; larger swallows real external moves.
-  ///
-  /// The two consumer signals are read LIVE on every tick, like the per-target
-  /// native gate: a surface opening or a pref changing must not need the poll job
-  /// rebuilt, because rebuilding it is what would drop the HDR edges nothing else
-  /// reports.
+  /// Control Center's slider quantization plus the float round-trip through
+  /// DisplayServices; larger swallows real external moves. Public so the pre-step
+  /// freshness read shares it.
+  public static let defaultTolerance = 0.008
+
+  /// `tolerance` is per instance so a test can widen or narrow it. The consumer
+  /// signals are read LIVE on every tick, like the native gate, so a surface
+  /// opening or a pref write never needs the job rebuilt.
   public init(
     targets: [Target],
     read: @escaping @Sendable (CGDirectDisplayID) -> Double?,
@@ -83,7 +84,7 @@ public actor BrightnessPoller {
     idleInterval: Duration = .seconds(1),
     slowIdleInterval: Duration = .seconds(10),
     batteryIdleInterval: Duration = .seconds(30),
-    tolerance: Double = 0.008
+    tolerance: Double = BrightnessPoller.defaultTolerance
   ) {
     self.targets = targets
     self.read = read

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
@@ -1,14 +1,21 @@
 import CoreGraphics
 import Foundation
+import os
+
+let pollLog = Logger(subsystem: "com.rydersel.Candela", category: "poll")
 
 /// Polls native brightness for displays whose controller is HDR-native,
 /// discards echoes of our own writes, and reports real external deltas to the
 /// controller. Ported from the MonitorControl fork's `refreshBrightness` poll
-/// job, the behavior oracle for both the cadence and the echo discard.
+/// job, the behavior oracle for the echo discard and for the moving/idle pair at
+/// the top of the cadence.
 ///
 /// It never smooths, never writes hardware and never decides staleness:
 /// `BrightnessController.adoptExternal` owns the easing and the generation
 /// discard.
+///
+/// Unlike the fork, the idle cadence is not one interval: `BrightnessPollCadence`
+/// lengthens it when nothing consumes the value. The task itself never stops.
 public actor BrightnessPoller {
   public struct Target: Sendable {
     public let displayID: CGDirectDisplayID
@@ -24,44 +31,70 @@ public actor BrightnessPoller {
     /// True while an earlier adoption is still easing toward its target: the
     /// echo discard must be bypassed or the chase never terminates.
     public let isConverging: @Sendable () -> Bool
+    /// Only externals vote on the cadence; see `BrightnessPollCadence.choose`.
+    public let isExternal: Bool
 
     public init(
       displayID: CGDirectDisplayID,
       expected: @escaping @Sendable () -> (value: Double?, generation: UInt64),
       isNativeActive: @escaping @Sendable () -> Bool,
       adopt: @escaping @Sendable (Double, UInt64) -> Void,
-      isConverging: @escaping @Sendable () -> Bool
+      isConverging: @escaping @Sendable () -> Bool,
+      isExternal: Bool
     ) {
       self.displayID = displayID
       self.expected = expected
       self.isNativeActive = isNativeActive
       self.adopt = adopt
       self.isConverging = isConverging
+      self.isExternal = isExternal
     }
   }
 
   private let targets: [Target]
   private let read: @Sendable (CGDirectDisplayID) -> Double?
   private let isEpochCurrent: @Sendable () -> Bool
+  private let isSyncEnabled: @Sendable () -> Bool
+  private let isSurfaceVisible: @Sendable () -> Bool
+  private let isOnBattery: @Sendable () -> Bool
   private let fastInterval: Duration
   private let idleInterval: Duration
+  private let slowIdleInterval: Duration
+  private let batteryIdleInterval: Duration
   private let tolerance: Double
+  /// Last cadence reported to the log, so a steady state costs no lines.
+  private var lastLoggedCadence: BrightnessPollCadence?
 
   /// `tolerance` covers Control Center's slider quantization plus the float
   /// round-trip through DisplayServices; larger swallows real external moves.
+  ///
+  /// The two consumer signals are read LIVE on every tick, like the per-target
+  /// native gate: a surface opening or a pref changing must not need the poll job
+  /// rebuilt, because rebuilding it is what would drop the HDR edges nothing else
+  /// reports.
   public init(
     targets: [Target],
     read: @escaping @Sendable (CGDirectDisplayID) -> Double?,
     isEpochCurrent: @escaping @Sendable () -> Bool,
+    isSyncEnabled: @escaping @Sendable () -> Bool,
+    isSurfaceVisible: @escaping @Sendable () -> Bool,
+    isOnBattery: @escaping @Sendable () -> Bool = { PowerSource.isOnBattery() },
     fastInterval: Duration = .milliseconds(100),
     idleInterval: Duration = .seconds(1),
+    slowIdleInterval: Duration = .seconds(10),
+    batteryIdleInterval: Duration = .seconds(30),
     tolerance: Double = 0.008
   ) {
     self.targets = targets
     self.read = read
     self.isEpochCurrent = isEpochCurrent
+    self.isSyncEnabled = isSyncEnabled
+    self.isSurfaceVisible = isSurfaceVisible
+    self.isOnBattery = isOnBattery
     self.fastInterval = fastInterval
     self.idleInterval = idleInterval
+    self.slowIdleInterval = slowIdleInterval
+    self.batteryIdleInterval = batteryIdleInterval
     self.tolerance = tolerance
   }
 
@@ -69,11 +102,47 @@ public actor BrightnessPoller {
   public func run() async {
     while !Task.isCancelled {
       let moving = tick()
+      let cadence = BrightnessPollCadence.choose(
+        isMoving: moving,
+        isSyncEnabled: isSyncEnabled(),
+        isSurfaceVisible: isSurfaceVisible(),
+        // Outside `tick`, which returns early mid-reconfigure: a burst must not
+        // decide the cadence after it.
+        isExternalNativeActive: externalNativeActive(),
+        isOnBattery: isOnBattery()
+      )
+      let sleep = interval(for: cadence)
+      log(cadence, sleeping: sleep)
       do {
-        try await Task.sleep(for: moving ? fastInterval : idleInterval)
+        try await Task.sleep(for: sleep)
       } catch {
         return
       }
+    }
+  }
+
+  /// The idle intervals are otherwise unobservable from outside the process.
+  /// `.fast` is not logged: it flips on every adopted value during a drag.
+  private func log(_ cadence: BrightnessPollCadence, sleeping: Duration) {
+    guard cadence != .fast, cadence != lastLoggedCadence else { return }
+    lastLoggedCadence = cadence
+    let ms = sleeping.components.seconds * 1000
+      + sleeping.components.attoseconds / 1_000_000_000_000_000
+    pollLog.info(
+      "native poll cadence \(cadence.name, privacy: .public) interval=\(ms, privacy: .public)ms"
+    )
+  }
+
+  private func externalNativeActive() -> Bool {
+    targets.contains { $0.isExternal && $0.isNativeActive() }
+  }
+
+  private func interval(for cadence: BrightnessPollCadence) -> Duration {
+    switch cadence {
+    case .fast: fastInterval
+    case .idle: idleInterval
+    case .slowIdle: slowIdleInterval
+    case .batterySlowIdle: batteryIdleInterval
     }
   }
 

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
@@ -102,24 +102,29 @@ public actor BrightnessPoller {
   /// Returns on cancellation.
   public func run() async {
     while !Task.isCancelled {
-      let moving = tick()
-      let cadence = BrightnessPollCadence.choose(
-        isMoving: moving,
-        isSyncEnabled: isSyncEnabled(),
-        isSurfaceVisible: isSurfaceVisible(),
-        // Outside `tick`, which returns early mid-reconfigure: a burst must not
-        // decide the cadence after it.
-        isExternalNativeActive: externalNativeActive(),
-        isOnBattery: isOnBattery()
-      )
-      let sleep = interval(for: cadence)
-      log(cadence, sleeping: sleep)
+      let delay = pollOnce()
       do {
-        try await Task.sleep(for: sleep)
+        try await Task.sleep(for: delay)
       } catch {
         return
       }
     }
+  }
+
+  /// Performs one poll and returns the delay before the next one.
+  func pollOnce() -> Duration {
+    let moving = tick()
+    let cadence = BrightnessPollCadence.choose(
+      isMoving: moving,
+      isSyncEnabled: isSyncEnabled(),
+      isSurfaceVisible: isSurfaceVisible(),
+      // A reconfiguration can skip the read without removing its consumers.
+      isExternalNativeActive: externalNativeActive(),
+      isOnBattery: isOnBattery()
+    )
+    let delay = interval(for: cadence)
+    log(cadence, sleeping: delay)
+    return delay
   }
 
   /// The idle intervals are otherwise unobservable from outside the process.

--- a/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
@@ -14,23 +14,21 @@ public enum TapLifecycleAction: Sendable, Equatable {
 /// The edge is decided from the INTENDED sets, never the tap's `isRunning`: an
 /// emergency teardown leaves that flag true.
 public enum TapLifecyclePolicy {
-  /// `previous` is the last watched set the app committed to: nil when no tap
-  /// could be armed at all (no grant, or a start that failed), which is not the
-  /// same as an empty set. Empty means the app deliberately watches nothing and
-  /// can pick the tap back up the moment a key needs it; nil means something
-  /// outside this decision has to change first, so restarting from here would
-  /// retry a failed start on every reconfigure and every menu close.
-  ///
-  /// Two non-empty sets always reconfigure, equal or not: the config carries the
-  /// alternate-brightness-key flag as well, and that pref reaches the tap
-  /// through this same path.
+  /// `previous` nil: no tap could be armed (no grant, or a failed start). Not the
+  /// empty set, and retryable, since most start failures are transient.
+  /// `permanentlyUnavailable` is the one failure a retry cannot fix.
+  /// Equal non-empty sets still reconfigure: the config also carries the
+  /// alternate-brightness-key flag.
   public static func action(
     previous: Set<MediaKey>?,
     next: Set<MediaKey>,
-    grantHeld: Bool
+    grantHeld: Bool,
+    permanentlyUnavailable: Bool
   ) -> TapLifecycleAction {
     guard grantHeld else { return .nothing }
-    guard let previous else { return .nothing }
+    // Set only where no tap exists, so there is never one here to stop.
+    guard !permanentlyUnavailable else { return .nothing }
+    guard let previous else { return next.isEmpty ? .nothing : .start }
     if previous.isEmpty {
       return next.isEmpty ? .nothing : .start
     }

--- a/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
@@ -4,6 +4,10 @@ public enum TapLifecycleAction: Sendable, Equatable {
   case start
   case stop
   case reconfigure
+  /// Nothing is watched and no tap exists, so there is nothing to do to one. The
+  /// empty set is committed anyway: "watching nothing on purpose" and "no tap could
+  /// run" are different answers, and diagnostics reports them apart.
+  case recordEmpty
   case nothing
 }
 
@@ -28,7 +32,7 @@ public enum TapLifecyclePolicy {
     guard grantHeld else { return .nothing }
     // Set only where no tap exists, so there is never one here to stop.
     guard !permanentlyUnavailable else { return .nothing }
-    guard let previous else { return next.isEmpty ? .nothing : .start }
+    guard let previous else { return next.isEmpty ? .recordEmpty : .start }
     if previous.isEmpty {
       return next.isEmpty ? .nothing : .start
     }

--- a/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
@@ -1,0 +1,39 @@
+/// What the app should do to the media-key event tap after the watched-key set
+/// is recomputed.
+public enum TapLifecycleAction: Sendable, Equatable {
+  case start
+  case stop
+  case reconfigure
+  case nothing
+}
+
+/// Decides whether the media-key tap should exist at all right now.
+///
+/// A tap watching nothing still costs a run-loop thread and two watchdog threads
+/// while every key passes through, so one exists only while something is watched.
+/// The edge is decided from the INTENDED sets, never the tap's `isRunning`: an
+/// emergency teardown leaves that flag true.
+public enum TapLifecyclePolicy {
+  /// `previous` is the last watched set the app committed to: nil when no tap
+  /// could be armed at all (no grant, or a start that failed), which is not the
+  /// same as an empty set. Empty means the app deliberately watches nothing and
+  /// can pick the tap back up the moment a key needs it; nil means something
+  /// outside this decision has to change first, so restarting from here would
+  /// retry a failed start on every reconfigure and every menu close.
+  ///
+  /// Two non-empty sets always reconfigure, equal or not: the config carries the
+  /// alternate-brightness-key flag as well, and that pref reaches the tap
+  /// through this same path.
+  public static func action(
+    previous: Set<MediaKey>?,
+    next: Set<MediaKey>,
+    grantHeld: Bool
+  ) -> TapLifecycleAction {
+    guard grantHeld else { return .nothing }
+    guard let previous else { return .nothing }
+    if previous.isEmpty {
+      return next.isEmpty ? .nothing : .start
+    }
+    return next.isEmpty ? .stop : .reconfigure
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
@@ -9,6 +9,9 @@ import Foundation
 public enum OledCareCadence {
   /// Restore-latency gate: any perceptible lag makes this unusable.
   public static let fast: Duration = .milliseconds(100)
+  /// The nomination geometry refresh rides this loop on a one second throttle:
+  /// slower stretches a moved window's shed, faster is dropped by the throttle.
+  public static let windowFollow: Duration = .seconds(1)
   /// The thresholds are minutes, so nothing needs a fast tick to reach them.
   public static let slow: Duration = .seconds(2)
   /// Nothing enrolled: the loop has no work, and `reconcileEnrollment` restarts
@@ -31,20 +34,36 @@ public enum OledCareCadence {
   /// it waits until skipped captures cannot explain the silence.
   public static let stallWarningSeconds: Double = 10 * OledCareCadence.samplingSeconds
 
-  /// Fast whenever a dim is UP BY ANY DELIVERY, or an achieved-state
-  /// verification is pending.
+  /// Fast whenever a dim INPUT SHOULD LIFT is up by any delivery, or an
+  /// achieved-state verification is pending.
   ///
   /// `anyOverlayUp` is the WANT, not the verified presence, on purpose: input
   /// lifts a dim the engine believes is up, and that belief needs fast ticks to
-  /// be corrected.
+  /// be corrected. Only dims `liftsOnInput` covers: detection dimming's mask is
+  /// `nominationDisplayed`, which buys the window-follow second, not 10 Hz.
   ///
   /// `anythingEnrolled` defaults to true so a caller that forgets it cannot idle
-  /// the loop by accident.
+  /// the loop by accident. A displayed nomination outranks it: a mask on screen
+  /// is work in flight whatever the caller says about enrollment.
   public static func interval(
     anyOverlayUp: Bool, anyLockDimEngaged: Bool, verificationPending: Bool,
-    anythingEnrolled: Bool = true
+    nominationDisplayed: Bool = false, anythingEnrolled: Bool = true
   ) -> Duration {
     if anyOverlayUp || anyLockDimEngaged || verificationPending { return fast }
+    if nominationDisplayed { return windowFollow }
     return anythingEnrolled ? slow : idle
+  }
+}
+
+extension OledDimState {
+  /// Whether the user's next input should end this dim. The cadence's fast term
+  /// and the driver's input monitor both key on it, so they cannot disagree.
+  /// `.active` is excluded though it can carry an overlay: detection dimming's
+  /// mask follows window geometry, not input, and counting it held the loop at 10 Hz.
+  public var liftsOnInput: Bool {
+    switch self {
+    case .idleDim, .blackout, .lockDim, .unfocusedDim: true
+    case .active, .suspended: false
+    }
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
@@ -26,21 +26,31 @@ public enum AccessibilityBackstopPolicy {
     /// The tap was re-armed by something else: a settings reset, or a pref that
     /// carries the re-arm without being about keys at all.
     case tapRearmed
+    /// The user was sent to the Accessibility list: the system prompt went up, or
+    /// one of the buttons that opens System Settings was pressed.
+    case sentToSystemSettings
   }
 
   /// Whether this edge reopens the hunt window, putting its clock back to zero.
   ///
-  /// Only a key-mode write does: a person turning a key family on with no grant is at
-  /// System Settings about to make it, however long the grant has been missing. The
-  /// tap's other re-arm routes re-derive the cadence from the live modes and leave the
-  /// clock where it is; reopening there would put an ungranted rig back on the
-  /// two-second interval for two minutes after a write that has nothing to do with
-  /// keys (a DDC availability switch, an audio-routing override).
+  /// Two of the three do, and they say the same thing about the person at the
+  /// keyboard: they are at System Settings about to make the grant, however long it
+  /// has been missing. Turning a key family on with no grant is that; so is being
+  /// handed the prompt or the list itself.
+  ///
+  /// A bare tap re-arm is not: those routes re-derive the cadence from the live
+  /// modes and leave the clock where it is. Reopening there would put an ungranted
+  /// rig back on the two-second interval for two minutes after a write that has
+  /// nothing to do with keys (a DDC availability switch, an audio-routing override).
   public static func reopensHunt(
     edge: Edge, granted: Bool, requiresAccessibility: Bool
   ) -> Bool {
-    guard edge == .keyModesWritten else { return false }
-    return !granted && requiresAccessibility
+    switch edge {
+    case .tapRearmed: return false
+    // The state halves still gate it: a held grant is not being hunted for, and an
+    // all-custom rig runs no timer for a re-stamp to move.
+    case .keyModesWritten, .sentToSystemSettings: return !granted && requiresAccessibility
+    }
   }
 
   /// `secondsSinceNotification` is nil when no notification has arrived this

--- a/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
@@ -18,6 +18,31 @@ public enum AccessibilityBackstopPolicy {
   /// lose the settle race, so the hunt resumes for this long after one.
   public static let notificationWindow: TimeInterval = 30
 
+  /// What asked for the backstop to be re-evaluated. Both cases carry the same state
+  /// and differ only in what they say about the person at the keyboard.
+  public enum Edge: Sendable, Equatable {
+    /// A key mode was written: someone chose whether a key family goes through us.
+    case keyModesWritten
+    /// The tap was re-armed by something else: a settings reset, or a pref that
+    /// carries the re-arm without being about keys at all.
+    case tapRearmed
+  }
+
+  /// Whether this edge reopens the hunt window, putting its clock back to zero.
+  ///
+  /// Only a key-mode write does: a person turning a key family on with no grant is at
+  /// System Settings about to make it, however long the grant has been missing. The
+  /// tap's other re-arm routes re-derive the cadence from the live modes and leave the
+  /// clock where it is; reopening there would put an ungranted rig back on the
+  /// two-second interval for two minutes after a write that has nothing to do with
+  /// keys (a DDC availability switch, an audio-routing override).
+  public static func reopensHunt(
+    edge: Edge, granted: Bool, requiresAccessibility: Bool
+  ) -> Bool {
+    guard edge == .keyModesWritten else { return false }
+    return !granted && requiresAccessibility
+  }
+
   /// `secondsSinceNotification` is nil when no notification has arrived this
   /// launch. A nil result means run no timer at all.
   public static func interval(

--- a/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// How often the Accessibility grant is polled behind the
+/// `com.apple.accessibility.api` notification. Held: watching for a revocation
+/// nothing else reports. Missing: hunting for a grant the user may be making now,
+/// worth two seconds for a while and very little an hour later.
+public enum AccessibilityBackstopPolicy {
+  /// Held: slow, but never zero. Latching on success is the defect this tracking
+  /// exists to prevent.
+  public static let heldInterval: TimeInterval = 10
+  /// Missing, with a grant plausibly moments away.
+  public static let huntingInterval: TimeInterval = 2
+  /// Missing long enough that nobody is standing at System Settings.
+  public static let restingInterval: TimeInterval = 30
+  /// Hunt length from the moment the grant went missing (launch, if it launched without one).
+  public static let huntWindow: TimeInterval = 120
+  /// A notification means TCC just changed something and the immediate read can
+  /// lose the settle race, so the hunt resumes for this long after one.
+  public static let notificationWindow: TimeInterval = 30
+
+  /// `secondsSinceNotification` is nil when no notification has arrived this
+  /// launch. A nil result means run no timer at all.
+  public static func interval(
+    granted: Bool,
+    requiresAccessibility: Bool,
+    secondsSinceMissingBegan: TimeInterval,
+    secondsSinceNotification: TimeInterval?
+  ) -> TimeInterval? {
+    // Before the skip: the prompt path trusts a held answer, so a stale `true`
+    // would leave a rig that turns a key family back on with dead keys and no prompt.
+    if granted { return heldInterval }
+    // Custom shortcuts are Carbon hotkeys: nothing prompts, reports or reads the
+    // grant on an all-custom rig.
+    guard requiresAccessibility else { return nil }
+    if secondsSinceMissingBegan < huntWindow { return huntingInterval }
+    if let secondsSinceNotification, secondsSinceNotification < notificationWindow {
+      return huntingInterval
+    }
+    return restingInterval
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/PowerSource.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/PowerSource.swift
@@ -1,0 +1,22 @@
+import Foundation
+import IOKit.ps
+
+/// Mains or battery, for anything that should cost less when unplugged.
+public enum PowerSource {
+  /// True only when an internal battery is the source in use. Everything this
+  /// cannot see (no battery, sources that will not enumerate) answers false, the
+  /// mains answer, so it degrades toward polling more often.
+  public static func isOnBattery() -> Bool {
+    guard let blob = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+      let sources = IOPSCopyPowerSourcesList(blob)?.takeRetainedValue() as? [CFTypeRef]
+    else { return false }
+    return sources.contains { source in
+      guard
+        let info = IOPSGetPowerSourceDescription(blob, source)?.takeUnretainedValue()
+          as? [String: Any],
+        info[kIOPSTypeKey] as? String == kIOPSInternalBatteryType
+      else { return false }
+      return info[kIOPSPowerSourceStateKey] as? String == kIOPSBatteryPowerValue
+    }
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/PrefPropagation.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/PrefPropagation.swift
@@ -107,6 +107,9 @@ public enum PrefEffect: Sendable, Hashable {
   /// virtual displays to the slot prefs. Carried by
   /// `virtualSlotConfigured` alone.
   case syncVirtualDisplays
+  /// `AppModel.notePollConsumerAppeared()`: rebuild the poll job so the first
+  /// fan-out does not wait out the idle interval in flight.
+  case restartBrightnessPoll
 }
 
 public enum PrefPropagation {
@@ -123,9 +126,14 @@ public enum PrefPropagation {
       // `hasVisibleSlider` derives from these two hide prefs.
       [.rebuildPanel, .updateStatusItem]
 
+    case .enableBrightnessSync:
+      // Sync is a poll consumer, so the job is rebuilt rather than left asleep on
+      // a long interval.
+      [.rebuildPanel, .restartBrightnessPoll]
+
     case .showContrast, .enableSliderSnap, .enableSliderPercent,
          .hideVolumeSlider, .friendlyName, .isDisabled, .hideOsd,
-         .enableBrightnessSync, .hideKeepAwake, .hideCombinedBrightness:
+         .hideKeepAwake, .hideCombinedBrightness:
       // `hideKeepAwake` is presentation alone: hiding the row while keep awake is ON
       // leaves the display awake, which the Menu Bar pane's caption says out loud.
       // `isDisabled` carries no `.rearmTap` deliberately: a display whose keyboard

--- a/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
@@ -57,4 +57,51 @@ struct AccessibilityBackstopPolicyTests {
     #expect(interval(requires: false, missingFor: 3600) == nil)
     #expect(interval(requires: false, sinceNotification: 0) == nil)
   }
+
+  /// The cadence an hour into a missing grant that the tap wants, for each edge.
+  ///
+  /// The edge goes THROUGH the policy, exactly as `AccessibilityPermission`'s two
+  /// doors do: nothing here decides for it, so hard-coding the predicate either way
+  /// moves one of the two answers below. What is modelled is only what the permission
+  /// object does with the verdict, which is to put the hunt clock back to zero.
+  private func cadenceAfterEdge(
+    _ edge: AccessibilityBackstopPolicy.Edge,
+    granted: Bool = false,
+    requires: Bool = true
+  ) -> TimeInterval? {
+    let reopens = AccessibilityBackstopPolicy.reopensHunt(
+      edge: edge, granted: granted, requiresAccessibility: requires
+    )
+    return interval(granted: granted, requires: requires, missingFor: reopens ? 0 : 3600)
+  }
+
+  /// A pref that re-arms the tap says nothing about whether anyone is at System
+  /// Settings, and most of them are not about keys at all, so the clock stays put.
+  @Test func anUnrelatedTapRearmLeavesTheRestingCadence() {
+    #expect(cadenceAfterEdge(.tapRearmed) == 30)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .tapRearmed, granted: false, requiresAccessibility: true
+    ) == false)
+  }
+
+  /// The one edge that does mean someone may be about to grant it.
+  @Test func aKeyModeWriteReopensTheHunt() {
+    #expect(cadenceAfterEdge(.keyModesWritten) == 2)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .keyModesWritten, granted: false, requiresAccessibility: true
+    ))
+  }
+
+  /// The state halves, on the edge that can carry them: a held grant is not being
+  /// hunted for, and an all-custom rig runs no timer for a re-stamp to move.
+  @Test func aKeyModeWriteReopensNothingWithoutBothStateHalves() {
+    #expect(cadenceAfterEdge(.keyModesWritten, granted: true) == 10)
+    #expect(cadenceAfterEdge(.keyModesWritten, requires: false) == nil)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .keyModesWritten, granted: true, requiresAccessibility: true
+    ) == false)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .keyModesWritten, granted: false, requiresAccessibility: false
+    ) == false)
+  }
 }

--- a/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import CandelaKit
+
+@Suite("Accessibility backstop cadence")
+struct AccessibilityBackstopPolicyTests {
+  private func interval(
+    granted: Bool = false,
+    requires: Bool = true,
+    missingFor: TimeInterval = 0,
+    sinceNotification: TimeInterval? = nil
+  ) -> TimeInterval? {
+    AccessibilityBackstopPolicy.interval(
+      granted: granted,
+      requiresAccessibility: requires,
+      secondsSinceMissingBegan: missingFor,
+      secondsSinceNotification: sinceNotification
+    )
+  }
+
+  @Test func aHeldGrantIsPolledForeverAtTenSeconds() {
+    #expect(interval(granted: true) == 10)
+    #expect(interval(granted: true, missingFor: 100_000) == 10)
+  }
+
+  /// The tracked answer feeds the prompt path, which declines to prompt while it
+  /// says the grant is held, so the held poll survives the skip.
+  @Test func aHeldGrantIsPolledEvenWhenNothingNeedsIt() {
+    #expect(interval(granted: true, requires: false) == 10)
+  }
+
+  @Test func aMissingGrantHuntsForTheFirstTwoMinutes() {
+    #expect(interval(missingFor: 0) == 2)
+    #expect(interval(missingFor: 60) == 2)
+    #expect(interval(missingFor: 119.9) == 2)
+  }
+
+  @Test func theHuntBacksOffOnceTheWindowHasPassed() {
+    #expect(interval(missingFor: 120) == 30)
+    #expect(interval(missingFor: 3600) == 30)
+  }
+
+  @Test func aNotificationReopensTheHuntFromAnyAge() {
+    #expect(interval(missingFor: 3600, sinceNotification: 0) == 2)
+    #expect(interval(missingFor: 3600, sinceNotification: 29.9) == 2)
+  }
+
+  @Test func theNotificationWindowExpiresBackToTheRestingCadence() {
+    #expect(interval(missingFor: 3600, sinceNotification: 30) == 30)
+    #expect(interval(missingFor: 3600, sinceNotification: 600) == 30)
+  }
+
+  /// An all-custom or all-disabled rig runs Carbon hotkeys only, so no timer.
+  @Test func nothingIsPolledWhenNoKeyFamilyNeedsTheGrant() {
+    #expect(interval(requires: false) == nil)
+    #expect(interval(requires: false, missingFor: 3600) == nil)
+    #expect(interval(requires: false, sinceNotification: 0) == nil)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
@@ -92,6 +92,29 @@ struct AccessibilityBackstopPolicyTests {
     ))
   }
 
+  /// The prompt and the two buttons that open the Accessibility list: the user is
+  /// at System Settings by construction, so the backstop polls fast for their
+  /// return however long the grant has been gone.
+  @Test func beingSentToSystemSettingsReopensTheHunt() {
+    #expect(cadenceAfterEdge(.sentToSystemSettings) == 2)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .sentToSystemSettings, granted: false, requiresAccessibility: true
+    ))
+  }
+
+  /// Same two halves as the key-mode write. The all-custom case is the live one:
+  /// the onboarding flow can offer the list before any key family wants the grant.
+  @Test func beingSentToSystemSettingsReopensNothingWithoutBothStateHalves() {
+    #expect(cadenceAfterEdge(.sentToSystemSettings, granted: true) == 10)
+    #expect(cadenceAfterEdge(.sentToSystemSettings, requires: false) == nil)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .sentToSystemSettings, granted: true, requiresAccessibility: true
+    ) == false)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .sentToSystemSettings, granted: false, requiresAccessibility: false
+    ) == false)
+  }
+
   /// The state halves, on the edge that can carry them: a held grant is not being
   /// hunted for, and an all-custom rig runs no timer for a re-stamp to move.
   @Test func aKeyModeWriteReopensNothingWithoutBothStateHalves() {

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollCadenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollCadenceTests.swift
@@ -1,0 +1,95 @@
+import os
+import Testing
+@testable import CandelaKit
+
+// MARK: - Cadence policy
+
+/// One row of the truth table. Every row is spelled out rather than re-derived: a
+/// test that recomputes the policy agrees with a wrong one just as readily.
+private struct Cell: Sendable, Hashable {
+  let moving: Bool
+  let surface: Bool
+  let sync: Bool
+  let native: Bool
+  let battery: Bool
+  let want: BrightnessPollCadence
+}
+
+private let cadenceCells: [Cell] = [
+  Cell(moving: false, surface: false, sync: false, native: false, battery: false, want: .slowIdle),
+  Cell(moving: false, surface: false, sync: false, native: false, battery: true,  want: .batterySlowIdle),
+  Cell(moving: false, surface: false, sync: false, native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: false, sync: false, native: true,  battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: false, battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: false, battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: true,  battery: true,  want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: false, battery: false, want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: false, battery: true,  want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: true,  battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: false, battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: false, battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: true,  battery: true,  want: .idle),
+  Cell(moving: true,  surface: false, sync: false, native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: false, native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: false, sync: false, native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: false, native: true,  battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: true,  battery: true,  want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: true,  battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: true,  battery: true,  want: .fast),
+]
+
+@Suite("Poll cadence policy")
+struct BrightnessPollCadencePolicyTests {
+  @Test func theTableCoversEveryCell() {
+    #expect(cadenceCells.count == 32)
+    // 32 rows is only every cell if no two describe the same inputs: a duplicated
+    // row and a missing one look identical from the count alone.
+    let inputs = Set(cadenceCells.map { [$0.moving, $0.surface, $0.sync, $0.native, $0.battery] })
+    #expect(inputs.count == 32)
+  }
+
+  @Test(arguments: cadenceCells)
+  fileprivate func cadence(_ cell: Cell) {
+    let got = BrightnessPollCadence.choose(
+      isMoving: cell.moving,
+      isSyncEnabled: cell.sync,
+      isSurfaceVisible: cell.surface,
+      isExternalNativeActive: cell.native,
+      isOnBattery: cell.battery
+    )
+    #expect(got == cell.want)
+  }
+
+  /// The power-source read is the one input with a cost, so it is asked for only
+  /// in the branch that uses it.
+  @Test func theBatteryIsNotReadUnlessTheSlowBranchIsReached() {
+    let asked = OSAllocatedUnfairLock(initialState: 0)
+    func onBattery() -> Bool {
+      asked.withLock { $0 += 1 }
+      return false
+    }
+    _ = BrightnessPollCadence.choose(
+      isMoving: true, isSyncEnabled: false, isSurfaceVisible: false,
+      isExternalNativeActive: false, isOnBattery: onBattery())
+    _ = BrightnessPollCadence.choose(
+      isMoving: false, isSyncEnabled: false, isSurfaceVisible: true,
+      isExternalNativeActive: false, isOnBattery: onBattery())
+    #expect(asked.withLock { $0 } == 0)
+    _ = BrightnessPollCadence.choose(
+      isMoving: false, isSyncEnabled: false, isSurfaceVisible: false,
+      isExternalNativeActive: false, isOnBattery: onBattery())
+    #expect(asked.withLock { $0 } == 1)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -168,11 +168,11 @@ private func makePoller(
 @Test func readMatchingExpectedIsDiscardedAsEcho() async {
   let probe = Probe(expected: 0.5, generation: 3, hardware: 0.5)
   let poller = makePoller(probe)
-  let task = Task { await poller.run() }
-  _ = await waitUntil { probe.reads.count >= 3 }
-  task.cancel()
-  #expect(probe.reads.count >= 3)
+  var intervals: [Duration] = []
+  for _ in 0..<3 { intervals.append(await poller.pollOnce()) }
+  #expect(probe.reads.count == 3)
   #expect(probe.adoptions.isEmpty)
+  #expect(intervals == Array(repeating: .milliseconds(30), count: 3))
 }
 
 @Test func readWithinToleranceIsDiscardedAsEcho() async {
@@ -261,15 +261,12 @@ private func makePoller(
 
 @Test func divergenceSwitchesToFastCadence() async {
   let probe = Probe(expected: 0.5, generation: 1, hardware: 0.9)
-  // The idle interval dwarfs waitUntil's window on purpose: `run()` ticks before it
-  // sleeps, so a fast poller produces five reads in ~40 ms while an idle one cannot
-  // produce read two inside 3 s. The gate below is the cadence assertion; an elapsed-time
-  // bound crossed 1.198 s under runner starvation while still on the fast cadence.
   let poller = makePoller(probe, fast: .milliseconds(10), idle: .seconds(30))
-  let task = Task { await poller.run() }
-  let got = await waitUntil { probe.reads.count >= 5 }
-  task.cancel()
-  #expect(got)
+  var intervals: [Duration] = []
+  for _ in 0..<5 { intervals.append(await poller.pollOnce()) }
+  #expect(probe.reads.count == 5)
+  #expect(probe.adoptions.count == 5)
+  #expect(intervals == Array(repeating: .milliseconds(10), count: 5))
 }
 
 @Test func echoStaysOnIdleCadence() async {

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -28,12 +28,27 @@ private final class Probe: Sendable {
     var converging = false
     var epochCurrent = true
     var hardware: Double? = 0.5
+    var syncEnabled = false
+    var surfaceVisible = false
+    var onBattery = false
+    /// Each counts wakeups, which reads cannot (a tick can skip its read). Two
+    /// counters so a sleep sliced to re-check only ONE signal still shows up.
+    var syncAsks = 0
+    var surfaceAsks = 0
   }
 
   private let state = OSAllocatedUnfairLock(initialState: State())
-  let displayID: CGDirectDisplayID = 7
+  let displayID: CGDirectDisplayID
+  /// A built-in probe is how a rig with nothing to consume the value is modelled:
+  /// it is polled like anything else but casts no vote on the cadence.
+  let isExternal: Bool
 
-  init(expected: Double?, generation: UInt64 = 0, hardware: Double? = 0.5) {
+  init(
+    expected: Double?, generation: UInt64 = 0, hardware: Double? = 0.5,
+    isExternal: Bool = true, displayID: CGDirectDisplayID = 7
+  ) {
+    self.isExternal = isExternal
+    self.displayID = displayID
     state.withLock {
       $0.expectedValue = expected
       $0.generation = generation
@@ -43,10 +58,15 @@ private final class Probe: Sendable {
 
   var reads: [ReadRecord] { state.withLock { $0.reads } }
   var adoptions: [Adoption] { state.withLock { $0.adoptions } }
+  var syncAsks: Int { state.withLock { $0.syncAsks } }
+  var surfaceAsks: Int { state.withLock { $0.surfaceAsks } }
 
   func setNativeActive(_ value: Bool) { state.withLock { $0.nativeActive = value } }
   func setConverging(_ value: Bool) { state.withLock { $0.converging = value } }
   func setEpochCurrent(_ value: Bool) { state.withLock { $0.epochCurrent = value } }
+  func setSyncEnabled(_ value: Bool) { state.withLock { $0.syncEnabled = value } }
+  func setSurfaceVisible(_ value: Bool) { state.withLock { $0.surfaceVisible = value } }
+  func setOnBattery(_ value: Bool) { state.withLock { $0.onBattery = value } }
 
   func read(_ id: CGDirectDisplayID) -> Double? {
     state.withLock { state in
@@ -59,6 +79,18 @@ private final class Probe: Sendable {
     { [state] in state.withLock { $0.epochCurrent } }
   }
 
+  var isSyncEnabled: @Sendable () -> Bool {
+    { [state] in state.withLock { $0.syncAsks += 1; return $0.syncEnabled } }
+  }
+
+  var isSurfaceVisible: @Sendable () -> Bool {
+    { [state] in state.withLock { $0.surfaceAsks += 1; return $0.surfaceVisible } }
+  }
+
+  var isOnBattery: @Sendable () -> Bool {
+    { [state] in state.withLock { $0.onBattery } }
+  }
+
   var target: BrightnessPoller.Target {
     BrightnessPoller.Target(
       displayID: displayID,
@@ -67,7 +99,8 @@ private final class Probe: Sendable {
       adopt: { [state] value, generation in
         state.withLock { $0.adoptions.append(Adoption(value: value, generation: generation)) }
       },
-      isConverging: { [state] in state.withLock { $0.converging } }
+      isConverging: { [state] in state.withLock { $0.converging } },
+      isExternal: isExternal
     )
   }
 }
@@ -88,15 +121,45 @@ private func makePoller(
   _ probe: Probe,
   fast: Duration = .milliseconds(10),
   idle: Duration = .milliseconds(30),
+  slowIdle: Duration = .milliseconds(60),
+  batteryIdle: Duration = .milliseconds(90),
   tolerance: Double = 0.008
 ) -> BrightnessPoller {
   BrightnessPoller(
     targets: [probe.target],
     read: { probe.read($0) },
     isEpochCurrent: probe.isEpochCurrent,
+    isSyncEnabled: probe.isSyncEnabled,
+    isSurfaceVisible: probe.isSurfaceVisible,
+    isOnBattery: probe.isOnBattery,
     fastInterval: fast,
     idleInterval: idle,
+    slowIdleInterval: slowIdle,
+    batteryIdleInterval: batteryIdle,
     tolerance: tolerance
+  )
+}
+
+/// Several targets on one job, so a rig can hold an external AND a built-in. The
+/// read routes by display id, which is why a probe can carry its own.
+private func makePoller(
+  _ probes: [Probe],
+  fast: Duration = .milliseconds(10),
+  idle: Duration = .milliseconds(30),
+  slowIdle: Duration = .milliseconds(60),
+  batteryIdle: Duration = .milliseconds(90)
+) -> BrightnessPoller {
+  BrightnessPoller(
+    targets: probes.map(\.target),
+    read: { id in probes.first { $0.displayID == id }.flatMap { $0.read(id) } },
+    isEpochCurrent: probes[0].isEpochCurrent,
+    isSyncEnabled: probes[0].isSyncEnabled,
+    isSurfaceVisible: probes[0].isSurfaceVisible,
+    isOnBattery: probes[0].isOnBattery,
+    fastInterval: fast,
+    idleInterval: idle,
+    slowIdleInterval: slowIdle,
+    batteryIdleInterval: batteryIdle
   )
 }
 
@@ -222,6 +285,149 @@ private func makePoller(
   // Idle cadence over this window is 2 reads and fast would be ~50, so only the upper
   // bound can show the wrong cadence, and starvation moves the count the safe way.
   #expect(probe.reads.count <= 4)
+}
+
+// MARK: - Idle cadence
+
+@Test func nothingConsumingTheValueLengthensTheInterval() async {
+  // Built-in only, echoing: nothing is moving, no surface is up, sync is off and
+  // no EXTERNAL is native, which is the whole of the slow condition.
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .milliseconds(200))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { !probe.reads.isEmpty }
+  try? await Task.sleep(for: .milliseconds(250))
+  task.cancel()
+  #expect(started)
+  // The idle interval here is the FAST one, so a poller that ignored the slow
+  // cadence would be at ~50 reads. The control below proves this window can carry
+  // them.
+  #expect(probe.reads.count <= 4)
+}
+
+@Test func aSurfaceAppearingShortensTheNextIntervalWithNoRestart() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .milliseconds(200))
+  let task = Task { await poller.run() }
+  _ = await waitUntil { !probe.reads.isEmpty }
+  // Flipped mid-run, on the SAME poll job: the cadence is re-read every tick, so
+  // nothing restarts it.
+  probe.setSurfaceVisible(true)
+  let sped = await waitUntil { probe.reads.count >= 20 }
+  task.cancel()
+  #expect(sped)
+}
+
+@Test func syncOnKeepsTheShortIntervalWithNoExternalNative() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  probe.setSyncEnabled(true)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .seconds(30))
+  let task = Task { await poller.run() }
+  let sped = await waitUntil { probe.reads.count >= 20 }
+  task.cancel()
+  #expect(sped)
+}
+
+@Test func batteryLengthensTheSlowIntervalFurther() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  probe.setOnBattery(true)
+  let poller = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(5),
+    slowIdle: .milliseconds(20), batteryIdle: .milliseconds(400))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { !probe.reads.isEmpty }
+  try? await Task.sleep(for: .milliseconds(300))
+  task.cancel()
+  #expect(started)
+  // On mains this window is ~15 reads.
+  #expect(probe.reads.count <= 2)
+}
+
+/// The whole saving, stated as wakeups rather than reads: a tick can skip its read
+/// (a non-native target), so only the per-loop cadence read counts the timer.
+@Test func aSlowIntervalWakesOncePerIntervalNotOncePerSecond() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let poller = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(20), slowIdle: .milliseconds(300))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { probe.syncAsks >= 1 }
+  try? await Task.sleep(for: .milliseconds(250))
+  task.cancel()
+  #expect(started)
+  // A sleep sliced at the idle interval would show about 12 in whichever signal it
+  // re-checked, so both are asserted.
+  #expect(probe.syncAsks <= 2)
+  #expect(probe.surfaceAsks <= 2)
+}
+
+/// The app's route back from a long interval is rebuilding the job, which buys
+/// nothing unless a fresh run reads BEFORE it sleeps.
+@Test func aFreshJobReadsBeforeItSleeps() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let first = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(50), slowIdle: .seconds(30))
+  let firstTask = Task { await first.run() }
+  _ = await waitUntil { !probe.reads.isEmpty }
+  firstTask.cancel() // asleep for 30 s, exactly the state a surface can open into
+  let before = probe.reads.count
+  probe.setSurfaceVisible(true)
+  let replacement = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(50), slowIdle: .seconds(30))
+  let start = ContinuousClock.now
+  let secondTask = Task { await replacement.run() }
+  let read = await waitUntil(.seconds(2)) { probe.reads.count > before }
+  let elapsed = ContinuousClock.now - start
+  secondTask.cancel()
+  #expect(read)
+  #expect(elapsed < .milliseconds(500))
+}
+
+/// A display on the DDC path is not a consumer of the poll: it is never read, so
+/// it must not hold the short interval either.
+@Test func aNonNativeExternalDoesNotHoldTheShortInterval() async {
+  let external = Probe(expected: 0.5, generation: 1, hardware: 0.5, displayID: 8)
+  external.setNativeActive(false)
+  let builtIn = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false, displayID: 9)
+  let poller = makePoller(
+    [builtIn, external], fast: .milliseconds(5), idle: .milliseconds(5),
+    slowIdle: .milliseconds(200))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { !builtIn.reads.isEmpty }
+  try? await Task.sleep(for: .milliseconds(250))
+  task.cancel()
+  #expect(started)
+  #expect(external.reads.isEmpty)
+  #expect(builtIn.reads.count <= 4)
+}
+
+/// The control for the test above: the same rig with the external ON the native
+/// path must hold the short interval, or the one above passes for the wrong reason.
+@Test func aNativeExternalDoesHoldTheShortInterval() async {
+  let external = Probe(expected: 0.5, generation: 1, hardware: 0.5, displayID: 8)
+  let builtIn = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false, displayID: 9)
+  let poller = makePoller(
+    [builtIn, external], fast: .milliseconds(5), idle: .milliseconds(5),
+    slowIdle: .seconds(30))
+  let task = Task { await poller.run() }
+  let sped = await waitUntil { builtIn.reads.count >= 20 }
+  task.cancel()
+  #expect(sped)
+}
+
+/// The poll job must survive every idle state: an external entering HDR reaches
+/// the native path through no call of ours, and the running poller is what
+/// notices.
+@Test func theSlowCadenceStillNoticesADisplayTurningNative() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.9)
+  probe.setNativeActive(false)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .milliseconds(50))
+  let task = Task { await poller.run() }
+  try? await Task.sleep(for: .milliseconds(120))
+  #expect(probe.reads.isEmpty)
+  probe.setNativeActive(true)
+  let adopted = await waitUntil { !probe.adoptions.isEmpty }
+  task.cancel()
+  #expect(adopted)
 }
 
 // MARK: - Lifecycle

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -369,17 +369,22 @@ private func makePoller(
   let firstTask = Task { await first.run() }
   _ = await waitUntil { !probe.reads.isEmpty }
   firstTask.cancel() // asleep for 30 s, exactly the state a surface can open into
+  // Awaited, not merely cancelled: a read the old job had already begun would
+  // otherwise land after the count below and pass for the new job's first read.
+  await firstTask.value
   let before = probe.reads.count
   probe.setSurfaceVisible(true)
   let replacement = makePoller(
     probe, fast: .milliseconds(5), idle: .milliseconds(50), slowIdle: .seconds(30))
   let start = ContinuousClock.now
   let secondTask = Task { await replacement.run() }
-  let read = await waitUntil(.seconds(2)) { probe.reads.count > before }
+  let read = await waitUntil(.seconds(5)) { probe.reads.count > before }
   let elapsed = ContinuousClock.now - start
   secondTask.cancel()
   #expect(read)
-  #expect(elapsed < .milliseconds(500))
+  // Milliseconds expected; the bound survives a loaded machine and stays an order
+  // of magnitude under the 30 s a job that slept first would wait.
+  #expect(elapsed < .seconds(2))
 }
 
 /// A display on the DDC path is not a consumer of the poll: it is never read, so

--- a/CandelaKit/Tests/CandelaKitTests/DDCWireDegradationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCWireDegradationTests.swift
@@ -185,11 +185,20 @@ struct DDCWireDegradationTests {
     await harness.ddc.setWritesSucceed(false)
     await failWrites(harness, count: 2)
 
-    await harness.controller.setHDRMode(.alwaysOn)
-    await harness.controller.setHDRMode(.off)
+    // Observe an external HDR window so no exit re-apply races the failure
+    // count. Candela's own HDR door is covered by the adjacent round-trip test.
+    await harness.hdr?.stubEnabled(true)
+    _ = await harness.hdr?.measuredHDREnabled(displayID: Harness.displayID)
+    await harness.controller.noteHDRStateMayHaveChanged()
+    await harness.hdr?.stubEnabled(false)
+    _ = await harness.hdr?.measuredHDREnabled(displayID: Harness.displayID)
+    await harness.controller.noteHDRStateMayHaveChanged()
 
     await failWrites(harness, count: 2, from: 0.75)
     #expect(!harness.controller.isWireUnresponsive)
+    // The counter must still work after the reset: one more failed write trips it.
+    await failWrites(harness, count: 1, from: 0.6)
+    #expect(harness.controller.isWireUnresponsive)
   }
 
   /// The built-in routes native, so nothing it does is evidence about a cable it

--- a/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
@@ -1,0 +1,75 @@
+import CoreGraphics
+import os
+import Testing
+@testable import CandelaKit
+
+/// `syncFromNativeBeforeStep`: the read a brightness key takes before it steps, so
+/// a value moved in Control Center while the poller was on its long interval does
+/// not jump back on the first press.
+@MainActor
+@Suite("Media-key freshness")
+struct MediaKeyFreshnessTests {
+  /// A panel whose brightness something else can move between calls.
+  private func makePanel(at value: Float) -> (Harness, OSAllocatedUnfairLock<Float>) {
+    let hardware = OSAllocatedUnfairLock(initialState: value)
+    let harness = Harness(role: .builtIn, readNative: { _ in hardware.withLock { $0 } })
+    return (harness, hardware)
+  }
+
+  private func near(_ a: Double, _ b: Double) -> Bool { abs(a - b) <= 1e-6 }
+
+  @Test func theStepStartsFromTheLiveRead() {
+    let (h, hardware) = makePanel(at: 0.5)
+    #expect(near(h.controller.brightness, 0.5))
+    hardware.withLock { $0 = 0.75 } // moved in Control Center, unobserved
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.75))
+    // One chiclet up from where the panel actually is.
+    #expect(h.controller.step(isUp: true, isFine: false) == 0.8125)
+  }
+
+  /// The positive control: without the read, the same press is the jump.
+  @Test func withoutTheReadTheFirstPressJumpsBack() {
+    let (h, hardware) = makePanel(at: 0.5)
+    hardware.withLock { $0 = 0.75 }
+    #expect(h.controller.step(isUp: true, isFine: false) == 0.5625)
+  }
+
+  @Test func aQueuedAdoptionIsRetired() {
+    let (h, hardware) = makePanel(at: 0.5)
+    let queued = h.controller.expectedNative().generation
+    hardware.withLock { $0 = 0.75 }
+    h.controller.syncFromNativeBeforeStep()
+    // An adoption the poller queued before the read describes an older look at the
+    // same panel, so it must not land on top of the fresh one.
+    #expect(h.controller.adoptExternal(0.4, generation: queued) == 0)
+    #expect(near(h.controller.brightness, 0.75))
+  }
+
+  @Test func quantizationNoiseIsNotAMove() {
+    let (h, hardware) = makePanel(at: 0.5)
+    hardware.withLock { $0 = 0.505 }
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.5))
+  }
+
+  /// Off the native path the register is DDC's, and this read must never go
+  /// looking for it.
+  @Test func nothingIsReadOffTheNativePath() async {
+    let h = Harness(hdrEnabled: false, readNative: { _ in 0.9 })
+    await h.prime()
+    h.controller.setBrightness(0.5)
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.5))
+  }
+
+  /// A read under a lock dim reads OUR write, not the user's value, and folding it
+  /// in would corrupt what the restore returns to.
+  @Test func nothingIsReadUnderATemporaryDim() {
+    let (h, hardware) = makePanel(at: 0.5)
+    h.controller.beginTemporaryDim(factor: 0.3)
+    hardware.withLock { $0 = 0.15 }
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.5))
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
@@ -9,6 +9,37 @@ import Testing
 @MainActor
 @Suite("Media-key freshness")
 struct MediaKeyFreshnessTests {
+  @Test(arguments: [false, true])
+  func consecutiveKeysReachTheDisplayAfterAnExternalMove(isUp: Bool) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    #expect(panel.hardware.withLock { $0.value } == 0.5)
+    panel.hardware.withLock { $0.value = isUp ? 0.46 : 0.54 }
+
+    let expected: [Float] = isUp ? [0.5, 0.5625, 0.625] : [0.5, 0.4375, 0.375]
+    for value in expected {
+      panel.controller.syncFromNativeBeforeStep()
+      #expect(panel.controller.step(isUp: isUp, isFine: false) == Double(value))
+      await panel.controller.waitForPendingWrites()
+      #expect(panel.hardware.withLock { $0.value } == value)
+    }
+  }
+
+  @Test(arguments: [Float(0.5), Float(0.505)])
+  func unchangedReadsDoNotCauseRedundantWrites(read: Float) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    panel.hardware.withLock { $0.value = read }
+
+    panel.controller.syncFromNativeBeforeStep()
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+
+    #expect(panel.hardware.withLock { $0.writes } == [0.5])
+  }
+
   /// A panel whose brightness something else can move between calls.
   private func makePanel(at value: Float) -> (Harness, OSAllocatedUnfairLock<Float>) {
     let hardware = OSAllocatedUnfairLock(initialState: value)
@@ -71,5 +102,35 @@ struct MediaKeyFreshnessTests {
     hardware.withLock { $0 = 0.15 }
     h.controller.syncFromNativeBeforeStep()
     #expect(near(h.controller.brightness, 0.5))
+  }
+}
+
+/// Keeps the real controller, applier and coalescer; only the display I/O is replaced.
+@MainActor
+struct NativeFreshnessPanel {
+  let controller: BrightnessController
+  let hardware: OSAllocatedUnfairLock<(value: Float, writes: [Float])>
+
+  init(at value: Float) {
+    let hardware = OSAllocatedUnfairLock(initialState: (value: value, writes: [Float]()))
+    self.hardware = hardware
+    controller = BrightnessController(
+      writer: FakeDDC(readResult: nil),
+      backends: BrightnessBackends(
+        applierNative: NativeBrightnessApplier(displayID: 7, apply: { value, _ in
+          hardware.withLock {
+            $0.value = value
+            $0.writes.append(value)
+          }
+          return true
+        }),
+        hdr: nil, shade: nil, gamma: nil,
+        readNative: { _ in hardware.withLock { $0.value } }
+      ),
+      prefs: DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "native-freshness"),
+      displayID: 7,
+      role: .builtIn,
+      wireSiblings: []
+    )
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/OledCareCadenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/OledCareCadenceTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import CandelaKit
+
+/// The cadence term a displayed nomination gets, and the state test the fast
+/// term and the input monitor share. The three-term truth table this extends
+/// lives in `LockDimTests`.
+@Suite("OLED care cadence (displayed nomination)")
+struct OledCareCadenceNominationTests {
+  /// The defect: the old fast term counted any overlay, so a nomination on an
+  /// `.active` display held the loop at 10 Hz. No input clears that mask.
+  @Test func aDisplayedNominationTicksAtTheWindowFollowIntervalRatherThanFast() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: true
+      ) == OledCareCadence.windowFollow
+    )
+    #expect(OledCareCadence.windowFollow == .seconds(1))
+  }
+
+  /// The geometry refresh under the mask is throttled at one second, so the
+  /// slow fall-through would double the wait a moved window's dim sheds in.
+  @Test func theWindowFollowIntervalSitsBetweenFastAndSlow() {
+    #expect(OledCareCadence.fast < OledCareCadence.windowFollow)
+    #expect(OledCareCadence.windowFollow < OledCareCadence.slow)
+  }
+
+  /// Every term that means a restore is owed still outranks it: the mask can
+  /// wait a second, a person's input cannot wait past the restore gate.
+  @Test func everyFastTermOutranksADisplayedNomination() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: true, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: true
+      ) == OledCareCadence.fast
+    )
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: true, verificationPending: false,
+        nominationDisplayed: true
+      ) == OledCareCadence.fast
+    )
+    // A mask change sets the verification marker, which is how a new mask still
+    // lands its achieved-state check at 100 ms.
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: true,
+        nominationDisplayed: true
+      ) == OledCareCadence.fast
+    )
+  }
+
+  /// Nothing on screen, nothing to follow: the term has to be off for the idle
+  /// cost this exists to cut to be cut at all.
+  @Test func noNominationLeavesTheOtherTermsAlone() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: false
+      ) == OledCareCadence.slow
+    )
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: false, anythingEnrolled: false
+      ) == OledCareCadence.idle
+    )
+    // The default matters: the parameter was added below the three the existing
+    // truth table passes, and every one of those cells omits it.
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false
+      ) == OledCareCadence.slow
+    )
+  }
+
+  /// A mask on screen is work in flight, whatever the caller believes about
+  /// enrollment. Contradictory input, decided toward the shorter interval for
+  /// the reason `anythingEnrolled` defaults to true.
+  @Test func aDisplayedNominationOutranksTheIdleFallThrough() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: true, anythingEnrolled: false
+      ) == OledCareCadence.windowFollow
+    )
+  }
+
+  /// The states an input event should end. `.active` is excluded even though it
+  /// can hold a nomination overlay, and `.suspended` holds nothing to end.
+  @Test func onlyTheDimsAnInputEndsLiftOnInput() {
+    #expect(OledDimState.idleDim.liftsOnInput)
+    #expect(OledDimState.blackout.liftsOnInput)
+    #expect(OledDimState.lockDim.liftsOnInput)
+    #expect(OledDimState.unfocusedDim.liftsOnInput)
+    #expect(!OledDimState.active.liftsOnInput)
+    #expect(!OledDimState.suspended.liftsOnInput)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/PrefPropagationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PrefPropagationTests.swift
@@ -185,6 +185,12 @@ struct PrefPropagationTests {
     // row is added to it, not swapped in.
     #expect(PrefPropagation.effects(forChange: .unavailableDDC)
       == [.refreshUI, .rearmTap, .reapplyDimming, .rebuildPanel])
+    // Sync is one of the poll cadence's consumers, so turning it on rebuilds the
+    // poll job rather than leaving it asleep on a long interval. It still writes
+    // nothing to hardware: no `.reapplyDimming`.
+    #expect(PrefPropagation.effects(forChange: .enableBrightnessSync)
+      == [.refreshUI, .rebuildPanel, .restartBrightnessPoll])
+    #expect(!PrefPropagation.effects(forChange: .showContrast).contains(.restartBrightnessPoll))
   }
 
   @Test func oledCarePrefsFanOutToOledCare() {

--- a/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
@@ -9,6 +9,36 @@ import Testing
 @MainActor
 @Suite("Surface brightness read")
 struct SurfaceBrightnessReadTests {
+  @Test(arguments: [false, true])
+  func aKeyAfterSurfaceAdoptionReachesTheDisplay(isUp: Bool) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    #expect(panel.hardware.withLock { $0.value } == 0.5)
+    panel.hardware.withLock { $0.value = isUp ? 0.46 : 0.54 }
+
+    #expect(panel.controller.adoptNativeForSurface() != 0)
+    panel.controller.syncFromNativeBeforeStep()
+    #expect(panel.controller.step(isUp: isUp, isFine: false) == 0.5)
+    await panel.controller.waitForPendingWrites()
+
+    #expect(panel.hardware.withLock { $0.value } == 0.5)
+  }
+
+  @Test(arguments: [Float(0.5), Float(0.505)])
+  func unchangedSurfaceReadsDoNotCauseRedundantWrites(read: Float) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    panel.hardware.withLock { $0.value = read }
+
+    #expect(panel.controller.adoptNativeForSurface() == 0)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+
+    #expect(panel.hardware.withLock { $0.writes } == [0.5])
+  }
+
   /// An external on the native path (HDR live), with a panel something else can
   /// move between calls and a store seeded with the value published at launch.
   private func nativeExternal(

--- a/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
@@ -1,0 +1,136 @@
+import CoreGraphics
+import os
+import Testing
+@testable import CandelaKit
+
+/// `adoptNativeForSurface`: the read a surface takes as it opens. Unlike the key
+/// route it has no `step()` behind it to write the value down, so it publishes,
+/// persists and hands back a delta for the sync fan-out.
+@MainActor
+@Suite("Surface brightness read")
+struct SurfaceBrightnessReadTests {
+  /// An external on the native path (HDR live), with a panel something else can
+  /// move between calls and a store seeded with the value published at launch.
+  private func nativeExternal(
+    at value: Float
+  ) async -> (Harness, OSAllocatedUnfairLock<Float>) {
+    let hardware = OSAllocatedUnfairLock(initialState: value)
+    let h = Harness(
+      hdrEnabled: true,
+      settle: .milliseconds(5),
+      seed: [Harness.storageKey: 1.0],
+      readNative: { _ in hardware.withLock { $0 } }
+    )
+    await h.prime()
+    await h.controller.setHDRMode(.alwaysOn)
+    // The entry assert submits; drained here so the in-flight gate is not what the
+    // assertions below are measuring.
+    await h.controller.waitForPendingWrites()
+    return (h, hardware)
+  }
+
+  private func near(_ a: Double, _ b: Double) -> Bool { abs(a - b) <= 1e-6 }
+
+  @Test func aSurfaceReadPersistsWhatItPublishes() async {
+    let (h, hardware) = await nativeExternal(at: 1.0)
+    #expect(h.store.values[Harness.storageKey] == 1.0)
+    hardware.withLock { $0 = 0.75 } // moved in Control Center, unobserved
+
+    let delta = h.controller.adoptNativeForSurface()
+
+    #expect(near(h.controller.brightness, 0.75))
+    #expect(near(delta, -0.25))
+    // The defect this pins: the bare snap published 0.75 and left 1.0 in the store,
+    // which is what the next launch restore would have written to the glass.
+    #expect(near(h.store.values[Harness.storageKey] ?? -1, 0.75))
+  }
+
+  @Test func aSurfaceReadDuringConvergenceIsANoOp() async {
+    let (h, hardware) = await nativeExternal(at: 1.0)
+    let generation = h.controller.expectedNative().generation
+    h.controller.adoptExternal(0.6, generation: generation)
+    #expect(h.controller.isConvergingFromExternal())
+    let published = h.controller.brightness
+    let stored = h.store.values[Harness.storageKey]
+    hardware.withLock { $0 = 0.6 }
+
+    #expect(h.controller.adoptNativeForSurface() == 0)
+
+    // The poller owns this move and lands it within a few ticks, fanning each eased
+    // step out as it goes; ending it here would leave the other displays short.
+    #expect(h.controller.brightness == published)
+    #expect(h.store.values[Harness.storageKey] == stored)
+    #expect(h.controller.isConvergingFromExternal())
+  }
+
+  @Test func nothingIsReadWhileTheEpochIsClosed() async {
+    let (h, hardware) = await nativeExternal(at: 1.0)
+    h.controller.setEpochProvider({ 1 }, isCurrent: { _ in false })
+    hardware.withLock { $0 = 0.75 }
+
+    #expect(h.controller.adoptNativeForSurface() == 0)
+    #expect(near(h.controller.brightness, 1.0))
+
+    // The positive control: the same read with the epoch open takes the value, so
+    // the assertion above is about the gate and not about a read that never works.
+    h.controller.setEpochProvider({ 1 }, isCurrent: { _ in true })
+    #expect(h.controller.adoptNativeForSurface() != 0)
+    #expect(near(h.controller.brightness, 0.75))
+  }
+}
+
+/// A native applier that holds every write until released, so a test can keep the
+/// coalescer's queue in flight without racing its drain.
+private actor GatedNativeApplier: BrightnessApplying {
+  nonisolated let accepts = HardwareTargetKind.native
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  private var released = false
+
+  func apply(_: HardwareTarget) async -> Bool {
+    if !released {
+      await withCheckedContinuation { waiters.append($0) }
+    }
+    return true
+  }
+
+  func release() {
+    released = true
+    for waiter in waiters { waiter.resume() }
+    waiters.removeAll()
+  }
+}
+
+/// The freshness read's in-flight gate, on the panel that has key repeat and no DDC
+/// wire. Its own suite because the applier has to be gated at construction.
+@MainActor
+@Suite("Freshness read against a queued write")
+struct FreshnessReadInFlightTests {
+  @Test func nothingIsReadWhileOurOwnWriteIsStillQueued() async {
+    let hardware = OSAllocatedUnfairLock<Float>(initialState: 0.75)
+    let applier = GatedNativeApplier()
+    let controller = BrightnessController(
+      writer: FakeDDC(readResult: nil),
+      backends: BrightnessBackends(
+        applierNative: applier, hdr: nil, shade: nil, gamma: nil,
+        readNative: { _ in hardware.withLock { $0 } }
+      ),
+      prefs: DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "t"),
+      displayID: 7,
+      role: .builtIn,
+      wireSiblings: []
+    )
+    #expect(controller.brightness == 0.75)
+
+    controller.setBrightness(0.5)
+    // The panel has not moved yet: the write is parked in the applier. A key repeat
+    // reading here would snap published state back to 0.75 and re-step from it.
+    controller.syncFromNativeBeforeStep()
+    #expect(controller.brightness == 0.5)
+
+    // The positive control: once the queue is empty the same read is taken.
+    await applier.release()
+    await controller.waitForPendingWrites()
+    controller.syncFromNativeBeforeStep()
+    #expect(controller.brightness == 0.75)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import CandelaKit
+
+@Suite("Media-key tap lifecycle")
+struct TapLifecyclePolicyTests {
+  private let brightness: Set<MediaKey> = [.brightnessUp, .brightnessDown]
+  private let everything: Set<MediaKey> = [
+    .brightnessUp, .brightnessDown, .volumeUp, .volumeDown, .mute,
+  ]
+
+  @Test func watchingNothingAndStillWatchingNothingDoesNothing() {
+    #expect(TapLifecyclePolicy.action(previous: [], next: [], grantHeld: true) == .nothing)
+  }
+
+  @Test func theFirstWatchedKeyStartsTheTap() {
+    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: true) == .start)
+    #expect(TapLifecyclePolicy.action(previous: [], next: [.mute], grantHeld: true) == .start)
+  }
+
+  @Test func losingTheLastWatchedKeyStopsTheTap() {
+    #expect(TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: true) == .stop)
+    #expect(TapLifecyclePolicy.action(previous: everything, next: [], grantHeld: true) == .stop)
+  }
+
+  /// Equal sets included: the flag for the alternate brightness keys rides the
+  /// same config and reaches the tap only through a reconfigure.
+  @Test func aTapThatStaysUpIsReconfigured() {
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: true)
+        == .reconfigure)
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: brightness, grantHeld: true)
+        == .reconfigure)
+    #expect(
+      TapLifecyclePolicy.action(previous: everything, next: [.mute], grantHeld: true)
+        == .reconfigure)
+  }
+
+  @Test func nothingStartsWithoutTheGrant() {
+    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: false) == .nothing)
+    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: false) == .nothing)
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: false)
+        == .nothing)
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: false) == .nothing)
+  }
+
+  /// No armed set at all is a tap that could not be built, not a tap watching
+  /// nothing, and this path is not the one that can fix it.
+  @Test func aTapThatNeverArmedIsNotRestartedFromHere() {
+    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: true) == .nothing)
+    #expect(TapLifecyclePolicy.action(previous: nil, next: [], grantHeld: true) == .nothing)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
@@ -55,8 +55,20 @@ struct TapLifecyclePolicyTests {
   @Test func aTapThatFailedToArmIsRetriedOnTheNextEdge() {
     #expect(action(previous: nil, next: brightness) == .start)
     #expect(action(previous: nil, next: [.mute]) == .start)
-    // Still nothing to watch, so still nothing to build.
-    #expect(action(previous: nil, next: []) == .nothing)
+  }
+
+  /// Nothing to watch and no tap to watch with. Nothing is built, but the empty set
+  /// is still committed: left unrecorded it reads as a tap that could not run, and
+  /// diagnostics says "not running" for keys released on purpose.
+  @Test func wantingNothingWithNoTapRecordsTheEmptySet() {
+    #expect(action(previous: nil, next: []) == .recordEmpty)
+  }
+
+  /// The grant outranks it: with no grant no tap can run, which is what "not
+  /// running" means, so there is no empty set to commit.
+  @Test func nothingIsRecordedWithoutTheGrant() {
+    #expect(action(previous: nil, next: [], grantHeld: false) == .nothing)
+    #expect(action(previous: [], next: [], grantHeld: false) == .nothing)
   }
 
   /// The one failure a retry cannot fix; without the latch every reconfigure and

--- a/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
@@ -8,48 +8,66 @@ struct TapLifecyclePolicyTests {
     .brightnessUp, .brightnessDown, .volumeUp, .volumeDown, .mute,
   ]
 
+  /// The ordinary rig: the grant is held and the tap can run. A cell that is
+  /// about either of those says so.
+  private func action(
+    previous: Set<MediaKey>?,
+    next: Set<MediaKey>,
+    grantHeld: Bool = true,
+    permanentlyUnavailable: Bool = false
+  ) -> TapLifecycleAction {
+    TapLifecyclePolicy.action(
+      previous: previous, next: next,
+      grantHeld: grantHeld, permanentlyUnavailable: permanentlyUnavailable)
+  }
+
   @Test func watchingNothingAndStillWatchingNothingDoesNothing() {
-    #expect(TapLifecyclePolicy.action(previous: [], next: [], grantHeld: true) == .nothing)
+    #expect(action(previous: [], next: []) == .nothing)
   }
 
   @Test func theFirstWatchedKeyStartsTheTap() {
-    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: true) == .start)
-    #expect(TapLifecyclePolicy.action(previous: [], next: [.mute], grantHeld: true) == .start)
+    #expect(action(previous: [], next: brightness) == .start)
+    #expect(action(previous: [], next: [.mute]) == .start)
   }
 
   @Test func losingTheLastWatchedKeyStopsTheTap() {
-    #expect(TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: true) == .stop)
-    #expect(TapLifecyclePolicy.action(previous: everything, next: [], grantHeld: true) == .stop)
+    #expect(action(previous: brightness, next: []) == .stop)
+    #expect(action(previous: everything, next: []) == .stop)
   }
 
   /// Equal sets included: the flag for the alternate brightness keys rides the
   /// same config and reaches the tap only through a reconfigure.
   @Test func aTapThatStaysUpIsReconfigured() {
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: true)
-        == .reconfigure)
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: brightness, grantHeld: true)
-        == .reconfigure)
-    #expect(
-      TapLifecyclePolicy.action(previous: everything, next: [.mute], grantHeld: true)
-        == .reconfigure)
+    #expect(action(previous: brightness, next: everything) == .reconfigure)
+    #expect(action(previous: brightness, next: brightness) == .reconfigure)
+    #expect(action(previous: everything, next: [.mute]) == .reconfigure)
   }
 
   @Test func nothingStartsWithoutTheGrant() {
-    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: false) == .nothing)
-    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: false) == .nothing)
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: false)
-        == .nothing)
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: false) == .nothing)
+    #expect(action(previous: [], next: brightness, grantHeld: false) == .nothing)
+    #expect(action(previous: nil, next: brightness, grantHeld: false) == .nothing)
+    #expect(action(previous: brightness, next: everything, grantHeld: false) == .nothing)
+    #expect(action(previous: brightness, next: [], grantHeld: false) == .nothing)
   }
 
-  /// No armed set at all is a tap that could not be built, not a tap watching
-  /// nothing, and this path is not the one that can fix it.
-  @Test func aTapThatNeverArmedIsNotRestartedFromHere() {
-    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: true) == .nothing)
-    #expect(TapLifecyclePolicy.action(previous: nil, next: [], grantHeld: true) == .nothing)
+  /// A nil armed set is usually a start that failed for something a later one need
+  /// not hit, so the next edge that wants keys tries again.
+  @Test func aTapThatFailedToArmIsRetriedOnTheNextEdge() {
+    #expect(action(previous: nil, next: brightness) == .start)
+    #expect(action(previous: nil, next: [.mute]) == .start)
+    // Still nothing to watch, so still nothing to build.
+    #expect(action(previous: nil, next: []) == .nothing)
+  }
+
+  /// The one failure a retry cannot fix; without the latch every reconfigure and
+  /// menu close would retry and re-log, forever.
+  @Test func aPermanentlyUnavailableTapIsNeverRetried() {
+    #expect(action(previous: nil, next: brightness, permanentlyUnavailable: true) == .nothing)
+    #expect(action(previous: [], next: brightness, permanentlyUnavailable: true) == .nothing)
+    #expect(action(previous: nil, next: [], permanentlyUnavailable: true) == .nothing)
+    // The app cannot reach this pairing: the latch is set only where a start
+    // failed, and that state records no watched set. Answered anyway.
+    #expect(
+      action(previous: brightness, next: everything, permanentlyUnavailable: true) == .nothing)
   }
 }


### PR DESCRIPTION
Reduce idle work while preserving immediate brightness updates when a user opens controls or presses a key. Merge this PR before #60; #60 includes this branch so the combined behavior has been tested together.

Addresses #51. The remaining manual hardware checks were deferred and the issue closed at the maintainer's request; unrun checks are documented below.

## What changed
- **Settings background** pauses whenever its window is not the key window, including after the window is closed. The window object outlives the close, and the 12 fps timeline behind it used to run for the life of the process once Settings had been opened.
- **Media-key tap** exists only while it watches a key. On a laptop with no external, or with both key families set to custom or off, the tap and its two watchdog threads no longer run. The edge is decided from the intended watched-key set and the grant, never from the tap's running flag; a stopped tap restarts from the refresh path the moment a key becomes watchable; a transient start failure is retried on the next edge, and only the unrecognised-event-fields failure latches for the process.
- **Accessibility backstop** polls at ten seconds while the grant is held, two seconds for the first two minutes without it and for a short window after each permission notification, thirty seconds after that, and not at all when no key family needs the grant. A key-mode write re-evaluates it in both directions.
- **Native brightness poller** never stops (an external entering HDR becomes native without restarting it, and the running loop is what notices), but reads once a second only while sync is on, a Candela surface is visible or an external is native; otherwise every ten seconds on mains and thirty on battery. Opening Settings or turning sync on rebuilds the job so the first read lands at once; opening the panel reads each native display synchronously before tracking starts. A media-key step on a native target reads the live value first, so a move made in Control Center during a long idle does not jump.
- **Static-region mask** no longer holds the care driver at 10 Hz or arms the global input monitor: both key on a dim that input should lift and that is actually delivered. A displayed mask holds a one-second window-follow cadence, the interval its geometry refresh already ran at.

## Regression fixes
- A trustworthy native brightness change now clears the previous write's duplicate memo. Moving brightness outside Candela, then stepping back to its last written value, reaches the display instead of leaving repeated keys stuck. Queued writes, temporary dimming and read noise keep their existing guards.
- Permanent tests cover upward/downward stepping, surface adoption before a key, and unchanged/noisy reads.
- Poll cadence tests inspect the real poller's selected delay instead of relying on wall-clock deadlines. The HDR wire-health test isolates the observed HDR reset from the exit's background reapply and verifies that subsequent failures still trip the counter. This addresses #58.

## Verification
Current branch `19478ed6`: 2,386 engine tests and 542 app tests passed. Combined with #60 at tree `e0f1c09d1444ef21c578b19dcf1f02aa3de34f62`: 2,512 engine tests passed in 20 consecutive full runs during a Release build; 560 app tests passed after regenerating the project. Deliberately disabling fast cadence and HDR reset makes the corresponding regression tests fail. Release debug-marker and Developer ID signing checks pass.

On the deployed combined build, native brightness readback proved 0.875 -> external 0.915 -> key 0.875 -> next key 0.8125. The app log records both writes to 0.875, proving the previous target is no longer suppressed. Original brightness was restored. The normal Dell resolution preview and Revert also passed.

Earlier hardware measurements for the idle changes (not repeated in full for this follow-up):

| State | CPU | Context switches per second |
|---|---|---|
| 1.0.2 build, idle, built-in only | 18.1% | 754 |
| This build, idle, Settings never opened | 0.00% | 1 |
| This build, Settings open (control) | 11.9% | 518 |
| This build, Settings closed again | 0.04% | 8 |

Also measured: no tap threads in a process sample with no external attached; plugging in the Dell started the tap and two posted brightness keys produced two DDC writes; the poll cadence line logged 30 s on battery, 10 s on mains, 1 s with Settings open, sync on, or the MAG in HDR, and back to slow on each exit; with the MAG in HDR a simulated Control Center move to 0.40 followed by one key press stepped to 0.4375 rather than jumping to full.

Deferred at the maintainer's request when merging (not recorded as passed): the static-region mask leg (detection dimming is off on this rig and the leg needs a five-minute dwell), the Accessibility revoke and re-grant loop, a settings reset from a rig with both key families on custom shortcuts and no grant, a revoke followed within ten seconds by plugging in an external, the panel's first frame under a real pointer session after a Control Center move, a held brightness key on the built-in (the steps must stay on the 1/16 grid), the Settings window updating within a second while another app is frontmost, and a relaunch after moving a native display's brightness outside Candela with the panel opened in between (the store must hold the moved value). The mask cadence and the tap, backstop and poll-cadence policies are pinned by unit tests; the rest is wiring.
