### PR TITLE
Mode applies, DDC reads and write pacing check what the display actually did

### DIFF
--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -91,13 +91,9 @@ final class AccessibilityPermission {
   /// The argument decides only the re-stamp below; the cadence re-reads the modes.
   func reevaluateBackstop(requiresAccessibility: Bool) {
     guard isMonitoring else { return }
-    // The needed-and-absent state BEGINS here when a mode write brings the tap
-    // back on a rig that had the poll stood down, so the hunt is re-stamped
-    // rather than read from a grant that went missing hours ago: the user is at
-    // System Settings making the grant right now, which is the one moment the
-    // fast cadence exists for. A nil `scheduledInterval` is that stood-down
-    // state, the only one the cadence answers with no timer at all.
-    if requiresAccessibility, !isGranted, scheduledInterval == nil {
+    // Re-stamp the hunt: someone turning a key family on with no grant is at
+    // System Settings about to make it, however long the grant has been missing.
+    if requiresAccessibility, !isGranted {
       missingSince = ProcessInfo.processInfo.systemUptime
     }
     scheduleBackstop()

--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -50,10 +50,16 @@ final class AccessibilityPermission {
     guard !isGranted else { return }
     // Deliberately the unmanaged constant, not a string literal.
     let promptKey = kAXTrustedCheckOptionPrompt.takeRetainedValue() as String
+    let granted = AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary)
+    // Only where the prompt actually went up. A false answer IS the prompt being
+    // shown, and its button opens the Accessibility list; a true answer showed
+    // nothing and sent nobody anywhere, so the clock has no reason to move (and
+    // `applyGranted` clears it below in any case).
+    if !granted { reevaluateBackstop(after: .sentToSystemSettings) }
     // Through `applyGranted`, not a bare assignment: if this call observes the
     // grant already present, the transition still has to reach `onChange` or the
     // tap never starts and `recheck` sees no change to report.
-    applyGranted(AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary))
+    applyGranted(granted)
   }
 
   /// Calls `onChange` on every TRANSITION, grant and revocation both. Never fires
@@ -80,7 +86,11 @@ final class AccessibilityPermission {
     scheduleBackstop()
   }
 
-  static func openSystemSettings() {
+  /// Opens the Accessibility list, and reopens the hunt on the way: this is the
+  /// route to the grant, so the backstop has to be at the hunting cadence when the
+  /// user comes back rather than resting at thirty seconds.
+  func openSystemSettings() {
+    reevaluateBackstop(after: .sentToSystemSettings)
     NSWorkspace.shared.open(
       URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
     )

--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -86,14 +86,31 @@ final class AccessibilityPermission {
     )
   }
 
-  /// Key modes changed. Called in both directions: nothing else stands the timer
+  /// The tap was re-armed. Every pref carrying the re-arm reaches here, most of them
+  /// nothing to do with keys (a DDC availability switch, an audio-routing override),
+  /// and so does the settings reset, which is the route that leaves an all-custom rig
+  /// wanting the tap with no timer running.
+  func noteTapRearmed() {
+    reevaluateBackstop(after: .tapRearmed)
+  }
+
+  /// A key mode was written. Called in both directions: nothing else stands the timer
   /// down when the last key family goes off, or re-arms it when one comes back.
-  /// The argument decides only the re-stamp below; the cadence re-reads the modes.
-  func reevaluateBackstop(requiresAccessibility: Bool) {
+  func noteKeyModesChanged() {
+    reevaluateBackstop(after: .keyModesWritten)
+  }
+
+  /// Both doors take this path with the same state; the EDGE is the whole difference,
+  /// and the policy is what turns it into "reopen the hunt clock" or "leave it".
+  private func reevaluateBackstop(after edge: AccessibilityBackstopPolicy.Edge) {
     guard isMonitoring else { return }
-    // Re-stamp the hunt: someone turning a key family on with no grant is at
-    // System Settings about to make it, however long the grant has been missing.
-    if requiresAccessibility, !isGranted {
+    if AccessibilityBackstopPolicy.reopensHunt(
+      edge: edge,
+      granted: isGranted,
+      // Read live, like the cadence below: the settings reset restores key-mode
+      // defaults without coming back through a caller that could report them.
+      requiresAccessibility: Self.storedModesRequireGrant()
+    ) {
       missingSince = ProcessInfo.processInfo.systemUptime
     }
     scheduleBackstop()

--- a/Candela/App/AccessibilityPermission.swift
+++ b/Candela/App/AccessibilityPermission.swift
@@ -14,13 +14,19 @@ import Observation
 /// keys die and nothing in the UI would say so.
 ///
 /// The undocumented `com.apple.accessibility.api` distributed notification is
-/// the fast path; a poll backstops it at 2 s while the grant is missing, 10 s
-/// while it is held.
+/// the fast path; a poll backstops it when that notification is missed or lands
+/// before TCC has settled. `AccessibilityBackstopPolicy` owns the cadence.
 @MainActor @Observable
 final class AccessibilityPermission {
   private(set) var isGranted: Bool
 
   @ObservationIgnored private var pollTimer: Timer?
+  /// Cadence `pollTimer` was armed at, so a tick can tell whether it still applies.
+  /// nil means no timer.
+  @ObservationIgnored private var scheduledInterval: TimeInterval?
+  /// Uptime, not wall clock: a clock change must not shorten or extend the hunt.
+  @ObservationIgnored private var missingSince: TimeInterval?
+  @ObservationIgnored private var lastNotification: TimeInterval?
   @ObservationIgnored private var onChange: (@MainActor (Bool) -> Void)?
   @ObservationIgnored private var notificationObserver: (any NSObjectProtocol)?
   /// Gates `scheduleBackstop()`: `promptIfNeeded()` can flip the grant before
@@ -32,7 +38,10 @@ final class AccessibilityPermission {
   private static let accessibilityAPIChanged = NSNotification.Name("com.apple.accessibility.api")
 
   init() {
-    isGranted = AXIsProcessTrustedWithOptions(nil)
+    let granted = AXIsProcessTrustedWithOptions(nil)
+    isGranted = granted
+    // A launch with no grant starts the hunt at launch.
+    missingSince = granted ? nil : ProcessInfo.processInfo.systemUptime
   }
 
   /// Shows the system Accessibility prompt when the grant is missing. No NSAlert:
@@ -61,8 +70,9 @@ final class AccessibilityPermission {
       forName: Self.accessibilityAPIChanged, object: nil, queue: nil
     ) { [weak self] _ in
       // TCC needs a moment to settle: reading immediately can still return the
-      // pre-change answer. The backstop covers us if it does.
+      // pre-change answer. The backstop covers that, so the hunt reopens before the read.
       Task { @MainActor in
+        self?.noteNotification()
         try? await Task.sleep(for: .milliseconds(100))
         self?.recheck()
       }
@@ -76,10 +86,51 @@ final class AccessibilityPermission {
     )
   }
 
-  /// (Re)arms the backstop poll at the cadence the current state calls for.
+  /// Key modes changed. Called in both directions: nothing else stands the timer
+  /// down when the last key family goes off, or re-arms it when one comes back.
+  /// The argument decides only the re-stamp below; the cadence re-reads the modes.
+  func reevaluateBackstop(requiresAccessibility: Bool) {
+    guard isMonitoring else { return }
+    // The needed-and-absent state BEGINS here when a mode write brings the tap
+    // back on a rig that had the poll stood down, so the hunt is re-stamped
+    // rather than read from a grant that went missing hours ago: the user is at
+    // System Settings making the grant right now, which is the one moment the
+    // fast cadence exists for. A nil `scheduledInterval` is that stood-down
+    // state, the only one the cadence answers with no timer at all.
+    if requiresAccessibility, !isGranted, scheduledInterval == nil {
+      missingSince = ProcessInfo.processInfo.systemUptime
+    }
+    scheduleBackstop()
+  }
+
+  private func noteNotification() {
+    lastNotification = ProcessInfo.processInfo.systemUptime
+    guard isMonitoring else { return }
+    scheduleBackstop()
+  }
+
+  private func desiredInterval() -> TimeInterval? {
+    let now = ProcessInfo.processInfo.systemUptime
+    return AccessibilityBackstopPolicy.interval(
+      granted: isGranted,
+      // Read live: the settings reset restores key-mode defaults without coming back here.
+      requiresAccessibility: Self.storedModesRequireGrant(),
+      secondsSinceMissingBegan: missingSince.map { now - $0 } ?? 0,
+      secondsSinceNotification: lastNotification.map { now - $0 }
+    )
+  }
+
+  /// (Re)arms the backstop poll at the cadence the current state calls for, or
+  /// stands it down entirely.
   private func scheduleBackstop() {
     pollTimer?.invalidate()
-    let interval: TimeInterval = isGranted ? 10 : 2
+    pollTimer = nil
+    scheduledInterval = desiredInterval()
+    guard let interval = scheduledInterval else {
+      // No key routes through the tap, so nothing reads the grant but the diagnostics
+      // report, whose line may lag until the next notification or mode write.
+      return
+    }
     // `.common` mode is load-bearing, so this is `Timer(timeInterval:)` plus an
     // explicit `RunLoop.main.add`, not `Timer.scheduledTimer`: a menu tracking
     // session holds the run loop in event-tracking mode, and a default-mode timer
@@ -95,16 +146,21 @@ final class AccessibilityPermission {
     RunLoop.main.add(timer, forMode: .common)
   }
 
-  /// Never invalidates the timer on success; latching is the defect this
-  /// tracking exists to prevent.
+  /// Never stops polling on success; latching is the defect this tracking exists
+  /// to prevent.
   private func recheck() {
     applyGranted(AXIsProcessTrustedWithOptions(nil))
+    // Both windows expire between ticks and `applyGranted` reschedules only on a
+    // transition, so the cadence is re-derived here every tick.
+    if isMonitoring, desiredInterval() != scheduledInterval {
+      scheduleBackstop()
+    }
   }
 
   private func applyGranted(_ granted: Bool) {
     guard granted != isGranted else { return }
     isGranted = granted
-    // Cadence follows the new state (2 s hunting, 10 s holding).
+    missingSince = granted ? nil : ProcessInfo.processInfo.systemUptime
     if isMonitoring {
       scheduleBackstop()
     }
@@ -113,6 +169,14 @@ final class AccessibilityPermission {
 }
 
 extension AccessibilityPermission {
+  /// The stored key modes' answer to whether the CGEvent tap is wanted at all.
+  static func storedModesRequireGrant() -> Bool {
+    let prefs = DisplayPrefs(persistenceKey: "app")
+    return KeyModePolicy.requiresAccessibility(
+      brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
+    )
+  }
+
   /// Whether a missing grant is worth telling the user about right now.
   ///
   /// Not simply `!isGranted`: custom shortcuts are Carbon hotkeys and need no
@@ -121,9 +185,6 @@ extension AccessibilityPermission {
   /// banner has to as well.
   var isWarningWarranted: Bool {
     guard !isGranted else { return false }
-    let prefs = DisplayPrefs(persistenceKey: "app")
-    return KeyModePolicy.requiresAccessibility(
-      brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
-    )
+    return Self.storedModesRequireGrant()
   }
 }

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -520,11 +520,20 @@ final class AppModel {
     lastArmedTapConfig = config
   }
 
-  /// No tap can run: the grant is gone, or the start failed. Diagnostics must
-  /// report "the media-key tap is not running", not the config of a tap that no
-  /// longer exists. A tap stopped because there is nothing to watch is NOT this;
-  /// that state records the empty config instead.
+  /// No tap can run: grant gone, or the start failed. Retryable: the next edge
+  /// that wants keys tries again. A tap stopped for lack of keys is not this; that
+  /// records the empty config.
   func noteTapDisarmed() {
+    lastArmedTapConfig = nil
+  }
+
+  /// The one failure a retry cannot clear: this macOS version does not answer the
+  /// CGEvent fields the decode reads. Without the latch every reconfigure and menu
+  /// close would retry and re-log the error. Never cleared.
+  private(set) var isTapPermanentlyUnavailable = false
+
+  func noteTapPermanentlyUnavailable() {
+    isTapPermanentlyUnavailable = true
     lastArmedTapConfig = nil
   }
 
@@ -1577,21 +1586,21 @@ final class AppModel {
     )
   }
 
-  /// A consumer appearing (a surface opening, brightness sync turned on) must not
-  /// wait out the idle interval already in flight, which is up to 10 seconds on
-  /// mains and 30 on battery.
-  ///
-  /// Rebuilding is the whole mechanism: the cancel drops the sleeping task and the
-  /// fresh `run()` ticks before it sleeps at all, so the value is current the moment
-  /// the surface draws. Waking the sleep instead would need a signal channel into
-  /// the actor, and slicing the sleep would put back the once-a-second timer this
-  /// work exists to remove.
-  ///
-  /// Cheap and main-actor-synchronous: it maps the live display list and starts a
-  /// task. Safe to call from inside a menu tracking session for that reason, which
-  /// is where the panel's open edge arrives.
+  /// A new consumer (a surface opening, sync turned on) must not wait out the idle
+  /// interval in flight, up to 30 s on battery. A fresh `run()` ticks before it
+  /// sleeps, so rebuilding is the wake-up. Not the panel's route: menu tracking
+  /// starves the main actor, so the rebuilt job would land after the panel closed.
   func notePollConsumerAppeared() {
     restartPoller()
+  }
+
+  /// Snaps every native display's published brightness onto its live value before
+  /// a surface draws. Synchronous: the panel's open edge runs inside menu tracking,
+  /// which starves anything that hops. No-op off the native path, so never DDC.
+  func refreshNativeBrightnessForSurface() {
+    for state in allControlledStates {
+      state.controller.syncFromNativeBeforeStep()
+    }
   }
 
   /// Rebuilds the native-brightness poll job for the current display set. Control
@@ -1658,12 +1667,8 @@ final class AppModel {
       isEpochCurrent: { [displayManager] in
         displayManager.isEpochCurrent(displayManager.currentEpoch())
       },
-      // Both read live on every tick rather than captured here, so a pref write or
-      // a surface opening changes the cadence without restarting the job. Restarting
-      // it is what would be dangerous: an external entering HDR reaches the native
-      // path through no call of ours, and only a RUNNING poller notices.
-      // The SAME predicate the fan-out is gated on below, reset latch included: a
-      // consumer that is refusing to consume is not a consumer.
+      // Read live every tick, never captured. Same predicate the fan-out is gated
+      // on, reset latch included: a consumer refusing to consume is not a consumer.
       isSyncEnabled: { [appPrefs, resettingOffMain] in
         appPrefs.enableBrightnessSync && !resettingOffMain.withLock { $0 }
       },

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -456,15 +456,23 @@ final class AppModel {
   /// refuse the second click.
   private(set) var isResetting = false
 
+  /// `isResetting` for the poll job's cadence closure, which runs off the main
+  /// actor. Written wherever the observable is, and nowhere else.
+  @ObservationIgnored private let resettingOffMain = OSAllocatedUnfairLock(initialState: false)
+
   /// Claims the latch. False means a reset is already running and this one must
   /// not start.
   func beginReset() -> Bool {
     guard !isResetting else { return false }
     isResetting = true
+    resettingOffMain.withLock { $0 = true }
     return true
   }
 
-  func endReset() { isResetting = false }
+  func endReset() {
+    isResetting = false
+    resettingOffMain.withLock { $0 = false }
+  }
 
   /// Per-display VCP 0x62 verdict from the capabilities string. Observable,
   /// so the panel's volume slider enables live the moment a probe lands. An ABSENT
@@ -838,9 +846,12 @@ final class AppModel {
     }
   }
 
+  // All three key paths read native first: published state can be an idle poll
+  // interval stale, and a step from it jumps a Control Center move back.
   func stepBrightnessAllExternal(isUp: Bool, isFine: Bool) -> [(id: CGDirectDisplayID, name: String, newValue: Double)] {
     keyEnabledStates(displays).map { state in
-      (state.id, state.display.name, state.controller.step(isUp: isUp, isFine: isFine))
+      state.controller.syncFromNativeBeforeStep()
+      return (state.id, state.display.name, state.controller.step(isUp: isUp, isFine: isFine))
     }
   }
 
@@ -857,6 +868,7 @@ final class AppModel {
       // `isDisabled` filters the loop body: a resolved-but-disabled display
       // steps nothing and shows no HUD.
       guard let slot, !keyEnabledStates([slot]).isEmpty else { return nil }
+      slot.controller.syncFromNativeBeforeStep()
       return (slot.id, slot.display.name,
               slot.controller.step(isUp: isUp, isFine: isFine))
     }
@@ -867,6 +879,7 @@ final class AppModel {
   /// online.
   func stepBrightnessBuiltIn(isUp: Bool, isFine: Bool) -> (id: CGDirectDisplayID, name: String, newValue: Double)? {
     guard let builtIn, !keyEnabledStates([builtIn]).isEmpty else { return nil }
+    builtIn.controller.syncFromNativeBeforeStep()
     return (builtIn.id, builtIn.display.name,
             builtIn.controller.step(isUp: isUp, isFine: isFine))
   }
@@ -1222,6 +1235,10 @@ final class AppModel {
   /// must never outlive the pass that dropped it.
   @ObservationIgnored private var pollerTask: Task<Void, Never>?
 
+  /// Whether a surface showing a brightness value is on screen; one of the
+  /// poller's cadence signals.
+  let surfaceVisibility = SurfaceVisibility()
+
   deinit {
     pollerTask?.cancel()
   }
@@ -1560,6 +1577,23 @@ final class AppModel {
     )
   }
 
+  /// A consumer appearing (a surface opening, brightness sync turned on) must not
+  /// wait out the idle interval already in flight, which is up to 10 seconds on
+  /// mains and 30 on battery.
+  ///
+  /// Rebuilding is the whole mechanism: the cancel drops the sleeping task and the
+  /// fresh `run()` ticks before it sleeps at all, so the value is current the moment
+  /// the surface draws. Waking the sleep instead would need a signal channel into
+  /// the actor, and slicing the sleep would put back the once-a-second timer this
+  /// work exists to remove.
+  ///
+  /// Cheap and main-actor-synchronous: it maps the live display list and starts a
+  /// task. Safe to call from inside a menu tracking session for that reason, which
+  /// is where the panel's open edge arrives.
+  func notePollConsumerAppeared() {
+    restartPoller()
+  }
+
   /// Rebuilds the native-brightness poll job for the current display set. Control
   /// Center and ambient changes bypass us entirely, so looking is the only way to
   /// stay in sync on the native path.
@@ -1570,6 +1604,8 @@ final class AppModel {
       return
     }
     let states = allControlledStates
+    // The built-in must not vote on the cadence; see `Target.isExternal`.
+    let externalIDs = Set(displays.map(\.id))
     let targets = states.map { state -> BrightnessPoller.Target in
       let controller = state.controller
       return BrightnessPoller.Target(
@@ -1610,7 +1646,8 @@ final class AppModel {
             )
           }
         },
-        isConverging: { controller.isConvergingFromExternal() }
+        isConverging: { controller.isConvergingFromExternal() },
+        isExternal: externalIDs.contains(state.id)
       )
     }
     let poller = BrightnessPoller(
@@ -1620,8 +1657,38 @@ final class AppModel {
       // suspended (mid-reconfigure burst or asleep): the poller's skip rule.
       isEpochCurrent: { [displayManager] in
         displayManager.isEpochCurrent(displayManager.currentEpoch())
-      }
+      },
+      // Both read live on every tick rather than captured here, so a pref write or
+      // a surface opening changes the cadence without restarting the job. Restarting
+      // it is what would be dangerous: an external entering HDR reaches the native
+      // path through no call of ours, and only a RUNNING poller notices.
+      // The SAME predicate the fan-out is gated on below, reset latch included: a
+      // consumer that is refusing to consume is not a consumer.
+      isSyncEnabled: { [appPrefs, resettingOffMain] in
+        appPrefs.enableBrightnessSync && !resettingOffMain.withLock { $0 }
+      },
+      isSurfaceVisible: { [surfaceVisibility] in surfaceVisibility.isVisible }
     )
     pollerTask = Task { await poller.run() }
   }
+}
+
+/// Whether a Candela surface showing a brightness value is on screen.
+///
+/// Lock-backed, not main-actor: the poller reads it off the main actor, and the
+/// panel writes it from inside a menu tracking session, where a hop would land
+/// after the menu closed.
+final class SurfaceVisibility: Sendable {
+  private struct State {
+    var isPanelOpen = false
+    var isSettingsVisible = false
+  }
+
+  private let state = OSAllocatedUnfairLock(initialState: State())
+
+  var isVisible: Bool { state.withLock { $0.isPanelOpen || $0.isSettingsVisible } }
+
+  func setPanelOpen(_ open: Bool) { state.withLock { $0.isPanelOpen = open } }
+
+  func setSettingsVisible(_ visible: Bool) { state.withLock { $0.isSettingsVisible = visible } }
 }

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -500,19 +500,22 @@ final class AppModel {
   /// rather than reporting them unenumerated.
   private(set) var hardwareFacts: [String: DisplayHardwareFacts] = [:]
 
-  /// The `WatchConfig` most recently ARMED, not the one most recently computed.
-  /// Those differ exactly when a rearm failed, which is the case the row exists
-  /// for. Recorded at the arm site in `StatusItemController`, never at the compute
-  /// site here.
+  /// The `WatchConfig` most recently COMMITTED to, not the one most recently
+  /// computed; they differ exactly when a rearm failed. Recorded in
+  /// `StatusItemController`, never here.
+  ///
+  /// Empty is not nil. Empty: the app watches nothing on purpose, so no tap exists.
+  /// nil: no tap could be built, the one state diagnostics calls "not running".
   private(set) var lastArmedTapConfig: MediaKeyEventTap.WatchConfig?
 
   func noteTapArmed(_ config: MediaKeyEventTap.WatchConfig) {
     lastArmedTapConfig = config
   }
 
-  /// The tap was torn down (a revoked grant). Diagnostics must report "the
-  /// media-key tap is not running", not the config of a tap that no longer
-  /// exists.
+  /// No tap can run: the grant is gone, or the start failed. Diagnostics must
+  /// report "the media-key tap is not running", not the config of a tap that no
+  /// longer exists. A tap stopped because there is nothing to watch is NOT this;
+  /// that state records the empty config instead.
   func noteTapDisarmed() {
     lastArmedTapConfig = nil
   }

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -1231,8 +1231,16 @@ final class AppModel {
   /// Returns the IDs of displays that departed in this pass. A caller that
   /// JOINED an already-running pass gets `[]`, not that pass's result, which is
   /// why cleanup rides `onDisplaysDeparted` instead.
+  ///
+  /// `settling` says a topology change is what triggered this pass, so its DDC
+  /// reads run over a wire that is still renegotiating. Only the topology
+  /// consumer passes it: launch and menu close both run on a quiet bus and are
+  /// the passes a panel's read verdict is earned on. A caller that JOINS an
+  /// in-flight pass gets that pass's mode, not its own; the window is one
+  /// refresh wide and either direction of the mismatch is one pass of the
+  /// behaviour that shipped.
   @discardableResult
-  func refresh() async -> [CGDirectDisplayID] {
+  func refresh(settling: Bool = false) async -> [CGDirectDisplayID] {
     // Cleared HERE as well as inside `performRefresh`, and the piggyback is why: a
     // caller that JOINS an in-flight pass never reaches `performRefresh`, so its
     // own change would be remembered as answered until some later pass ran. Display
@@ -1243,7 +1251,7 @@ final class AppModel {
       _ = await refreshTask.value
       return []
     }
-    let task = Task { await performRefresh() }
+    let task = Task { await performRefresh(settling: settling) }
     refreshTask = task
     refreshTaskGeneration &+= 1
     let generation = refreshTaskGeneration
@@ -1301,7 +1309,7 @@ final class AppModel {
   /// controller's deinit finishes its coalescer, which lands any pending write
   /// before the drain task exits, so no explicit `waitForPendingWrites()` is
   /// needed.
-  private func performRefresh() async -> [CGDirectDisplayID] {
+  private func performRefresh(settling: Bool = false) async -> [CGDirectDisplayID] {
     // The display set is about to be re-derived, so a memoized "discovery does
     // not know this id" is no longer evidence about anything.
     discoveredPersistenceKeys.clear()
@@ -1451,24 +1459,25 @@ final class AppModel {
       // Safe mode issues NO DDC reads.
       // `BrightnessController.refreshFromHardware` is ungated on `startupAction` in
       // the engine, so the gate lands here.
-      if !safeMode { await state.controller.refreshFromHardware() }
-      await state.volume.refreshFromHardware() // no-op unless startupAction == .read
-      await state.contrast.refreshFromHardware()
+      if !safeMode { await state.controller.refreshFromHardware(settling: settling) }
+      // no-op unless startupAction == .read
+      await state.volume.refreshFromHardware(settling: settling)
+      await state.contrast.refreshFromHardware(settling: settling)
     }
     for state in kept {
       // Let any coalesced tail-write land before reading back, then resync from
       // hardware. Harmless no-op on write-only panels: the read fails its guard and
       // the last-written state stands.
       await state.controller.waitForPendingWrites()
-      if !safeMode { await state.controller.refreshFromHardware() }
+      if !safeMode { await state.controller.refreshFromHardware(settling: settling) }
       // Kept displays re-read volume and contrast too, both gated no-ops unless
       // startupAction == .read. Same drain-before-read shape as the brightness leg:
       // a queued coalescer write must not land after the read has already adopted
       // the pre-write hardware value.
       await state.volume.waitForPendingWrites()
-      await state.volume.refreshFromHardware()
+      await state.volume.refreshFromHardware(settling: settling)
       await state.contrast.waitForPendingWrites()
-      await state.contrast.refreshFromHardware()
+      await state.contrast.refreshFromHardware(settling: settling)
     }
     // Resync the built-in from its native read (cheap; a freshly created
     // controller already seeded from the same read at init). That read is native,

--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -1594,12 +1594,26 @@ final class AppModel {
     restartPoller()
   }
 
-  /// Snaps every native display's published brightness onto its live value before
-  /// a surface draws. Synchronous: the panel's open edge runs inside menu tracking,
-  /// which starves anything that hops. No-op off the native path, so never DDC.
+  /// Adopts every native display's live brightness before a surface draws, through
+  /// the same route the poller takes: published, persisted, and fanned out to the
+  /// other displays when sync is on. Synchronous: the panel's open edge runs inside
+  /// menu tracking, which starves anything that hops. No-op off the native path, so
+  /// never DDC.
   func refreshNativeBrightnessForSurface() {
-    for state in allControlledStates {
-      state.controller.syncFromNativeBeforeStep()
+    let controllers = allControlledStates.map(\.controller)
+    // Every display is read before anything is written, so a fan-out cannot land on
+    // a display this pass has not looked at yet and be read back as a move of its own.
+    let adopted = controllers.compactMap { controller -> (BrightnessController, Double)? in
+      let delta = controller.adoptNativeForSurface()
+      return delta == 0 ? nil : (controller, delta)
+    }
+    for (source, delta) in adopted {
+      // The poller's own gate, reset latch included: a fan-out during a reset keeps
+      // that display's queue busy and the reset then gives up on restoring its HDR.
+      BrightnessSync.fanOut(
+        delta: delta, from: source, to: controllers,
+        isEnabled: appPrefs.enableBrightnessSync && !isResetting
+      )
     }
   }
 

--- a/Candela/App/DiagnosticsPageCopy.swift
+++ b/Candela/App/DiagnosticsPageCopy.swift
@@ -129,7 +129,10 @@ enum DiagnosticsPageCopy {
       notAttempted(isSafeMode: isSafeMode, readsBackAtStartup: readsBackAtStartup)
     case .answered:
       "The values shown elsewhere in this window come from the display itself."
-    case .allZeros, .noReply:
+    // A refusal joins them because this caption is about where the numbers on
+    // screen came from, and a register the display will not report is one more
+    // number it did not supply.
+    case .allZeros, .noReply, .refused:
       "The values shown elsewhere in this window are what \(AppInfo.productName) last wrote, not what the display reports."
     }
   }

--- a/Candela/App/DiagnosticsPageCopy.swift
+++ b/Candela/App/DiagnosticsPageCopy.swift
@@ -142,6 +142,9 @@ enum DiagnosticsPageCopy {
   /// reports `.doNothing` whatever is stored, so reading the pref first
   /// would report the pref rather than the session. Everything else falls through
   /// to a sentence that claims no cause.
+  ///
+  /// "No answer recorded", not "nothing has been read": one silent pass is held,
+  /// not published (`DDCReadSkipLatch`), so the display may well have been read.
   static func notAttempted(isSafeMode: Bool, readsBackAtStartup: Bool) -> LocalizedStringKey {
     if isSafeMode {
       return "Safe Mode is on for this session, so nothing is read back from any display. The values shown elsewhere in this window come from your saved settings, not from the display."
@@ -149,7 +152,7 @@ enum DiagnosticsPageCopy {
     if !readsBackAtStartup {
       return "\(AppInfo.productName) is not set to read values back from displays at startup. The values shown elsewhere in this window come from your saved settings, not from the display."
     }
-    return "Nothing has been read from this display yet. The values shown elsewhere in this window come from your saved settings, not from the display."
+    return "No answer has been recorded from this display yet. The values shown elsewhere in this window come from your saved settings, not from the display."
   }
 
   // MARK: - Availability

--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -195,19 +195,17 @@ final class DisplayModeCoordinator {
     /// The one answerable surface, fixed at preview start.
     let surface: PreviewSurface
     var secondsRemaining: Int
-    /// Set when `confirm()`, `revert()` or the expiry threw. The display did not
-    /// move, the session still holds the fallback, and both buttons stay live.
+    /// Set when `confirm()`, `revert()` or the expiry threw. The session still
+    /// holds the fallback and Revert stays available.
     /// Nothing auto-retries, so a silent failure would leave the user on a mode
     /// they never approved.
     var failure: DisplayConfigError?
     /// Reported by the session, not inferred: a failed expiry disarms the
     /// countdown while a failed commit deliberately leaves it armed.
     var isCountingDown: Bool
-    /// Set when the apply that began this preview committed onto something
-    /// other than `mode`. `mode` stays the question, since that is what Keep
-    /// re-applies; this is how a surface can also say what the glass shows,
-    /// which is the one thing a person answering cannot check for themselves.
+    /// Latest committed failure, retained across refusals that move nothing.
     var unhonouredCommit: DisplayConfigError.UnhonouredCommit?
+    var canKeep: Bool { unhonouredCommit == nil }
     /// Non-nil when this preview is a SYNTHESIZED size: the engine has a
     /// virtual display up and the panel mirrored onto it, and the answer goes
     /// to `SynthesisPreviewSession` rather than `ModePreviewSession`.
@@ -1581,7 +1579,10 @@ final class DisplayModeCoordinator {
     if let previewed = answered.synthesized {
       return await performSynthesisResolve(previewed, keeping: keeping)
     }
-    let answeredMode = PreviewedMode(displayID: answered.displayID, mode: answered.mode)
+    let answeredMode = PreviewedMode(
+      displayID: answered.displayID, mode: answered.mode,
+      unhonouredCommit: answered.unhonouredCommit
+    )
     let outcome = keeping
       ? await session.confirm(answeredMode)
       : await session.revert(answeredMode)

--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -203,6 +203,11 @@ final class DisplayModeCoordinator {
     /// Reported by the session, not inferred: a failed expiry disarms the
     /// countdown while a failed commit deliberately leaves it armed.
     var isCountingDown: Bool
+    /// Set when the apply that began this preview committed onto something
+    /// other than `mode`. `mode` stays the question, since that is what Keep
+    /// re-applies; this is how a surface can also say what the glass shows,
+    /// which is the one thing a person answering cannot check for themselves.
+    var unhonouredCommit: DisplayConfigError.UnhonouredCommit?
     /// Non-nil when this preview is a SYNTHESIZED size: the engine has a
     /// virtual display up and the panel mirrored onto it, and the answer goes
     /// to `SynthesisPreviewSession` rather than `ModePreviewSession`.
@@ -1132,6 +1137,7 @@ final class DisplayModeCoordinator {
       secondsRemaining: 0,
       failure: nil,
       isCountingDown: false,
+      unhonouredCommit: outstanding.unhonouredCommit,
       synthesized: nil,
       synthesisFailure: nil
     )
@@ -1152,6 +1158,9 @@ final class DisplayModeCoordinator {
       secondsRemaining: 0,
       failure: nil,
       isCountingDown: false,
+      // The mode session is not the engine here, so there is no committed mode
+      // apply to have gone unhonoured.
+      unhonouredCommit: nil,
       synthesized: outstanding,
       synthesisFailure: nil
     )
@@ -1231,8 +1240,9 @@ final class DisplayModeCoordinator {
     // claim is then held continuously through the countdown's resolution.
     //
     // The refusal is REPORTED by the synthesis coordinator rather than as a
-    // `StartFailure`: that surface says "CoreGraphics error <n>", and what went
-    // wrong was a virtual display refusing to come down.
+    // `StartFailure`: that surface reports a display-configuration failure and
+    // its diagnostic prints a CoreGraphics code, and what went wrong here was a
+    // virtual display refusing to come down.
     guard await endOutstandingSynthesisPreview() else {
       log.error("Refused a mode change on display \(displayID): an outstanding synthesized size could not be disengaged")
       await adopt(.keep)
@@ -1492,8 +1502,9 @@ final class DisplayModeCoordinator {
   /// keeps this one in.
   ///
   /// An engine failure goes through the refusal the synthesis coordinator renders,
-  /// never a `StartFailure`: that surface says "CoreGraphics error <n>", and what
-  /// would have gone wrong is a virtual display.
+  /// never a `StartFailure`: that surface reports a display-configuration failure
+  /// and its diagnostic prints a CoreGraphics code, and what would have gone
+  /// wrong here is a virtual display.
   private func restoreStopAfterAFallenPick(on displayID: CGDirectDisplayID) async {
     guard let size = restoreStopIfPickFalls.removeValue(forKey: displayID) else { return }
     guard let synthesis,
@@ -1747,6 +1758,7 @@ final class DisplayModeCoordinator {
         secondsRemaining: await coordinator.session.secondsRemaining,
         failure: nil,
         isCountingDown: counting,
+        unhonouredCommit: nil,
         synthesized: outstanding,
         synthesisFailure: carried
       )
@@ -1782,6 +1794,10 @@ final class DisplayModeCoordinator {
       secondsRemaining: await session.secondsRemaining,
       failure: carried,
       isCountingDown: counting,
+      // Read from the session on every rebuild, not carried across like
+      // `failure`: the session holds it for as long as the preview stands, so a
+      // countdown tick cannot lose it and a fresh preview cannot inherit it.
+      unhonouredCommit: outstanding.unhonouredCommit,
       synthesized: nil,
       synthesisFailure: nil
     )

--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -781,6 +781,9 @@ final class DisplayModeCoordinator {
       // reconfiguration and the event it produces calls this again.
       arrivals.release(previewed)
     }
+    // Synchronous on the main actor, so an unhonoured commit blocks here for the
+    // configurator's whole settle window. An honoured one returns on the first
+    // read; the alternative is reporting a restore that did not happen.
     for display in displays where display.id != previewed {
       // Synthesis reapply runs AFTER the stored-mode decision for the same
       // display, never beside it: engaging makes the panel a mirror slave, and a
@@ -845,11 +848,10 @@ final class DisplayModeCoordinator {
         try configurator.apply(mode, to: display.id, scope: .session)
         log.log("reapplied stored mode on display \(display.id): \(mode.logicalWidth)x\(mode.logicalHeight) @\(mode.refreshHz)Hz")
       } catch {
-        // `apply` throws when staging or completion fails AND when the resolved
-        // `CGDisplayMode`'s descriptor does not match the one asked for, a
-        // reassigned `ioModeID` now denoting a different mode. On the unattended
-        // path that second case must not be swallowed: `try?` would leave the
-        // display on some third mode with the app reporting a successful restore.
+        // Not `try?`: that would report a successful restore over a refused
+        // transaction, a reassigned `ioModeID`, or a commit the display did not
+        // honour. Only the last one moved the display, so the notice claims
+        // nothing about where it was left.
         let configError = error as? DisplayConfigError
           ?? DisplayConfigError(cgErrorCode: -1)
         notice = .failed(configError)

--- a/Candela/App/DisplayModeCopy.swift
+++ b/Candela/App/DisplayModeCopy.swift
@@ -6,6 +6,30 @@ import SwiftUI
 /// true native HiDPI at an arbitrary size), and a rule split across private
 /// helpers drifts the first time one is edited.
 enum DisplayModeCopy {
+  /// How a surface spells a size. Everything in the app windows writes
+  /// "2560 × 1440" and calls it a resolution; guided setup writes "2560 x 1440"
+  /// and calls it a size, on every line it has. A sentence that arrives in the
+  /// other dialect reads as a line borrowed from somewhere else, so the dialect
+  /// is a parameter here rather than a second copy of the sentence over there.
+  enum SizeDialect {
+    case resolution
+    case size
+
+    var times: String {
+      switch self {
+      case .resolution: "×"
+      case .size: "x"
+      }
+    }
+
+    var noun: String {
+      switch self {
+      case .resolution: "resolution"
+      case .size: "size"
+      }
+    }
+  }
+
   /// The plain size, with no hedge. This rule rides on the tags of surfaces that
   /// OFFER a size (the shared size vocabulary, one source in
   /// `DisplayModeCoordinator.Catalog.tags(for:isLowResolutionDuplicate:)`);
@@ -21,9 +45,10 @@ enum DisplayModeCopy {
   }
 
   /// Bare numbers, for the density model's recommendation: a logical size with
-  /// no mode behind it. Routed here so the times sign has one spelling.
-  static func size(width: Int, height: Int) -> String {
-    "\(width) × \(height)"
+  /// no mode behind it. Routed here so each dialect's times sign has one
+  /// spelling.
+  static func size(width: Int, height: Int, dialect: SizeDialect = .resolution) -> String {
+    "\(width) \(dialect.times) \(height)"
   }
 
   /// Marks an option this app's own enumeration found. States what WE did, not
@@ -98,35 +123,98 @@ enum DisplayModeCopy {
     return "Keep \(spoken)? \(countdown(seconds))"
   }
 
+  /// Beside the keep question, when the apply that started the preview
+  /// committed onto something else. The question names what was ASKED for,
+  /// because that is what Keep re-applies; this names what the display is
+  /// showing, which is the one thing the person answering cannot check against
+  /// the question in front of them.
+  ///
+  /// States the geometry and nothing else. Whether the mode is wrong for the
+  /// panel, or scanned out on the wrong wire timing, is not something a
+  /// readback can tell us.
+  static func achievedGeometry(_ commit: DisplayConfigError.UnhonouredCommit) -> String {
+    guard let achieved = commit.achieved else { return unreadableAchievedGeometry() }
+    return achievedGeometry(
+      width: achieved.logicalWidth, height: achieved.logicalHeight,
+      refreshHz: achieved.refreshHz
+    )
+  }
+
+  /// The same sentence from bare numbers, for a surface holding the geometry
+  /// without the error it came from: guided setup's flow model is deliberately
+  /// free of engine types, and its adapters carry them. That surface passes its
+  /// own dialect, so the caption reads in the page's spelling rather than
+  /// arriving in the settings window's.
+  static func achievedGeometry(
+    width: Int, height: Int, refreshHz: Double, dialect: SizeDialect = .resolution
+  ) -> String {
+    "The display is showing \(size(width: width, height: height, dialect: dialect)), \(refresh(refreshHz))."
+  }
+
+  /// The other arm, spelled once for both entry points.
+  static func unreadableAchievedGeometry(dialect: SizeDialect = .resolution) -> String {
+    "This display did not report which \(dialect.noun) it is showing."
+  }
+
   // The CoreGraphics code stays out of these sentences: it is diagnostic, and
   // belongs in a tooltip, not in a line read while the screen is wrong.
 
   // Computed, not stored: `LocalizedStringKey` is not `Sendable`, so a static
   // `let` of one is a concurrency error under complete checking.
 
-  /// A `begin()` that failed. No preview is armed, so there is nothing to
-  /// answer. No claim that nothing changed: the readback can fail on a commit
-  /// CoreGraphics already made.
+  /// A `begin()` that failed with nothing committed. No preview is armed and no
+  /// transaction went through, so this display is where it was: the mode was
+  /// unreadable, the change would not stage, or the commit was refused.
   static var startFailure: LocalizedStringKey {
-    "\(AppInfo.productName) could not switch this display to the resolution you picked. Check what it is showing before trying again."
+    "\(AppInfo.productName) could not switch this display to the resolution you picked. Nothing changed, so it is still showing the resolution it was on."
   }
 
-  /// One sentence for either reason a selection took no effect: a new reason
-  /// with no row here is a compile error, not surfaces quietly disagreeing.
+  /// The same failure with a commit behind it, which has exactly one route:
+  /// ending an outstanding preview on ANOTHER display committed without landing
+  /// where it was asked to, and `ModePreviewSession.begin` returns before it
+  /// touches this display. So this display did not move and that one did not go
+  /// back, and neither half may be said the other way round.
+  static var startFailureAfterACommit: LocalizedStringKey {
+    "\(AppInfo.productName) could not switch this display to the resolution you picked, because another display could not be put back to the resolution it was on. Check that display before trying again."
+  }
+
+  /// One sentence for each reason a selection took no effect: a new reason with
+  /// no row here is a compile error, not surfaces quietly disagreeing.
   static func startFailure(_ reason: DisplayModeCoordinator.StartFailure.Reason) -> LocalizedStringKey {
     switch reason {
-    case .failed: startFailure
+    case let .failed(error): error.didCommit ? startFailureAfterACommit : startFailure
     case let .blocked(claimant): ReconfigurationCopy.blocked(by: claimant)
     }
+  }
+
+  /// The floating card's subject line, under a title that says this display's
+  /// resolution did not change.
+  ///
+  /// The committed arm names TWO displays. Its caption is about a display that
+  /// is not this one, so a card naming one display above that sentence reads as
+  /// a contradiction rather than as one story. The other display cannot be
+  /// named: `DisplayConfigError` carries no display ID, and widening it would
+  /// touch every caller.
+  static func startFailureSubject(
+    displayName: String, reason: DisplayModeCoordinator.StartFailure.Reason
+  ) -> String {
+    guard case let .failed(error) = reason, error.didCommit else { return displayName }
+    return displayName.isEmpty
+      ? "This display and another display"
+      : "\(displayName) and another display"
   }
 
   /// The tooltip beside it: diagnostic, not part of the statement.
   ///
   /// Through `diagnostic(_:)`: ending a preview on ANOTHER display can commit
-  /// without taking, and that failure has no CoreGraphics code to print.
+  /// without taking, and that failure has no CoreGraphics code to print. It also
+  /// has no display ID on it, so which display it is about is said here, where
+  /// the route is known, rather than inside `diagnostic`, which several surfaces
+  /// share.
   static func startFailureDiagnostic(_ reason: DisplayModeCoordinator.StartFailure.Reason) -> String {
     switch reason {
-    case let .failed(error): diagnostic(error)
+    case let .failed(error):
+      error.didCommit ? "Another display: \(diagnostic(error))" : diagnostic(error)
     case let .blocked(claimant): "Held by \(claimant.rawValue)"
     }
   }

--- a/Candela/App/DisplayModeCopy.swift
+++ b/Candela/App/DisplayModeCopy.swift
@@ -126,14 +126,20 @@ enum DisplayModeCopy {
   /// without taking, and that failure has no CoreGraphics code to print.
   static func startFailureDiagnostic(_ reason: DisplayModeCoordinator.StartFailure.Reason) -> String {
     switch reason {
-    case let .failed(error):
-      if let unhonoured = error.unhonouredCommit {
-        let landed = unhonoured.achieved.map { "\(size($0)), \(refresh($0.refreshHz))" }
-        return "CoreGraphics reported success; display shows \(landed ?? "an unreadable resolution")"
-      }
-      return "CoreGraphics error \(error.cgErrorCode)"
-    case let .blocked(claimant): return "Held by \(claimant.rawValue)"
+    case let .failed(error): diagnostic(error)
+    case let .blocked(claimant): "Held by \(claimant.rawValue)"
     }
+  }
+
+  /// The tooltip for any `DisplayConfigError`; no surface reads `cgErrorCode`
+  /// itself. An unhonoured commit's code is a sentinel, not a CoreGraphics
+  /// error, and the finding there is which resolution the display was left on.
+  static func diagnostic(_ error: DisplayConfigError) -> String {
+    guard let unhonoured = error.unhonouredCommit else {
+      return "CoreGraphics error \(error.cgErrorCode)"
+    }
+    let landed = unhonoured.achieved.map { "\(size($0)), \(refresh($0.refreshHz))" }
+    return "CoreGraphics reported success; display shows \(landed ?? "an unreadable resolution")"
   }
 
   /// A `confirm()`/`revert()`/expiry that threw. Nothing auto-retries, so this

--- a/Candela/App/DisplayModeCopy.swift
+++ b/Candela/App/DisplayModeCopy.swift
@@ -109,17 +109,21 @@ enum DisplayModeCopy {
       : "Reverting in \(seconds) seconds. Answer in the confirmation window."
   }
 
-  /// A11y contract 8: posted when the answerable banner appears. The 10- and
-  /// 3-second re-announcements reuse `countdown(_:)`.
-  ///
-  /// Names the resolution, never says the display changed to it: an unhonoured
-  /// commit leaves something else on the glass, and the listener cannot check.
-  ///
-  /// When the apply DID commit onto something else, the achieved geometry is
-  /// spoken after the countdown. A sighted person reads that off the caption
-  /// beside the question; someone listening has no caption, and the question
-  /// alone would have them approve a size the display is not showing. Last, so
-  /// the question and its deadline still lead.
+  static func pendingAnswer(displayName: String, canKeep: Bool) -> String {
+    canKeep
+      ? "Waiting for you to keep or revert the new resolution on \(displayName)."
+      : "The preview on \(displayName) could not be verified. Use Revert to restore the previous resolution."
+  }
+
+  static func previewTitle(canKeep: Bool) -> String {
+    canKeep ? "Keep this resolution?" : "Resolution preview could not be verified"
+  }
+
+  static func recoveryInstruction(dialect: SizeDialect = .resolution) -> String {
+    "Revert to the previous \(dialect.noun), then choose the \(dialect.noun) again to preview it."
+  }
+
+  /// A recovery preview never asks a listener to approve an unverified mode.
   static func previewAnnouncement(
     mode: DisplayMode, seconds: Int,
     unhonouredCommit: DisplayConfigError.UnhonouredCommit? = nil
@@ -129,9 +133,10 @@ enum DisplayModeCopy {
       logicalHeight: mode.logicalHeight,
       refreshHz: mode.refreshHz
     )
-    let question = "Keep \(spoken)? \(countdown(seconds))"
-    guard let unhonouredCommit else { return question }
-    return "\(question) \(spokenAchievedGeometry(unhonouredCommit))"
+    guard let unhonouredCommit else {
+      return "Keep \(spoken)? \(countdown(seconds))"
+    }
+    return "\(previewTitle(canKeep: false)). \(recoveryInstruction()) \(countdown(seconds)) \(spokenAchievedGeometry(unhonouredCommit))"
   }
 
   /// The achieved-geometry sentence in spoken form. Not `achievedGeometry`: that
@@ -147,15 +152,8 @@ enum DisplayModeCopy {
     return "The display is showing \(spoken)."
   }
 
-  /// Beside the keep question, when the apply that started the preview
-  /// committed onto something else. The question names what was ASKED for,
-  /// because that is what Keep re-applies; this names what the display is
-  /// showing, which is the one thing the person answering cannot check against
-  /// the question in front of them.
-  ///
-  /// States the geometry and nothing else. Whether the mode is wrong for the
-  /// panel, or scanned out on the wrong wire timing, is not something a
-  /// readback can tell us.
+  /// Latest achieved geometry beside the recovery instruction. Readback cannot
+  /// tell whether the display is using the correct wire timing.
   static func achievedGeometry(_ commit: DisplayConfigError.UnhonouredCommit) -> String {
     guard let achieved = commit.achieved else { return unreadableAchievedGeometry() }
     return achievedGeometry(

--- a/Candela/App/DisplayModeCopy.swift
+++ b/Candela/App/DisplayModeCopy.swift
@@ -86,13 +86,16 @@ enum DisplayModeCopy {
 
   /// A11y contract 8: posted when the answerable banner appears. The 10- and
   /// 3-second re-announcements reuse `countdown(_:)`.
+  ///
+  /// Names the resolution, never says the display changed to it: an unhonoured
+  /// commit leaves something else on the glass, and the listener cannot check.
   static func previewAnnouncement(mode: DisplayMode, seconds: Int) -> String {
     let spoken = ModeSpeech.spoken(
       logicalWidth: mode.logicalWidth,
       logicalHeight: mode.logicalHeight,
       refreshHz: mode.refreshHz
     )
-    return "Display changed to \(spoken). Keep this resolution? \(countdown(seconds))"
+    return "Keep \(spoken)? \(countdown(seconds))"
   }
 
   // The CoreGraphics code stays out of these sentences: it is diagnostic, and
@@ -101,9 +104,11 @@ enum DisplayModeCopy {
   // Computed, not stored: `LocalizedStringKey` is not `Sendable`, so a static
   // `let` of one is a concurrency error under complete checking.
 
-  /// A `begin()` that failed. Nothing was applied, so nothing needs answering.
+  /// A `begin()` that failed. No preview is armed, so there is nothing to
+  /// answer. No claim that nothing changed: the readback can fail on a commit
+  /// CoreGraphics already made.
   static var startFailure: LocalizedStringKey {
-    "\(AppInfo.productName) could not switch this display. Nothing changed."
+    "\(AppInfo.productName) could not switch this display to the resolution you picked. Check what it is showing before trying again."
   }
 
   /// One sentence for either reason a selection took no effect: a new reason
@@ -116,17 +121,26 @@ enum DisplayModeCopy {
   }
 
   /// The tooltip beside it: diagnostic, not part of the statement.
+  ///
+  /// Through `diagnostic(_:)`: ending a preview on ANOTHER display can commit
+  /// without taking, and that failure has no CoreGraphics code to print.
   static func startFailureDiagnostic(_ reason: DisplayModeCoordinator.StartFailure.Reason) -> String {
     switch reason {
-    case let .failed(error): "CoreGraphics error \(error.cgErrorCode)"
-    case let .blocked(claimant): "Held by \(claimant.rawValue)"
+    case let .failed(error):
+      if let unhonoured = error.unhonouredCommit {
+        let landed = unhonoured.achieved.map { "\(size($0)), \(refresh($0.refreshHz))" }
+        return "CoreGraphics reported success; display shows \(landed ?? "an unreadable resolution")"
+      }
+      return "CoreGraphics error \(error.cgErrorCode)"
+    case let .blocked(claimant): return "Held by \(claimant.rawValue)"
     }
   }
 
-  /// A `confirm()`/`revert()`/expiry that threw. The preview is still on the
-  /// display and nothing auto-retries, so this must invite another attempt.
+  /// A `confirm()`/`revert()`/expiry that threw. Nothing auto-retries, so this
+  /// must invite another attempt. It does not say which resolution is on the
+  /// glass: the readback can fail on a commit CoreGraphics already made.
   static var resolveFailure: LocalizedStringKey {
-    "\(AppInfo.productName) could not complete that change. The display is still showing the preview. Try again."
+    "\(AppInfo.productName) could not complete that change. Check this display, then try again."
   }
 
   /// Said only alongside `resolveFailure`: the countdown is spent, so the user
@@ -155,9 +169,11 @@ enum DisplayModeCopy {
   }
 
   /// The apply failed. Distinct from `reapplyUnavailable` because the mode
-  /// still exists, so trying again from the list is worth doing.
+  /// still exists, so trying again from the list is worth doing. No claim about
+  /// where the display was left: the readback can fail on a commit that went
+  /// through, unattended.
   static func reapplyFailed(requested: DisplayModeDescriptor) -> LocalizedStringKey {
-    "\(AppInfo.productName) could not restore the resolution saved for this display (\(size(requested)), \(refresh(requested.refreshHz))). Nothing was changed."
+    "\(AppInfo.productName) could not restore the resolution saved for this display (\(size(requested)), \(refresh(requested.refreshHz))). Pick it from the list of resolutions to try again."
   }
 
   /// One sentence for whichever happened, so both surfaces say the same thing.

--- a/Candela/App/DisplayModeCopy.swift
+++ b/Candela/App/DisplayModeCopy.swift
@@ -114,13 +114,37 @@ enum DisplayModeCopy {
   ///
   /// Names the resolution, never says the display changed to it: an unhonoured
   /// commit leaves something else on the glass, and the listener cannot check.
-  static func previewAnnouncement(mode: DisplayMode, seconds: Int) -> String {
+  ///
+  /// When the apply DID commit onto something else, the achieved geometry is
+  /// spoken after the countdown. A sighted person reads that off the caption
+  /// beside the question; someone listening has no caption, and the question
+  /// alone would have them approve a size the display is not showing. Last, so
+  /// the question and its deadline still lead.
+  static func previewAnnouncement(
+    mode: DisplayMode, seconds: Int,
+    unhonouredCommit: DisplayConfigError.UnhonouredCommit? = nil
+  ) -> String {
     let spoken = ModeSpeech.spoken(
       logicalWidth: mode.logicalWidth,
       logicalHeight: mode.logicalHeight,
       refreshHz: mode.refreshHz
     )
-    return "Keep \(spoken)? \(countdown(seconds))"
+    let question = "Keep \(spoken)? \(countdown(seconds))"
+    guard let unhonouredCommit else { return question }
+    return "\(question) \(spokenAchievedGeometry(unhonouredCommit))"
+  }
+
+  /// The achieved-geometry sentence in spoken form. Not `achievedGeometry`: that
+  /// is display text down to the times sign and the "Hz" abbreviation, and both
+  /// are read inconsistently. Same statement, said out loud.
+  static func spokenAchievedGeometry(_ commit: DisplayConfigError.UnhonouredCommit) -> String {
+    guard let achieved = commit.achieved else { return unreadableAchievedGeometry() }
+    let spoken = ModeSpeech.spoken(
+      logicalWidth: achieved.logicalWidth,
+      logicalHeight: achieved.logicalHeight,
+      refreshHz: achieved.refreshHz
+    )
+    return "The display is showing \(spoken)."
   }
 
   /// Beside the keep question, when the apply that started the preview

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -458,7 +458,12 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
         self.model.mirroring.refreshTopology()
         // Return value ignored: this loop often JOINS a pass a menu close started,
         // and a joiner gets an empty list. Cleanup rides `onDisplaysDeparted`.
-        await self.model.refresh()
+        //
+        // The ONE settling caller: this is the app's reconfiguration intake, so
+        // the DDC reads inside the pass run over a wire still renegotiating. A
+        // silence there is discarded rather than counted. Launch and menu close
+        // keep counting, and they are what earns a panel its read verdict.
+        await self.model.refresh(settling: true)
         self.refreshTapConfig()
         self.updateStatusItemVisibility()
         // OLED care: display IDs can be REASSIGNED with every display still

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -303,9 +303,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // hotkeys and need no grant, so an all-custom rig must not be shown a TCC
       // prompt it can only refuse.
       let prefs = DisplayPrefs(persistenceKey: "app")
-      guard KeyModePolicy.requiresAccessibility(
+      let required = KeyModePolicy.requiresAccessibility(
         brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
-      ) else { return }
+      )
+      // Ahead of the guard: the backstop must hear a key family going off as well
+      // as coming on, and nothing else reports either edge.
+      self?.model.accessibility.reevaluateBackstop(requiresAccessibility: required)
+      guard required else { return }
       self?.model.accessibility.promptIfNeeded()
     }
     settingsActions.updateStatusItem = { [weak self] in self?.updateStatusItemVisibility() }

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -1413,6 +1413,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // Computed once and recorded only on success: `lastArmedTapConfig` is what is
     // actually being watched, and a config that failed to arm is not that.
     let config = model.tapConfig
+    // An empty tap still costs three threads for nothing. The empty config, not a
+    // disarm, keeps diagnostics on "watching nothing" and the restart edge visible.
+    guard !config.watchedKeys.isEmpty else {
+      mediaKeyTap.stop()
+      model.noteTapArmed(config)
+      return
+    }
     do {
       try mediaKeyTap.start(config: config)
       model.noteTapArmed(config)
@@ -1425,18 +1432,44 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
         fields the media-key decode reads; media keys are off until Candela is updated
         """
       )
+      // A failed start is not "watching nothing": the keys are dead and the
+      // diagnostics row must say so. It also stops the refresh path retrying a
+      // start that cannot succeed, on every menu close, forever.
+      model.noteTapDisarmed()
     } catch {
       log.error("media-key tap failed to start: \(error); keys disabled until relaunch")
+      model.noteTapDisarmed()
     }
   }
 
-  /// Re-arms or disarms brightness keys after display topology changes (the
-  /// fork's `updateMediaKeyTap`). No-op unless the tap is running.
+  /// Re-arms, re-configures or tears down the tap after the watched-key set can
+  /// have changed (the fork's `updateMediaKeyTap`). The edge comes from the last
+  /// committed set, never `mediaKeyTap.isRunning`: an emergency teardown leaves
+  /// that flag true.
   private func refreshTapConfig() {
-    guard let mediaKeyTap, mediaKeyTap.isRunning else { return }
+    guard let mediaKeyTap else { return }
     let config = model.tapConfig
-    mediaKeyTap.update(config: config)
-    model.noteTapArmed(config)
+    switch TapLifecyclePolicy.action(
+      previous: model.lastArmedTapConfig?.watchedKeys,
+      next: config.watchedKeys,
+      grantHeld: model.accessibility.isGranted
+    ) {
+    case .start:
+      startMediaKeyTap()
+    case .stop:
+      // Not `noteTapDisarmed`: the keys are released on purpose, which is a
+      // different answer from a tap that cannot run.
+      mediaKeyTap.stop()
+      model.noteTapArmed(config)
+    case .reconfigure:
+      mediaKeyTap.update(config: config)
+      model.noteTapArmed(config)
+    case .nothing:
+      // The stored config is left alone, so in the watching-nothing state the
+      // alternate-brightness-key flag inside it can go stale. Nothing reads that
+      // flag while no tap exists, and the next start recomputes the whole config.
+      break
+    }
   }
 
   /// Filled while a keep-awake assertion is held: it suppresses every OLED care

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -118,6 +118,9 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
   /// Sleep/wake observation tokens: block-based observers stay registered only
   /// while retained. Never removed, app-lifetime.
   private var sleepWakeObservers: [any NSObjectProtocol] = []
+  /// Belt on the panel-open flag: AppKit's end-of-tracking signal, held like the
+  /// tokens above.
+  private var menuTrackingObserver: (any NSObjectProtocol)?
   /// Startup/wake DDC restore choreography. `startupAction` is app-level
   /// but read through DisplayPrefs like every other engine pref, and under safe
   /// mode through a prefs object whose getter reports `.doNothing`, which
@@ -193,6 +196,16 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     statusItem = item
     updateStatusItemImage()
     trackKeepAwake()
+
+    // A panel-open flag left true is a poller that never slows down, so the end of
+    // tracking clears it as well as `menuDidClose`. AppKit posts this for every
+    // session end, including the `cancelTracking` routes below.
+    menuTrackingObserver = NotificationCenter.default.addObserver(
+      forName: NSMenu.didEndTrackingNotification, object: menu, queue: .main
+    ) { [weak self] _ in
+      // A hop is safe here: the tracking session has just ended.
+      Task { @MainActor in self?.model.surfaceVisibility.setPanelOpen(false) }
+    }
 
     // Panel controls that have to end this tracking session reach it through
     // here: the gear button (a window cannot take focus while it runs) and
@@ -1012,18 +1025,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     return false
   }
 
-  /// The panel is a consumer of every polled brightness value, so the poller has
-  /// to be told while it is on screen. Set synchronously, not through a task hop:
-  /// menu tracking starves main-actor work, so a hop would land only once the menu
-  /// had closed again.
-  ///
-  /// The restart is what makes the panel's first frame current: the flag alone
-  /// changes only the NEXT interval, and the idle one already in flight can be 10
-  /// seconds long. The built-in's row is the one that shows it, since Control
-  /// Center and ambient light move that value with nothing of ours involved.
+  /// The panel consumes every polled value. Set synchronously: menu tracking
+  /// starves main-actor work, so a hop would land after the menu closed. The flag
+  /// changes only the NEXT interval, so the first frame takes a direct read; a
+  /// rebuilt poll job would adopt after the panel closed, for the same reason.
   func menuWillOpen(_: NSMenu) {
     model.surfaceVisibility.setPanelOpen(true)
-    model.notePollConsumerAppeared()
+    model.refreshNativeBrightnessForSurface()
   }
 
   func menuDidClose(_: NSMenu) {
@@ -1429,6 +1437,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
 
   private func startMediaKeyTap() {
     guard let mediaKeyTap else { return }
+    // Every start route stops here rather than failing and logging again.
+    guard !model.isTapPermanentlyUnavailable else { return }
     // Computed once and recorded only on success: `lastArmedTapConfig` is what is
     // actually being watched, and a config that failed to arm is not that.
     let config = model.tapConfig
@@ -1451,12 +1461,12 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
         fields the media-key decode reads; media keys are off until Candela is updated
         """
       )
-      // A failed start is not "watching nothing": the keys are dead and the
-      // diagnostics row must say so. It also stops the refresh path retrying a
-      // start that cannot succeed, on every menu close, forever.
-      model.noteTapDisarmed()
+      // No later edge may retry a start that cannot succeed.
+      model.noteTapPermanentlyUnavailable()
     } catch {
-      log.error("media-key tap failed to start: \(error); keys disabled until relaunch")
+      // Transient, usually a port refused while TCC was still settling: the next
+      // edge that wants keys tries again.
+      log.error("media-key tap failed to start: \(error); retried on the next edge")
       model.noteTapDisarmed()
     }
   }
@@ -1471,7 +1481,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     switch TapLifecyclePolicy.action(
       previous: model.lastArmedTapConfig?.watchedKeys,
       next: config.watchedKeys,
-      grantHeld: model.accessibility.isGranted
+      grantHeld: model.accessibility.isGranted,
+      permanentlyUnavailable: model.isTapPermanentlyUnavailable
     ) {
     case .start:
       startMediaKeyTap()
@@ -1484,9 +1495,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       mediaKeyTap.update(config: config)
       model.noteTapArmed(config)
     case .nothing:
-      // The stored config is left alone, so in the watching-nothing state the
-      // alternate-brightness-key flag inside it can go stale. Nothing reads that
-      // flag while no tap exists, and the next start recomputes the whole config.
+      // The stored config can carry a stale alternate-brightness flag while no tap
+      // exists; nothing reads it, and the next start recomputes the whole config.
       break
     }
   }

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -1513,6 +1513,10 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     case .reconfigure:
       mediaKeyTap.update(config: config)
       model.noteTapArmed(config)
+    case .recordEmpty:
+      // Nothing to stop: no tap was ever armed. Recording the empty set is what
+      // separates keys released on purpose from a tap that could not run.
+      model.noteTapArmed(config)
     case .nothing:
       // The stored config can carry a stale alternate-brightness flag while no tap
       // exists; nothing reads it, and the next start recomputes the whole config.

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -1012,7 +1012,22 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     return false
   }
 
+  /// The panel is a consumer of every polled brightness value, so the poller has
+  /// to be told while it is on screen. Set synchronously, not through a task hop:
+  /// menu tracking starves main-actor work, so a hop would land only once the menu
+  /// had closed again.
+  ///
+  /// The restart is what makes the panel's first frame current: the flag alone
+  /// changes only the NEXT interval, and the idle one already in flight can be 10
+  /// seconds long. The built-in's row is the one that shows it, since Control
+  /// Center and ambient light move that value with nothing of ours involved.
+  func menuWillOpen(_: NSMenu) {
+    model.surfaceVisibility.setPanelOpen(true)
+    model.notePollConsumerAppeared()
+  }
+
   func menuDidClose(_: NSMenu) {
+    model.surfaceVisibility.setPanelOpen(false)
     // Re-discover displays and re-read hardware once tracking has ended and
     // the run loop is back in default mode, so the next open starts fresh.
     Task {

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -203,8 +203,11 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     menuTrackingObserver = NotificationCenter.default.addObserver(
       forName: NSMenu.didEndTrackingNotification, object: menu, queue: .main
     ) { [weak self] _ in
-      // A hop is safe here: the tracking session has just ended.
-      Task { @MainActor in self?.model.surfaceVisibility.setPanelOpen(false) }
+      // Delivered on the main queue, so the flag is cleared in this turn rather
+      // than in a task the next open could outrun: menu tracking starves
+      // main-actor task execution, and a reopen inside that window would have its
+      // fresh `menuWillOpen` flag cleared by the previous session's late hop.
+      MainActor.assumeIsolated { self?.model.surfaceVisibility.setPanelOpen(false) }
     }
 
     // Panel controls that have to end this tracking session reach it through
@@ -308,6 +311,13 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // every mode write through the seam. Static because the manager instance is
       // private here and the KeyboardShortcuts registry is global.
       ShortcutManager.syncRegistration()
+      // Here as well as in `recheckPermissions`, which the settings reset does not
+      // call: a reset from an all-custom ungranted rig restores the media-key
+      // defaults, so the tap becomes wanted with no timer left to notice the grant
+      // arriving. The door WITHOUT the hunt re-stamp, because most prefs that re-arm
+      // the tap say nothing about whether anyone is at System Settings; the key-mode
+      // write below is the one that does.
+      self?.model.accessibility.noteTapRearmed()
     }
     settingsActions.recheckPermissions = { [weak self] in
       // The fork computes this and never calls it, so changing a
@@ -315,14 +325,10 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       // change actually made the CGEvent tap wanted. Custom shortcuts are Carbon
       // hotkeys and need no grant, so an all-custom rig must not be shown a TCC
       // prompt it can only refuse.
-      let prefs = DisplayPrefs(persistenceKey: "app")
-      let required = KeyModePolicy.requiresAccessibility(
-        brightness: prefs.keyboardBrightness, volume: prefs.keyboardVolume
-      )
-      // Ahead of the guard: the backstop must hear a key family going off as well
-      // as coming on, and nothing else reports either edge.
-      self?.model.accessibility.reevaluateBackstop(requiresAccessibility: required)
-      guard required else { return }
+      // Ahead of the guard: the backstop must hear a key family going off as well as
+      // coming on. This is the edge that reopens the hunt, and the only one.
+      self?.model.accessibility.noteKeyModesChanged()
+      guard AccessibilityPermission.storedModesRequireGrant() else { return }
       self?.model.accessibility.promptIfNeeded()
     }
     settingsActions.updateStatusItem = { [weak self] in self?.updateStatusItemVisibility() }
@@ -1447,6 +1453,19 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     guard !config.watchedKeys.isEmpty else {
       mediaKeyTap.stop()
       model.noteTapArmed(config)
+      return
+    }
+    // The tracked grant is refreshed by a poll, so a revocation made in System
+    // Settings and followed by a plug-in inside that window would run `tapCreate`
+    // while TCC is still committing the delete, which is the wedge the emergency
+    // teardown's settle closure waits out. One live read costs nothing here (no
+    // options, so it can never prompt) and it is only taken on a start edge.
+    // Not the policy input: the tracked flag stays what decides the lifecycle.
+    guard AXIsProcessTrustedWithOptions(nil) else {
+      // `.info` rather than `.error`: an expected decline, and the only observable
+      // that separates it from a start nobody attempted. The next edge retries.
+      log.info("media-key tap not started: the Accessibility grant reads false right now")
+      model.noteTapDisarmed()
       return
     }
     do {

--- a/Candela/App/SynthesisLinkBounce.swift
+++ b/Candela/App/SynthesisLinkBounce.swift
@@ -163,7 +163,8 @@ struct BouncingSynthesisDriver: SynthesisDriving {
       // Session scope, matching the engine's own applies.
       try configurator.apply(target, to: displayID, scope: .session)
     } catch {
-      Self.log.info("synthesis.retime could not run for display \(displayID): \(String(describing: error), privacy: .public)")
+      // "Did not land": the apply also throws on a commit the display did not honour.
+      Self.log.info("synthesis.retime did not land on display \(displayID): \(String(describing: error), privacy: .public)")
       return false
     }
     // THE RETURN CODE IS NOT THE EVIDENCE. The apply cross-checks the RESOLVED

--- a/Candela/App/SynthesisLinkBounce.swift
+++ b/Candela/App/SynthesisLinkBounce.swift
@@ -239,8 +239,9 @@ struct BouncingSynthesisDriver: SynthesisDriving {
     do {
       try configurator.apply(ownMode, to: displayID, scope: .session)
     } catch {
+      // "Did not put back": the apply also throws on a commit the display did not honour.
       Self.log.error("""
-      synthesis.restore could not put display \(displayID, privacy: .public) back on \
+      synthesis.restore did not put display \(displayID, privacy: .public) back on \
       \(ownMode.logicalWidth, privacy: .public)x\(ownMode.logicalHeight, privacy: .public): \
       \(String(describing: error), privacy: .public)
       """)

--- a/Candela/AppKitIslands/ModeConfirmationWindow.swift
+++ b/Candela/AppKitIslands/ModeConfirmationWindow.swift
@@ -95,7 +95,9 @@ struct ModeConfirmationView: View {
           // leave the display on a mode the user never approved, held only
           // until the app exits.
           ConfirmationCaption(DisplayModeCopy.resolveFailure)
-            .help("CoreGraphics error \(failure.cgErrorCode)")
+            // Not the bare code: an unhonoured commit's code is a sentinel, not a
+            // CoreGraphics error.
+            .help(DisplayModeCopy.diagnostic(failure))
         }
         if preview.isCountingDown {
           ConfirmationCountdown(DisplayModeCopy.countdown(preview.secondsRemaining))

--- a/Candela/AppKitIslands/ModeConfirmationWindow.swift
+++ b/Candela/AppKitIslands/ModeConfirmationWindow.swift
@@ -87,12 +87,11 @@ struct ModeConfirmationView: View {
     // remembered passing in.
     if let preview = coordinator.preview {
       ConfirmationCard {
-        ConfirmationTitle("Keep this resolution?")
+        ConfirmationTitle(LocalizedStringKey(DisplayModeCopy.previewTitle(canKeep: preview.canKeep)))
         ConfirmationSubtitle(verbatim: subtitle(preview))
 
-        // The subtitle names what Keep re-applies; this names what the display
-        // is showing while the question sits on it.
         if let commit = preview.unhonouredCommit {
+          ConfirmationCaption(Text(verbatim: DisplayModeCopy.recoveryInstruction()))
           ConfirmationCaption(Text(verbatim: DisplayModeCopy.achievedGeometry(commit)))
         }
 
@@ -117,11 +116,13 @@ struct ModeConfirmationView: View {
           // refused as stale rather than resolved by an answer given about
           // something else.
           Button("Revert Now") { Task { await coordinator.revert(preview) } }
-            .buttonStyle(AnswerButtonStyle(isPrimary: false))
+            .buttonStyle(AnswerButtonStyle(isPrimary: !preview.canKeep))
             .keyboardShortcut(.cancelAction)
-          Button("Keep") { Task { await coordinator.confirm(preview) } }
-            .buttonStyle(AnswerButtonStyle(isPrimary: true))
-            .keyboardShortcut(.defaultAction)
+          if preview.canKeep {
+            Button("Keep") { Task { await coordinator.confirm(preview) } }
+              .buttonStyle(AnswerButtonStyle(isPrimary: true))
+              .keyboardShortcut(.defaultAction)
+          }
         }
         // While a selection is still landing the window is about to change, so
         // offering an answer to the old one is pointless, though harmless.

--- a/Candela/AppKitIslands/ModeConfirmationWindow.swift
+++ b/Candela/AppKitIslands/ModeConfirmationWindow.swift
@@ -90,6 +90,12 @@ struct ModeConfirmationView: View {
         ConfirmationTitle("Keep this resolution?")
         ConfirmationSubtitle(verbatim: subtitle(preview))
 
+        // The subtitle names what Keep re-applies; this names what the display
+        // is showing while the question sits on it.
+        if let commit = preview.unhonouredCommit {
+          ConfirmationCaption(Text(verbatim: DisplayModeCopy.achievedGeometry(commit)))
+        }
+
         if let failure = preview.failure {
           // Nothing auto-retries a failed resolution. Staying silent would
           // leave the display on a mode the user never approved, held only
@@ -137,8 +143,14 @@ struct ModeConfirmationView: View {
     if let failure = coordinator.startFailure {
       ConfirmationCard {
         ConfirmationTitle("Resolution not changed")
-        if !displayName.isEmpty {
-          ConfirmationSubtitle(verbatim: displayName)
+        // Names both displays where the caption below is about a second one, so
+        // the title, the subject and the sentence read as one story rather than
+        // as a card that contradicts itself.
+        let subject = DisplayModeCopy.startFailureSubject(
+          displayName: displayName, reason: failure.reason
+        )
+        if !subject.isEmpty {
+          ConfirmationSubtitle(verbatim: subject)
         }
         ConfirmationCaption(DisplayModeCopy.startFailure(failure.reason))
           .help(DisplayModeCopy.startFailureDiagnostic(failure.reason))

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -186,7 +186,10 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// content for a whole sampling slot reads as burn-in, the symptom the feature
   /// exists to prevent. The poll under it is a measured 0.46 ms, and it only
   /// runs while a mask is on screen.
-  private static let nominationGeometryInterval: Duration = .seconds(1)
+  ///
+  /// Derived, never a second literal: the driver ticks at `windowFollow` while a
+  /// mask is up, and a throttle above that tick silently halves the follow rate.
+  private static let nominationGeometryInterval: Duration = OledCareCadence.windowFollow
   /// "At most every few minutes, plus at termination" (spec §4). A defaults
   /// write per sample would put one on a permanent 60 s timer per panel for a
   /// value that is only ever read by a settings view.

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -114,9 +114,9 @@ final class OledCareCoordinator: CheckupCareHolding {
     /// `.active` is exactly when detection dimming runs.
     var assertionHeld = false
     /// The current nomination in PANEL space. The LUMINANCE half changes only
-    /// when a new sample lands; the WINDOW half is re-read on the fast loop
-    /// while a nomination is displayed (`refreshNominationGeometry`), so a moved
-    /// window sheds its dim in about a second. Nil means "nothing qualifies",
+    /// when a new sample lands; the WINDOW half is re-read once a second while a
+    /// nomination is displayed (`refreshNominationGeometry`), so a moved window
+    /// sheds its dim in about a second. Nil means "nothing qualifies",
     /// deliberately distinguishable from an all-zero mask: the render then keeps
     /// the cheaper scalar path.
     var nominatedMask: OverlayMask?
@@ -164,10 +164,10 @@ final class OledCareCoordinator: CheckupCareHolding {
     var lockDimRamp: Task<Void, Never>?
   }
 
-  /// Poll cadence: slow while every enrolled display is `.active`/`.suspended`;
-  /// fast while any dim is up by any delivery (the restore latency gate is
-  /// 100 ms) or a verification is pending. The predicate and both
-  /// durations live in `OledCareCadence`, under test.
+  /// Poll cadence: fast while a dim input should lift is up by any delivery or a
+  /// verification is pending; the window-follow second while a nomination mask is
+  /// on screen with no such dim; slow otherwise. `OledCareCadence` owns the
+  /// predicates and durations, under test.
   /// After this much CONTINUOUS settling the signal is ignored: the entry gate
   /// exists for a transition window measured in seconds, not for a latch that
   /// never cleared.
@@ -1035,10 +1035,11 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// entries outlive the state that issued them.
   private func cadence() -> Duration {
     OledCareCadence.interval(
-      anyOverlayUp: states.values.contains { $0.lastAppliedAlpha != nil },
+      anyOverlayUp: anyOverlayDimUp(),
       anyLockDimEngaged: states.values.contains(where: \.lockDimEngaged),
       verificationPending: states.values.contains(where: \.needsVerify)
         || !pendingRemovalVerifications.isEmpty,
+      nominationDisplayed: anyNominationDisplayed(),
       anythingEnrolled: !states.isEmpty
     )
   }
@@ -1046,7 +1047,26 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// Dims that input can lift. A pending verification also runs the fast
   /// cadence but gives an input event nothing to do.
   private func anyDimUp() -> Bool {
-    states.values.contains { $0.lastAppliedAlpha != nil || $0.lockDimEngaged }
+    anyOverlayDimUp() || states.values.contains(where: \.lockDimEngaged)
+  }
+
+  /// An overlay that is up BECAUSE the display is dimmed, as opposed to detection
+  /// dimming's mask on an `.active` display, which no input clears. `tick()`
+  /// assigns `dimStates` before the driver asks, so this is this tick's verdict.
+  /// A display that departed mid-debounce reads as no dim; its teardown
+  /// verification rides the pending-removal list, which runs fast on its own.
+  private func anyOverlayDimUp() -> Bool {
+    states.contains { key, state in
+      state.lastAppliedAlpha != nil && dimStates[key]?.liftsOnInput == true
+    }
+  }
+
+  /// A nomination actually reaching the panel: a mask kept current under a
+  /// mirror-set suspension renders nothing. Over-reports a dimmed display whose
+  /// nomination is not composed (blackout, display sleep under a uniform dim),
+  /// harmlessly, since every one of those states takes the fast term first.
+  private func anyNominationDisplayed() -> Bool {
+    states.values.contains { $0.nominatedMask != nil && $0.lastAppliedAlpha != nil }
   }
 
   // MARK: - Event-driven restore

--- a/Candela/Onboarding/OnboardingFlowModel.swift
+++ b/Candela/Onboarding/OnboardingFlowModel.swift
@@ -38,6 +38,20 @@ enum OnboardingApplyState: Equatable, Sendable {
   case failed
 }
 
+/// What the display is showing when the apply that opened the countdown
+/// COMMITTED without landing on the size that was asked for. Absent means the
+/// apply landed, which is the ordinary case.
+///
+/// Its own type rather than the engine's `UnhonouredCommit`, so this model stays
+/// free of engine types the way the rest of it is; the live applier maps one
+/// onto the other and the fixture applier can produce it without a display.
+enum OnboardingAchievedSize: Equatable, Sendable {
+  case size(width: Int, height: Int, refreshHz: Double)
+  /// The commit went through and the display would not say what it is running.
+  /// Not the same as landing: a readback that failed is evidence of nothing.
+  case unreadable
+}
+
 /// Drives the guided setup flow over an `OnboardingEnvironment`. Owns the
 /// derived page list, the in-flow choices and the commit seam. In fixture mode
 /// (the mock and tests) commits are recorded and the permission grant is
@@ -170,6 +184,9 @@ final class OnboardingFlowModel {
   /// The choice under countdown. Recorded into `sizeChoices` only when the
   /// countdown is answered; until then the decision does not exist yet.
   private var pendingApply: PendingApply?
+  /// Reported with each tick rather than once, so it follows the applier's own
+  /// reading of the preview and cannot outlive it.
+  private var pendingAchieved: OnboardingAchievedSize?
   private var applyTicker: Task<Void, Never>?
 
   static let applyCountdownSeconds = 15
@@ -352,6 +369,9 @@ final class OnboardingFlowModel {
     pendingApply = PendingApply(
       displayKey: displayKey, choice: choice,
       looksLikeWidth: size.width, looksLikeHeight: size.height)
+    // Nothing has been applied yet, so the previous apply's divergence must not
+    // caption this one's question.
+    pendingAchieved = nil
     applyState = .counting(secondsRemaining: applierCountdownSeconds)
     onApplySize(displayKey, size.width, size.height)
   }
@@ -380,9 +400,15 @@ final class OnboardingFlowModel {
 
   // MARK: - Size apply reports (called by the seam implementation)
 
-  func applyCountdownTicked(secondsRemaining: Int) {
+  /// `achieved` rides the tick because the applier reads it from the same
+  /// preview the seconds come from: one report, one reading, so the caption and
+  /// the countdown cannot describe different moments.
+  func applyCountdownTicked(
+    secondsRemaining: Int, achieved: OnboardingAchievedSize? = nil
+  ) {
     guard pendingApply != nil else { return }
     applyState = .counting(secondsRemaining: max(0, secondsRemaining))
+    pendingAchieved = achieved
   }
 
   /// A kept apply: the display is already showing the size, so record the
@@ -403,6 +429,7 @@ final class OnboardingFlowModel {
     applyTicker?.cancel()
     sizeChoices[pending.displayKey] = .keepCurrent
     pendingApply = nil
+    pendingAchieved = nil
     applyState = .reverted
   }
 
@@ -412,6 +439,7 @@ final class OnboardingFlowModel {
     guard pendingApply != nil else { return }
     applyTicker?.cancel()
     pendingApply = nil
+    pendingAchieved = nil
     applyState = .failed
   }
 
@@ -429,6 +457,14 @@ final class OnboardingFlowModel {
   func pendingAppliedSize(forKey key: String) -> (width: Int, height: Int)? {
     guard let pendingApply, pendingApply.displayKey == key else { return nil }
     return (pendingApply.looksLikeWidth, pendingApply.looksLikeHeight)
+  }
+
+  /// What this display is showing instead, when the apply committed onto
+  /// something else. Nil in the ordinary case, where the size above IS what is
+  /// on the glass and a caption would be noise.
+  func pendingAchievedSize(forKey key: String) -> OnboardingAchievedSize? {
+    guard let pendingApply, pendingApply.displayKey == key else { return nil }
+    return pendingAchieved
   }
 
   // MARK: - Fixture applier
@@ -468,6 +504,7 @@ final class OnboardingFlowModel {
   private func resetApplyState() {
     applyTicker?.cancel()
     pendingApply = nil
+    pendingAchieved = nil
     applyState = .idle
   }
 

--- a/Candela/Onboarding/OnboardingFlowModel.swift
+++ b/Candela/Onboarding/OnboardingFlowModel.swift
@@ -38,9 +38,8 @@ enum OnboardingApplyState: Equatable, Sendable {
   case failed
 }
 
-/// What the display is showing when the apply that opened the countdown
-/// COMMITTED without landing on the size that was asked for. Absent means the
-/// apply landed, which is the ordinary case.
+/// Latest evidence of a committed failure during preview, Keep, or Revert.
+/// Absent means the preview remains eligible for Keep.
 ///
 /// Its own type rather than the engine's `UnhonouredCommit`, so this model stays
 /// free of engine types the way the rest of it is; the live applier maps one
@@ -380,7 +379,7 @@ final class OnboardingFlowModel {
   /// click racing an expiry answers nothing. In live mode the shipped
   /// coordinator refuses a stale answer on its own; this guard mirrors it.
   func keepSize() {
-    guard case .counting = applyState else { return }
+    guard case .counting = applyState, pendingAchieved == nil else { return }
     onKeepSize()
   }
 

--- a/Candela/Onboarding/OnboardingLiveApplier.swift
+++ b/Candela/Onboarding/OnboardingLiveApplier.swift
@@ -208,6 +208,20 @@ final class OnboardingLiveApplier {
     }
   }
 
+  /// The engine's answer in the flow model's vocabulary. A commit that did not
+  /// land but could not be read back is its own case: a failed readback is not
+  /// evidence the size arrived, so it must not map to nil.
+  private static func achievedSize(
+    _ commit: DisplayConfigError.UnhonouredCommit?
+  ) -> OnboardingAchievedSize? {
+    guard let commit else { return nil }
+    guard let achieved = commit.achieved else { return .unreadable }
+    return .size(
+      width: achieved.logicalWidth, height: achieved.logicalHeight,
+      refreshHz: achieved.refreshHz
+    )
+  }
+
   private func processCoordinatorState() {
     guard let pendingID = pendingDisplayID else { return }
     let coordinator = model.displayModes
@@ -221,7 +235,10 @@ final class OnboardingLiveApplier {
         answer(keeping: keeping)
         return
       }
-      flow?.applyCountdownTicked(secondsRemaining: preview.secondsRemaining)
+      flow?.applyCountdownTicked(
+        secondsRemaining: preview.secondsRemaining,
+        achieved: Self.achievedSize(preview.unhonouredCommit)
+      )
       return
     }
     // No outstanding preview for this display. While an answer is in flight

--- a/Candela/Onboarding/OnboardingLiveApplier.swift
+++ b/Candela/Onboarding/OnboardingLiveApplier.swift
@@ -168,7 +168,7 @@ final class OnboardingLiveApplier {
       // auto-retries, so the model stays counting and the next click retries
       // through the same path. Not `applyFailed`: that is for an apply that
       // never started, and it would abandon a preview still on the glass.
-      break
+      processCoordinatorState()
     case .stale:
       // The answer named a preview that had already resolved (an expiry
       // racing the click). The coordinator's own handling ran; read what it

--- a/Candela/Onboarding/OnboardingSizePage.swift
+++ b/Candela/Onboarding/OnboardingSizePage.swift
@@ -191,6 +191,23 @@ struct OnboardingSizePage: View {
     .padding(.horizontal, 60)
   }
 
+  /// One sentence for what the display is actually showing, from
+  /// `DisplayModeCopy` so this page cannot word it differently from the other
+  /// three surfaces that ask the same question.
+  ///
+  /// In THIS page's dialect: every size here is written "2560 x 1440" and the
+  /// noun is always "size", so the shared sentence arrives spelled the way the
+  /// glyph, the apply button and the alternatives grid above it already are.
+  static func achievedCaption(_ achieved: OnboardingAchievedSize) -> String {
+    switch achieved {
+    case let .size(width, height, refreshHz):
+      DisplayModeCopy.achievedGeometry(
+        width: width, height: height, refreshHz: refreshHz, dialect: .size)
+    case .unreadable:
+      DisplayModeCopy.unreadableAchievedGeometry(dialect: .size)
+    }
+  }
+
   /// The keep and revert bar, the safety shape the picker ships. The copy
   /// states the semantic: expiry reverts, so the size sticks only on Keep.
   private func countdownBar(seconds: Int) -> some View {
@@ -200,6 +217,17 @@ struct OnboardingSizePage: View {
         .foregroundStyle(OnboardingStyle.bodyColor)
         .monospacedDigit()
         .contentTransition(.numericText())
+      // Beside the question, in the words the settings banner and the
+      // confirmation card use. The GLYPH above keeps naming the REQUESTED size:
+      // Keep re-applies and re-verifies that size, so it is what the question is
+      // about, and this line is what the glass shows in the meantime.
+      if let achieved = model.pendingAchievedSize(forKey: displayKey) {
+        Text(verbatim: Self.achievedCaption(achieved))
+          .font(.callout)
+          .foregroundStyle(OnboardingStyle.faintColor)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+      }
       HStack(spacing: 14) {
         Button("Keep") { model.keepSize() }
           .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))

--- a/Candela/Onboarding/OnboardingSizePage.swift
+++ b/Candela/Onboarding/OnboardingSizePage.swift
@@ -210,18 +210,32 @@ struct OnboardingSizePage: View {
 
   /// The keep and revert bar, the safety shape the picker ships. The copy
   /// states the semantic: expiry reverts, so the size sticks only on Keep.
+  static func countdownCaption(seconds: Int, canKeep: Bool) -> String {
+    guard seconds > 0 else {
+      return "The automatic revert could not restore the previous size. Choose Revert to try again."
+    }
+    return canKeep
+      ? "Reverting to the previous size in \(seconds)s unless you keep it"
+      : "Reverting to the previous size in \(seconds)s"
+  }
+
   private func countdownBar(seconds: Int) -> some View {
     VStack(spacing: 12) {
-      Text("Reverting to the previous size in \(seconds)s unless you keep it")
+      Text(verbatim: Self.countdownCaption(
+        seconds: seconds, canKeep: model.pendingAchievedSize(forKey: displayKey) == nil))
         .font(.callout)
         .foregroundStyle(OnboardingStyle.bodyColor)
         .monospacedDigit()
         .contentTransition(.numericText())
-      // Beside the question, in the words the settings banner and the
-      // confirmation card use. The GLYPH above keeps naming the REQUESTED size:
-      // Keep re-applies and re-verifies that size, so it is what the question is
-      // about, and this line is what the glass shows in the meantime.
       if let achieved = model.pendingAchievedSize(forKey: displayKey) {
+        Text("Size preview could not be verified")
+          .font(.callout.weight(.semibold))
+          .foregroundStyle(OnboardingStyle.bodyColor)
+        Text(verbatim: DisplayModeCopy.recoveryInstruction(dialect: .size))
+          .font(.callout)
+          .foregroundStyle(OnboardingStyle.bodyColor)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
         Text(verbatim: Self.achievedCaption(achieved))
           .font(.callout)
           .foregroundStyle(OnboardingStyle.faintColor)
@@ -229,11 +243,14 @@ struct OnboardingSizePage: View {
           .fixedSize(horizontal: false, vertical: true)
       }
       HStack(spacing: 14) {
-        Button("Keep") { model.keepSize() }
-          .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))
-          .keyboardShortcut(.defaultAction)
+        if model.pendingAchievedSize(forKey: displayKey) == nil {
+          Button("Keep") { model.keepSize() }
+            .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))
+            .keyboardShortcut(.defaultAction)
+        }
         Button("Revert") { model.revertSize() }
           .buttonStyle(OnboardingSecondaryButtonStyle())
+          .keyboardShortcut(.cancelAction)
       }
     }
   }

--- a/Candela/Onboarding/OnboardingWindowController.swift
+++ b/Candela/Onboarding/OnboardingWindowController.swift
@@ -102,7 +102,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     let permission = model.accessibility
     flow.onCommit = { router.route($0) }
     flow.onRequestAccessibility = { permission.promptIfNeeded() }
-    flow.onOpenAccessibilitySettings = { AccessibilityPermission.openSystemSettings() }
+    flow.onOpenAccessibilitySettings = { permission.openSystemSettings() }
     // The request and nothing else. The return value means "already
     // granted", not "granted now" (it is false when the dialog was merely
     // shown), so nothing may gate on it; the telemetry pref itself is written

--- a/Candela/Panel/PanelResolutionSection.swift
+++ b/Candela/Panel/PanelResolutionSection.swift
@@ -101,11 +101,11 @@ struct PanelResolutionSection: View {
           }
           .transition(.opacity)
         }
-        if isAwaitingAnswer {
-          PanelCaption("Waiting for you to keep or revert the new resolution on \(displayName).", style: .tertiary)
+        if isAwaitingAnswer, let preview = coordinator.preview {
+          PanelCaption("\(DisplayModeCopy.pendingAnswer(displayName: displayName, canKeep: preview.canKeep))", style: .tertiary)
           // The answer is elsewhere, but this list names sizes, and a list
           // whose checkmark disagrees with the glass needs to say why.
-          if let commit = coordinator.preview?.unhonouredCommit {
+          if let commit = preview.unhonouredCommit {
             PanelCaption("\(DisplayModeCopy.achievedGeometry(commit))", style: .tertiary)
           }
         }

--- a/Candela/Panel/PanelResolutionSection.swift
+++ b/Candela/Panel/PanelResolutionSection.swift
@@ -103,6 +103,11 @@ struct PanelResolutionSection: View {
         }
         if isAwaitingAnswer {
           PanelCaption("Waiting for you to keep or revert the new resolution on \(displayName).", style: .tertiary)
+          // The answer is elsewhere, but this list names sizes, and a list
+          // whose checkmark disagrees with the glass needs to say why.
+          if let commit = coordinator.preview?.unhonouredCommit {
+            PanelCaption("\(DisplayModeCopy.achievedGeometry(commit))", style: .tertiary)
+          }
         }
         startFailure
         synthesisRefusal

--- a/Candela/Panel/PanelView.swift
+++ b/Candela/Panel/PanelView.swift
@@ -332,7 +332,7 @@ struct PanelView: View {
         // open behind the frontmost app. Queued: `endTracking` only asks the
         // session to end, and a synchronous open still runs inside it.
         PanelMenu.endTracking()
-        Task { @MainActor in AccessibilityPermission.openSystemSettings() }
+        Task { @MainActor in model.accessibility.openSystemSettings() }
       }
       .buttonStyle(.link)
       .font(.system(size: 12))

--- a/Candela/Settings/AdvancedPage.swift
+++ b/Candela/Settings/AdvancedPage.swift
@@ -455,18 +455,19 @@ struct AdvancedPage: View {
   /// NOT `DDCReadEvidence.worst(...)`: worst-wins folds a display whose
   /// brightness answered but whose volume came back all zeros to `.allZeros`,
   /// which would make "has never answered a read" false. One `.answered`
-  /// anywhere disqualifies it.
+  /// anywhere disqualifies it, and so does one refusal: the display replied,
+  /// so the caption this gates would be a false statement about the wire.
   private var readbackNeverAnswered: Bool {
     let evidence = [
       state.controller.readEvidence,
       state.volume.readEvidence,
       state.contrast.readEvidence,
     ]
-    guard !evidence.contains(.answered) else { return false }
+    guard !evidence.contains(.answered), !evidence.contains(.refused) else { return false }
     return evidence.contains { proves in
       switch proves {
       case .allZeros, .noReply: true
-      case .notAttempted, .answered: false
+      case .notAttempted, .answered, .refused: false
       }
     }
   }

--- a/Candela/Settings/BannerRegion.swift
+++ b/Candela/Settings/BannerRegion.swift
@@ -528,7 +528,12 @@ private struct AnswerableModeBanner: View {
     .onAppear {
       keepFocused = true
       AccessibilityNotification.Announcement(
-        DisplayModeCopy.previewAnnouncement(mode: preview.mode, seconds: preview.secondsRemaining)
+        DisplayModeCopy.previewAnnouncement(
+          mode: preview.mode, seconds: preview.secondsRemaining,
+          // The caption above says this to a reader; the announcement is the
+          // only route a listener has to it.
+          unhonouredCommit: preview.unhonouredCommit
+        )
       ).post()
     }
     // Driven by the tick this view already re-renders on, never a timer of its own.

--- a/Candela/Settings/BannerRegion.swift
+++ b/Candela/Settings/BannerRegion.swift
@@ -465,20 +465,20 @@ private struct AnswerableModeBanner: View {
   let preview: DisplayModeCoordinator.Preview
 
   @AccessibilityFocusState private var keepFocused: Bool
+  @AccessibilityFocusState private var revertFocused: Bool
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      Text("Keep this resolution?")
+      Text(verbatim: DisplayModeCopy.previewTitle(canKeep: preview.canKeep))
         .font(.callout.weight(.semibold))
         .foregroundStyle(SettingsTheme.titleColor)
       Text(verbatim: "\(DisplayModeCopy.size(preview.mode)), \(DisplayModeCopy.refresh(preview.mode.refreshHz))")
         .font(.callout)
         .foregroundStyle(SettingsTheme.bodyColor)
 
-      // Beside the question, not instead of it: the size above is what Keep
-      // re-applies, and this is what the glass shows in the meantime.
       if let commit = preview.unhonouredCommit {
+        SettingsCaption(verbatim: DisplayModeCopy.recoveryInstruction())
         SettingsCaption(verbatim: DisplayModeCopy.achievedGeometry(commit))
       }
 
@@ -505,15 +505,18 @@ private struct AnswerableModeBanner: View {
         // landing between the click and the queued operation is refused as
         // stale. Keeping writes the stored mode when Remember is on; reverting
         // and expiry never do.
-        Button("Keep") { Task { await coordinator.confirm(preview) } }
-          .buttonStyle(SettingsPrimaryButtonStyle())
-          .keyboardShortcut(.defaultAction)
-          .accessibilityLabel("Keep")
-          .accessibilityFocused($keepFocused)
+        if preview.canKeep {
+          Button("Keep") { Task { await coordinator.confirm(preview) } }
+            .buttonStyle(SettingsPrimaryButtonStyle())
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("Keep")
+            .accessibilityFocused($keepFocused)
+        }
         Button("Revert Now") { Task { await coordinator.revert(preview) } }
           .buttonStyle(SettingsSecondaryButtonStyle())
           .keyboardShortcut(.cancelAction)
           .accessibilityLabel("Revert Now")
+          .accessibilityFocused($revertFocused)
       }
       // Belt to the intent check: while a selection is landing, an answer to
       // the old preview is pointless.
@@ -526,7 +529,8 @@ private struct AnswerableModeBanner: View {
     .animation(Motion.notice(reduceMotion: reduceMotion), value: preview.failure != nil)
     .accessibilityElement(children: .contain)
     .onAppear {
-      keepFocused = true
+      keepFocused = preview.canKeep
+      revertFocused = !preview.canKeep
       AccessibilityNotification.Announcement(
         DisplayModeCopy.previewAnnouncement(
           mode: preview.mode, seconds: preview.secondsRemaining,
@@ -534,6 +538,14 @@ private struct AnswerableModeBanner: View {
           // only route a listener has to it.
           unhonouredCommit: preview.unhonouredCommit
         )
+      ).post()
+    }
+    .onChange(of: preview.unhonouredCommit) { _, commit in
+      guard let commit else { return }
+      keepFocused = false
+      revertFocused = true
+      AccessibilityNotification.Announcement(
+        "\(DisplayModeCopy.previewTitle(canKeep: false)). \(DisplayModeCopy.recoveryInstruction()) \(DisplayModeCopy.spokenAchievedGeometry(commit))"
       ).post()
     }
     // Driven by the tick this view already re-renders on, never a timer of its own.

--- a/Candela/Settings/BannerRegion.swift
+++ b/Candela/Settings/BannerRegion.swift
@@ -476,6 +476,12 @@ private struct AnswerableModeBanner: View {
         .font(.callout)
         .foregroundStyle(SettingsTheme.bodyColor)
 
+      // Beside the question, not instead of it: the size above is what Keep
+      // re-applies, and this is what the glass shows in the meantime.
+      if let commit = preview.unhonouredCommit {
+        SettingsCaption(verbatim: DisplayModeCopy.achievedGeometry(commit))
+      }
+
       if let failure = preview.failure {
         // Nothing auto-retries a failed resolution. Silence here would leave
         // the display on a mode the user never approved.

--- a/Candela/Settings/BannerRegion.swift
+++ b/Candela/Settings/BannerRegion.swift
@@ -480,7 +480,9 @@ private struct AnswerableModeBanner: View {
         // Nothing auto-retries a failed resolution. Silence here would leave
         // the display on a mode the user never approved.
         SettingsCaption(DisplayModeCopy.resolveFailure)
-          .help("CoreGraphics error \(failure.cgErrorCode)")
+          // Not the bare code: an unhonoured commit's code is a sentinel, not a
+          // CoreGraphics error.
+          .help(DisplayModeCopy.diagnostic(failure))
           .transition(.opacity)
       }
       if preview.isCountingDown {

--- a/Candela/Settings/DisplayHeroView.swift
+++ b/Candela/Settings/DisplayHeroView.swift
@@ -410,10 +410,10 @@ struct DisplayHeroView: View {
     // The brightness controller's OWN evidence, not the folded worst-of-three
     // the diagnostics page states: this sentence is about the number on the
     // brightness slider, and a volume read that answered must not speak for it.
-    // Both silent verdicts group together: either way the value shown is what
-    // we last wrote.
+    // The two silent verdicts and a refusal group together: this caption is
+    // about where the number came from, and none of the three supplied one.
     switch state.controller.readEvidence {
-    case .allZeros, .noReply:
+    case .allZeros, .noReply, .refused:
       return .valueNotReadBack
     case .answered, .notAttempted:
       return nil

--- a/Candela/Settings/KeyboardPane.swift
+++ b/Candela/Settings/KeyboardPane.swift
@@ -80,7 +80,7 @@ struct KeyboardPane: View {
         // The page's one action while the grant is missing, so it takes the
         // primary style. Trailing ellipsis: it opens another app (buttons.md).
         Button("Open System Settings…") {
-          AccessibilityPermission.openSystemSettings()
+          model.accessibility.openSystemSettings()
         }
         .buttonStyle(SettingsPrimaryButtonStyle())
         .accessibilityLabel("Open System Settings…")

--- a/Candela/Settings/ReapplyDiagnostic.swift
+++ b/Candela/Settings/ReapplyDiagnostic.swift
@@ -1,15 +1,18 @@
 import CandelaKit
 import SwiftUI
 
-/// The CoreGraphics code goes in a tooltip, out of the sentence someone reads
-/// while working out what happened to their screen. Only `.failed` gets one: an
-/// empty tooltip would imply an error that a substitution never had.
+/// The diagnostic goes in a tooltip, out of the sentence someone reads while
+/// working out what happened to their screen. Only `.failed` gets one: an empty
+/// tooltip would imply an error that a substitution never had.
+///
+/// Through `DisplayModeCopy.diagnostic`, never the raw code: an unhonoured
+/// commit has no CoreGraphics error to print.
 struct ReapplyDiagnostic: ViewModifier {
   let notice: ModeReapplyNotice
 
   @ViewBuilder func body(content: Content) -> some View {
     if case let .failed(error) = notice {
-      content.help("CoreGraphics error \(error.cgErrorCode)")
+      content.help(DisplayModeCopy.diagnostic(error))
     } else {
       content
     }

--- a/Candela/Settings/SettingsActions.swift
+++ b/Candela/Settings/SettingsActions.swift
@@ -95,6 +95,7 @@ final class SettingsActions {
       // must not put the DDC bus to work on every timeout tweak.
       model.oledCare.reapplyAfterPrefChange(persistenceKey: persistenceKey)
     }
+    if effects.contains(.restartBrightnessPoll) { model?.notePollConsumerAppeared() }
     if effects.contains(.syncVirtualDisplays) {
       // Converge live virtual displays to the slot prefs. The model hops
       // off the main actor itself; nothing here blocks.

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -50,10 +50,10 @@ struct SettingsRootView: View {
 
   @Environment(AppModel.self) private var model
 
-  /// Whether this window is on screen, for the brightness poller's cadence. A
-  /// CLOSED settings window reports `.inactive` here, since the window object
-  /// outlives the close, and so does one sitting behind another app: the same
-  /// answer for the poller's purposes, because nobody is reading the sliders.
+  /// Whether this window is on screen, for the poller's cadence. A CLOSED window
+  /// reports `.inactive` (the object outlives the close), as does one behind
+  /// another app. Looser than the canvas's `.key` threshold on purpose: a window
+  /// behind another Candela window still shows its values.
   @Environment(\.controlActiveState) private var activeState
 
   private func noteSettingsVisible(_ visible: Bool) {

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -50,11 +50,27 @@ struct SettingsRootView: View {
 
   @Environment(AppModel.self) private var model
 
-  /// Whether this window is on screen, for the poller's cadence. A CLOSED window
-  /// reports `.inactive` (the object outlives the close), as does one behind
-  /// another app. Looser than the canvas's `.key` threshold on purpose: a window
-  /// behind another Candela window still shows its values.
+  /// The FALLBACK visibility signal, and only that. Every window of a
+  /// non-frontmost app reports `.inactive`, so on its own this reads a settings
+  /// page open beside another app as closed, and the poller then serves a hero
+  /// slider that is on screen at the idle interval.
   @Environment(\.controlActiveState) private var activeState
+
+  /// What the hosting window says about itself: on screen and not fully covered.
+  /// nil until a window has attached, which is the whole window in which the
+  /// activation fallback speaks.
+  @State private var windowVisibility: Bool?
+
+  /// The window's own answer wherever there is one.
+  static func isSettingsOnScreen(
+    windowVisibility: Bool?, activeState: ControlActiveState
+  ) -> Bool {
+    windowVisibility ?? (activeState != .inactive)
+  }
+
+  private var isOnScreen: Bool {
+    Self.isSettingsOnScreen(windowVisibility: windowVisibility, activeState: activeState)
+  }
 
   private func noteSettingsVisible(_ visible: Bool) {
     model.surfaceVisibility.setSettingsVisible(visible)
@@ -114,9 +130,9 @@ struct SettingsRootView: View {
     .preferredColorScheme(.dark)
     // The window is a poll consumer while up; becoming visible also restarts the
     // job so the first frame is not a slow interval stale.
-    .onAppear { noteSettingsVisible(activeState != .inactive) }
-    .onChange(of: activeState) { _, state in
-      noteSettingsVisible(state != .inactive)
+    .onAppear { noteSettingsVisible(isOnScreen) }
+    .onChange(of: isOnScreen) { _, visible in
+      noteSettingsVisible(visible)
     }
     // Belt on the flag: a consumer left true is a poller that never slows down.
     .onDisappear { model.surfaceVisibility.setSettingsVisible(false) }
@@ -166,7 +182,8 @@ struct SettingsRootView: View {
       SettingsWindowTitleHost(
         displayKey: presentation.displayKey,
         fallbackTitle: selectedPaneTitle,
-        navigationToken: currentPathDepth))
+        navigationToken: currentPathDepth,
+        onWindowVisibility: { windowVisibility = $0 }))
     .onAppear {
       if let pending = SettingsOpener.pendingSelection {
         SettingsOpener.pendingSelection = nil
@@ -761,11 +778,17 @@ private struct SettingsWindowTitleHost: View {
   /// Also covers the same-frame race where the key has left the connected states.
   let fallbackTitle: String
   let navigationToken: Int
+  /// Passed straight through: the configurator is where the hosting window is
+  /// already reached, so the visibility signal needs no second window route.
+  let onWindowVisibility: @MainActor (Bool) -> Void
 
   @Environment(AppModel.self) private var model
 
   var body: some View {
-    SettingsWindowConfigurator(title: title, navigationToken: navigationToken)
+    SettingsWindowConfigurator(
+      title: title,
+      navigationToken: navigationToken,
+      onWindowVisibility: onWindowVisibility)
   }
 
   private var title: String {
@@ -814,20 +837,25 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
   /// contract promptly. Measured: a push flips `titleVisibility` back to visible
   /// and draws the window title at the leading edge.
   let navigationToken: Int
+  /// Reports whether the window is on screen and not fully covered. Called only
+  /// on a change, and never from inside a SwiftUI update pass.
+  let onWindowVisibility: @MainActor (Bool) -> Void
 
   func makeNSView(context: Context) -> NSView {
     let coordinator = context.coordinator
+    coordinator.reportVisibility = onWindowVisibility
     coordinator.desiredTitle = title
     let view = WindowAttachedView()
     // The view has no window during `makeNSView`, and asking again after a
     // `DispatchQueue.main.async` hop answered nil whenever the hop lost the
     // race, with nothing to retry it.
-    view.onAttach = { [weak coordinator] window in coordinator?.apply(to: window) }
+    view.onAttach = { [weak coordinator] window in coordinator?.attach(to: window) }
     return view
   }
 
   func updateNSView(_ view: NSView, context: Context) {
     let coordinator = context.coordinator
+    coordinator.reportVisibility = onWindowVisibility
     coordinator.desiredTitle = title
     if let window = view.window { coordinator.apply(to: window) }
   }
@@ -860,13 +888,23 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
   /// only hides the disagreement, and the frame where AppKit wins the race
   /// still shows a window named for a pane that is not on screen.
   final class Coordinator {
-    // Nonisolated storage so `deinit` can remove the observer: a `@MainActor`
+    // Nonisolated storage so `deinit` can remove the observers: a `@MainActor`
     // property is unreachable from a nonisolated deinit under Swift 6.
-    // `removeObserver` is thread-safe, and both properties are only ever
-    // WRITTEN from `apply(to:)`, which is main-actor.
+    // `removeObserver` is thread-safe, and every property below is only ever
+    // WRITTEN from a main-actor method of this class.
     private var observer: NSObjectProtocol?
+    /// The occlusion and close observations, held apart from the update-pass one
+    /// so all three come down together with the window they watch.
+    private var visibilityObservers: [NSObjectProtocol] = []
     private weak var observedWindow: NSWindow?
     private var title = ""
+    /// Last value handed out, so the update-pass belt below can re-assert the
+    /// answer every pass without waking SwiftUI for a value it already has.
+    private var reportedVisibility: Bool?
+
+    /// Replaced on every update, so a report lands on the live view rather than
+    /// the one that was on screen when the window attached.
+    @MainActor var reportVisibility: @MainActor (Bool) -> Void = { _ in }
 
     /// Re-applied to the window the moment it changes, so a dropped write
     /// cannot outlive one update.
@@ -893,6 +931,32 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
     /// coordinator alive.
     private struct WeakCoordinatorBox: @unchecked Sendable {
       weak var coordinator: Coordinator?
+    }
+
+    /// The window has arrived: assert the contract at once, and report the
+    /// visibility on a hop. `viewDidMoveToWindow` runs inside the SwiftUI update
+    /// pass that attached the view, and a state write there is undefined; the
+    /// hop costs one run-loop turn, during which the activation fallback answers.
+    @MainActor func attach(to window: NSWindow) {
+      apply(to: window)
+      Task { @MainActor [weak self] in
+        guard let self, let window = self.observedWindow else { return }
+        self.report(self.isOnScreen(window))
+      }
+    }
+
+    /// Whether anyone can see this window: on screen, and not fully covered by
+    /// an opaque window in front of it. `isVisible` is the ordered-out half, and
+    /// it is not redundant: occlusion is tracked for windows on screen, so a
+    /// window that has gone away is not a state to read as visible.
+    @MainActor private func isOnScreen(_ window: NSWindow) -> Bool {
+      window.isVisible && window.occlusionState.contains(.visible)
+    }
+
+    @MainActor private func report(_ visible: Bool) {
+      guard reportedVisibility != visible else { return }
+      reportedVisibility = visible
+      reportVisibility(visible)
     }
 
     @MainActor func apply(to window: NSWindow) {
@@ -984,6 +1048,8 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
     @MainActor private func observe(_ window: NSWindow) {
       guard observedWindow !== window else { return }
       if let observer { NotificationCenter.default.removeObserver(observer) }
+      for observer in visibilityObservers { NotificationCenter.default.removeObserver(observer) }
+      visibilityObservers = []
       observedWindow = window
       let box = WeakWindowBox(window: window)
       let owner = WeakCoordinatorBox(coordinator: self)
@@ -996,12 +1062,36 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
           guard let coordinator = owner.coordinator, let window = box.window else { return }
           coordinator.apply(to: window)
           coordinator.restoreMinimumSize(on: window)
+          // The belt on the way back IN. A window ordered back on screen is
+          // updated, whatever the occlusion notification did or did not post,
+          // and a stale `false` here is a hero slider served at the idle
+          // interval. Deduplicated, so a per-pass call is not a per-pass write.
+          coordinator.report(coordinator.isOnScreen(window))
         }
       }
+      visibilityObservers.append(
+        NotificationCenter.default.addObserver(
+          forName: NSWindow.didChangeOcclusionStateNotification, object: window, queue: .main
+        ) { _ in
+          MainActor.assumeIsolated {
+            guard let coordinator = owner.coordinator, let window = box.window else { return }
+            coordinator.report(coordinator.isOnScreen(window))
+          }
+        })
+      // The belt on the way OUT: a closing window is not promised to post an
+      // occlusion change, and it stops being updated, so neither route above can
+      // be trusted to say it has gone. `willClose` always arrives.
+      visibilityObservers.append(
+        NotificationCenter.default.addObserver(
+          forName: NSWindow.willCloseNotification, object: window, queue: .main
+        ) { _ in
+          MainActor.assumeIsolated { owner.coordinator?.report(false) }
+        })
     }
 
     deinit {
       if let observer { NotificationCenter.default.removeObserver(observer) }
+      for observer in visibilityObservers { NotificationCenter.default.removeObserver(observer) }
     }
   }
 }

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -50,6 +50,17 @@ struct SettingsRootView: View {
 
   @Environment(AppModel.self) private var model
 
+  /// Whether this window is on screen, for the brightness poller's cadence. A
+  /// CLOSED settings window reports `.inactive` here, since the window object
+  /// outlives the close, and so does one sitting behind another app: the same
+  /// answer for the poller's purposes, because nobody is reading the sliders.
+  @Environment(\.controlActiveState) private var activeState
+
+  private func noteSettingsVisible(_ visible: Bool) {
+    model.surfaceVisibility.setSettingsVisible(visible)
+    if visible { model.notePollConsumerAppeared() }
+  }
+
   var body: some View {
     ZStack {
       // One canvas for the life of the window, so a selection change moves the
@@ -101,6 +112,14 @@ struct SettingsRootView: View {
     // Dark-only: every colour comes from the theme layer and none of
     // them has a light-appearance answer.
     .preferredColorScheme(.dark)
+    // The window is a poll consumer while up; becoming visible also restarts the
+    // job so the first frame is not a slow interval stale.
+    .onAppear { noteSettingsVisible(activeState != .inactive) }
+    .onChange(of: activeState) { _, state in
+      noteSettingsVisible(state != .inactive)
+    }
+    // Belt on the flag: a consumer left true is a poller that never slows down.
+    .onDisappear { model.surfaceVisibility.setSettingsVisible(false) }
     // The cross-link navigation seam, wired here because this view
     // owns the selection and re-wired per appearance so a reopened window binds
     // to the live view identity.

--- a/Candela/Settings/Theme/SettingsCanvas.swift
+++ b/Candela/Settings/Theme/SettingsCanvas.swift
@@ -3,25 +3,36 @@ import SwiftUI
 /// The drifting glow ground under every settings page, tinted per destination.
 ///
 /// The window keeps ONE canvas alive across every selection so the light moves
-/// rather than cutting to a new one. Reduce Motion holds it at its first
-/// frame.
+/// rather than cutting to a new one. Reduce Motion holds it at its first frame.
+/// Anything short of a key window holds the frame it froze on instead, so the
+/// drift resumes where it stopped rather than jumping.
 struct SettingsCanvas: View {
   var accent: Color
   var secondary: Color
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.controlActiveState) private var activeState
+
+  /// Off-key time is discounted from the drift clock, so coming back resumes the
+  /// motion instead of jumping it forward.
+  @State private var offKeySince: Date?
+  @State private var offKeyTotal: TimeInterval = 0
 
   var body: some View {
     ZStack {
       Color(red: 0.035, green: 0.035, blue: 0.06)
       if reduceMotion {
         blobs(at: 0)
-      } else {
+      } else if activeState == .key {
         // 12 fps: a blob centre moves about a third of a point per frame, and
         // each frame costs two full-window Gaussian blurs.
         TimelineView(.animation(minimumInterval: 1.0 / 12.0)) { context in
-          blobs(at: context.date.timeIntervalSinceReferenceDate)
+          blobs(at: drift(at: context.date))
         }
+      } else {
+        // A CLOSED window lands here too: the object outlives the close and used
+        // to pay for two blurs 12 times a second forever.
+        blobs(at: drift(at: offKeySince ?? .now))
       }
       RadialGradient(
         colors: [.clear, Color.black.opacity(0.5)],
@@ -30,6 +41,19 @@ struct SettingsCanvas: View {
     }
     .ignoresSafeArea()
     .accessibilityHidden(true)
+    .onAppear { if activeState != .key, offKeySince == nil { offKeySince = .now } }
+    .onChange(of: activeState) { _, state in
+      if state == .key {
+        if let since = offKeySince { offKeyTotal += Date.now.timeIntervalSince(since) }
+        offKeySince = nil
+      } else if offKeySince == nil {
+        offKeySince = .now
+      }
+    }
+  }
+
+  private func drift(at date: Date) -> TimeInterval {
+    date.timeIntervalSinceReferenceDate - offKeyTotal
   }
 
   private func blobs(at time: TimeInterval) -> some View {

--- a/Candela/Settings/Theme/SettingsCanvas.swift
+++ b/Candela/Settings/Theme/SettingsCanvas.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 /// The drifting glow ground under every settings page, tinted per destination.
+/// The Heat Map window draws it too, as its own window's ground.
 ///
 /// The window keeps ONE canvas alive across every selection so the light moves
 /// rather than cutting to a new one. Reduce Motion holds it at its first frame.
-/// Anything short of a key window holds the frame it froze on instead, so the
-/// drift resumes where it stopped rather than jumping.
+/// A non-key window holds the frame it froze on, so the drift resumes where it
+/// stopped. Stricter than the poller's consumer threshold on purpose: only the
+/// focused window has to pay for 12 frames a second.
 struct SettingsCanvas: View {
   var accent: Color
   var secondary: Color

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -318,8 +318,11 @@ struct CopyBuilderTests {
     let notSet = render(DiagnosticsPageCopy.notAttempted(isSafeMode: false, readsBackAtStartup: false))
     #expect(notSet.contains("is not set to read values back from displays at startup"))
 
+    // One silent pass is held, not published, so the display may have been read;
+    // "nothing has been read" would be false there.
     let nothingYet = render(DiagnosticsPageCopy.notAttempted(isSafeMode: false, readsBackAtStartup: true))
-    #expect(nothingYet.contains("Nothing has been read from this display yet"))
+    #expect(nothingYet.contains("No answer has been recorded from this display yet"))
+    #expect(!nothingYet.contains("Nothing has been read"))
   }
 
   @Test func diagnosticsWriteGateLabelNamesNoWireTheBuiltInLacks() {

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -442,16 +442,41 @@ struct CopyBuilderTests {
         == "CoreGraphics error 1001")
     #expect(DisplayModeCopy.startFailureDiagnostic(.blocked(by: .rotation)) == "Held by rotation")
 
-    // A commit that went through unhonoured has no error code worth printing:
-    // CoreGraphics reported success, and the finding is which resolution the
-    // display was left on.
+    // No code to print for an unhonoured commit. Achieved differs from requested
+    // so the assertions can tell which one the sentence names.
+    let landed = DisplayMode(
+      ioModeID: 9, logicalWidth: 1920, logicalHeight: 1080,
+      pixelWidth: 1920, pixelHeight: 1080, refreshHz: 30, isNative: false)
     let unhonoured = DisplayModeCopy.startFailureDiagnostic(
       .failed(
         DisplayConfigError(
-          unhonouredCommit: .init(requested: Self.mode, achieved: Self.mode))))
+          unhonouredCommit: .init(requested: Self.mode, achieved: landed))))
     #expect(!unhonoured.contains("CoreGraphics error"))
     #expect(unhonoured.contains("reported success"))
-    #expect(unhonoured.contains(DisplayModeCopy.size(Self.mode)))
+    #expect(unhonoured.contains(DisplayModeCopy.size(landed)))
+    #expect(unhonoured.contains(DisplayModeCopy.refresh(landed.refreshHz)))
+    #expect(!unhonoured.contains(DisplayModeCopy.size(Self.mode)))
+  }
+
+  /// Every tooltip that renders a `DisplayConfigError` calls this, so the
+  /// unhonoured arm is pinned once.
+  @Test func displayModeDiagnosticRendersBothArms() {
+    #expect(DisplayModeCopy.diagnostic(DisplayConfigError(cgErrorCode: 1001)) == "CoreGraphics error 1001")
+
+    let landed = DisplayMode(
+      ioModeID: 9, logicalWidth: 1920, logicalHeight: 1080,
+      pixelWidth: 1920, pixelHeight: 1080, refreshHz: 30, isNative: false)
+    let committed = DisplayModeCopy.diagnostic(
+      DisplayConfigError(unhonouredCommit: .init(requested: Self.mode, achieved: landed)))
+    #expect(committed.contains(DisplayModeCopy.size(landed)))
+    // The sentinel is not a CoreGraphics code and must never be printed as one.
+    #expect(!committed.contains("\(DisplayConfigError.unhonouredCommitCode)"))
+
+    // An unreadable achieved mode is still an unhonoured commit, not the code arm.
+    let unreadable = DisplayModeCopy.diagnostic(
+      DisplayConfigError(unhonouredCommit: .init(requested: Self.mode, achieved: nil)))
+    #expect(unreadable.contains("unreadable resolution"))
+    #expect(!unreadable.contains("CoreGraphics error"))
   }
 
   @Test func displayModeResolveFailuresInviteAnotherAttempt() {

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -415,6 +415,41 @@ struct CopyBuilderTests {
     #expect(!spoken.contains("×"))
   }
 
+  /// The caption beside the keep question is silent to a listener, so an
+  /// unhonoured commit's achieved geometry rides the announcement too. Otherwise
+  /// the one person who cannot check the screen approves a size the display is
+  /// not showing.
+  @Test func displayModePreviewAnnouncementSpeaksTheAchievedGeometryToo() {
+    let spoken = DisplayModeCopy.previewAnnouncement(
+      mode: Self.mode, seconds: 15,
+      unhonouredCommit: .init(requested: Self.mode, achieved: Self.landedMode))
+    // The question and its deadline still lead.
+    #expect(spoken.hasPrefix("Keep 2,560 by 1,440 at 60 hertz?"))
+    #expect(spoken.contains(DisplayModeCopy.countdown(15)))
+    // The same statement the caption makes, in the spoken spelling: grouped
+    // digits, words for the rate, and no times sign.
+    #expect(spoken.hasSuffix("The display is showing 1,920 by 1,080 at 30 hertz."))
+    #expect(!spoken.contains("×"))
+    #expect(!spoken.contains("Hz"))
+    // The size that was ASKED for still leads; the achieved one never replaces it.
+    #expect(spoken.contains("2,560 by 1,440"))
+
+    // A display that cannot say what it is showing gets the other sentence,
+    // never silence.
+    let unreadable = DisplayModeCopy.previewAnnouncement(
+      mode: Self.mode, seconds: 15,
+      unhonouredCommit: .init(requested: Self.mode, achieved: nil))
+    #expect(unreadable.hasSuffix(DisplayModeCopy.unreadableAchievedGeometry()))
+  }
+
+  /// The control: an honoured apply says nothing extra, so the announcement does
+  /// not imply a divergence on every preview.
+  @Test func displayModePreviewAnnouncementStaysBareWhenTheCommitWasHonoured() {
+    #expect(
+      DisplayModeCopy.previewAnnouncement(mode: Self.mode, seconds: 15, unhonouredCommit: nil)
+        == DisplayModeCopy.previewAnnouncement(mode: Self.mode, seconds: 15))
+  }
+
   @Test func displayModeMarksMakeNoQualityClaim() {
     #expect(DisplayModeCopy.addedByApp == "Added by \(AppInfo.productName)")
     #expect(DisplayModeCopy.recommended == "Recommended")
@@ -1037,6 +1072,16 @@ struct CopyBuilderTests {
       add(
         "DisplayModeCopy.previewAnnouncement(\(seconds))",
         DisplayModeCopy.previewAnnouncement(mode: Self.mode, seconds: seconds))
+      add(
+        "DisplayModeCopy.previewAnnouncement(\(seconds), unhonoured)",
+        DisplayModeCopy.previewAnnouncement(
+          mode: Self.mode, seconds: seconds,
+          unhonouredCommit: .init(requested: Self.mode, achieved: Self.landedMode)))
+      add(
+        "DisplayModeCopy.previewAnnouncement(\(seconds), unreadable)",
+        DisplayModeCopy.previewAnnouncement(
+          mode: Self.mode, seconds: seconds,
+          unhonouredCommit: .init(requested: Self.mode, achieved: nil)))
     }
     add("DisplayModeCopy.startFailure", DisplayModeCopy.startFailure)
     add("DisplayModeCopy.startFailureAfterACommit", DisplayModeCopy.startFailureAfterACommit)

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -403,6 +403,17 @@ struct CopyBuilderTests {
     #expect(DisplayModeCopy.passiveCountdown(9).contains("Answer in the confirmation window"))
   }
 
+  @Test func menuBarModeStatusOnlyOffersTheAnswersAvailableToThePreview() {
+    let recovery = DisplayModeCopy.pendingAnswer(displayName: "Desk display", canKeep: false)
+    #expect(recovery.contains("Desk display"))
+    #expect(recovery.contains("could not be verified"))
+    #expect(recovery.contains("Revert"))
+    #expect(!recovery.lowercased().contains("keep"))
+    let ordinary = DisplayModeCopy.pendingAnswer(displayName: "Desk display", canKeep: true)
+    #expect(ordinary.contains("keep or revert"))
+    #expect(ordinary.contains("Desk display"))
+  }
+
   @Test func displayModePreviewAnnouncementSpeaksTheModeAndTheDeadline() {
     let spoken = DisplayModeCopy.previewAnnouncement(mode: Self.mode, seconds: 15)
     #expect(spoken.contains("2,560 by 1,440 at 60 hertz"))
@@ -423,16 +434,17 @@ struct CopyBuilderTests {
     let spoken = DisplayModeCopy.previewAnnouncement(
       mode: Self.mode, seconds: 15,
       unhonouredCommit: .init(requested: Self.mode, achieved: Self.landedMode))
-    // The question and its deadline still lead.
-    #expect(spoken.hasPrefix("Keep 2,560 by 1,440 at 60 hertz?"))
+    #expect(spoken.hasPrefix("Resolution preview could not be verified."))
+    #expect(!spoken.contains("Keep "))
+    #expect(spoken.contains("Revert"))
     #expect(spoken.contains(DisplayModeCopy.countdown(15)))
     // The same statement the caption makes, in the spoken spelling: grouped
     // digits, words for the rate, and no times sign.
     #expect(spoken.hasSuffix("The display is showing 1,920 by 1,080 at 30 hertz."))
     #expect(!spoken.contains("×"))
     #expect(!spoken.contains("Hz"))
-    // The size that was ASKED for still leads; the achieved one never replaces it.
-    #expect(spoken.contains("2,560 by 1,440"))
+    // A new choice is needed before another preview can be approved.
+    #expect(spoken.contains("choose the resolution again"))
 
     // A display that cannot say what it is showing gets the other sentence,
     // never silence.

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -397,7 +397,10 @@ struct CopyBuilderTests {
   @Test func displayModePreviewAnnouncementSpeaksTheModeAndTheDeadline() {
     let spoken = DisplayModeCopy.previewAnnouncement(mode: Self.mode, seconds: 15)
     #expect(spoken.contains("2,560 by 1,440 at 60 hertz"))
-    #expect(spoken.contains("Keep this resolution?"))
+    #expect(spoken.hasPrefix("Keep 2,560 by 1,440 at 60 hertz?"))
+    // Spoken to someone who cannot look: an unhonoured commit leaves something
+    // else on the glass.
+    #expect(!spoken.contains("Display changed to"))
     #expect(spoken.contains(DisplayModeCopy.countdown(15)))
     // No glyphs in a spoken string: the times sign is read inconsistently.
     #expect(!spoken.contains("×"))
@@ -423,6 +426,9 @@ struct CopyBuilderTests {
 
   @Test func displayModeStartFailureStatesEitherReason() {
     #expect(render(DisplayModeCopy.startFailure).contains("could not switch this display"))
+    // The readback can fail on a commit that went through, so no "nothing changed".
+    #expect(!render(DisplayModeCopy.startFailure).contains("Nothing changed"))
+    #expect(render(DisplayModeCopy.startFailure).contains("Check what it is showing"))
     #expect(
       render(DisplayModeCopy.startFailure(.failed(DisplayConfigError(cgErrorCode: 1001))))
         == render(DisplayModeCopy.startFailure))
@@ -435,11 +441,24 @@ struct CopyBuilderTests {
       DisplayModeCopy.startFailureDiagnostic(.failed(DisplayConfigError(cgErrorCode: 1001)))
         == "CoreGraphics error 1001")
     #expect(DisplayModeCopy.startFailureDiagnostic(.blocked(by: .rotation)) == "Held by rotation")
+
+    // A commit that went through unhonoured has no error code worth printing:
+    // CoreGraphics reported success, and the finding is which resolution the
+    // display was left on.
+    let unhonoured = DisplayModeCopy.startFailureDiagnostic(
+      .failed(
+        DisplayConfigError(
+          unhonouredCommit: .init(requested: Self.mode, achieved: Self.mode))))
+    #expect(!unhonoured.contains("CoreGraphics error"))
+    #expect(unhonoured.contains("reported success"))
+    #expect(unhonoured.contains(DisplayModeCopy.size(Self.mode)))
   }
 
   @Test func displayModeResolveFailuresInviteAnotherAttempt() {
-    #expect(render(DisplayModeCopy.resolveFailure).contains("still showing the preview"))
-    #expect(render(DisplayModeCopy.resolveFailure).contains("Try again"))
+    // The readback can fail on a commit that went through, so no claim about
+    // what is showing.
+    #expect(!render(DisplayModeCopy.resolveFailure).contains("still showing the preview"))
+    #expect(render(DisplayModeCopy.resolveFailure).contains("then try again"))
     #expect(render(DisplayModeCopy.expiryAlreadyRan).contains("already run"))
   }
 
@@ -463,7 +482,10 @@ struct CopyBuilderTests {
     #expect(unavailable.contains("left this display as it found it"))
 
     let failed = render(DisplayModeCopy.reapplyFailed(requested: Self.descriptor))
-    #expect(failed.contains("Nothing was changed"))
+    // Unattended, and the readback can fail after the commit: must not say the
+    // display did not move.
+    #expect(!failed.contains("Nothing was changed"))
+    #expect(failed.contains("Pick it from the list of resolutions"))
 
     // One sentence per notice, and each routes to its own builder.
     #expect(

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -71,6 +71,12 @@ struct CopyBuilderTests {
     logicalWidth: 3440, logicalHeight: 1440,
     pixelWidth: 3440, pixelHeight: 1440, refreshHz: 175)
 
+  /// Where an unhonoured commit left the display. Every field differs from
+  /// `mode`, so a sentence naming the wrong one of the two cannot pass.
+  private static let landedMode = DisplayMode(
+    ioModeID: 9, logicalWidth: 1920, logicalHeight: 1080,
+    pixelWidth: 1920, pixelHeight: 1080, refreshHz: 30, isNative: false)
+
   // MARK: - ArrangementCopy
 
   @Test func arrangementReportTitleNamesWhatTheCardReports() {
@@ -427,11 +433,57 @@ struct CopyBuilderTests {
     #expect(!scaled.contains("native"))
   }
 
+  /// The caption beside the keep question. The question names what Keep
+  /// re-applies; this names what the display is showing instead, which is the
+  /// half a person answering cannot check.
+  @Test func displayModeAchievedGeometryNamesWhatTheGlassShows() {
+    let caption = DisplayModeCopy.achievedGeometry(
+      .init(requested: Self.mode, achieved: Self.landedMode))
+    #expect(caption == "The display is showing 1920 × 1080, 30 Hz.")
+    // The requested size is already on screen above it, and repeating it there
+    // would make the two lines read as one contradiction.
+    #expect(!caption.contains(DisplayModeCopy.size(Self.mode)))
+
+    // A readback that failed is not evidence about the mode, so nothing is named.
+    let unreadable = DisplayModeCopy.achievedGeometry(
+      .init(requested: Self.mode, achieved: nil))
+    #expect(unreadable == "This display did not report which resolution it is showing.")
+    #expect(!unreadable.contains("×"))
+  }
+
+  /// One sentence, two dialects: the app windows write a size with the times
+  /// sign and call it a resolution, guided setup writes it with an x and calls
+  /// it a size. Both come from here, so neither surface can drift.
+  @Test func displayModeAchievedGeometrySpeaksEachSurfacesDialect() {
+    #expect(
+      DisplayModeCopy.achievedGeometry(width: 1920, height: 1080, refreshHz: 30, dialect: .size)
+        == "The display is showing 1920 x 1080, 30 Hz.")
+    #expect(
+      DisplayModeCopy.unreadableAchievedGeometry(dialect: .size)
+        == "This display did not report which size it is showing.")
+
+    // The control: the dialect is doing something, and the default is the one
+    // every existing surface already speaks.
+    for dialect in [DisplayModeCopy.SizeDialect.resolution, .size] {
+      let sentence = DisplayModeCopy.achievedGeometry(
+        width: 1920, height: 1080, refreshHz: 30, dialect: dialect)
+      #expect(sentence.contains(dialect.times))
+      #expect(sentence.contains("1920 \(dialect.times) 1080"))
+      #expect(DisplayModeCopy.unreadableAchievedGeometry(dialect: dialect).contains(dialect.noun))
+    }
+    #expect(DisplayModeCopy.SizeDialect.resolution.times != DisplayModeCopy.SizeDialect.size.times)
+    #expect(DisplayModeCopy.SizeDialect.resolution.noun != DisplayModeCopy.SizeDialect.size.noun)
+    #expect(
+      DisplayModeCopy.achievedGeometry(width: 1920, height: 1080, refreshHz: 30)
+        == DisplayModeCopy.achievedGeometry(
+          width: 1920, height: 1080, refreshHz: 30, dialect: .resolution))
+  }
+
   @Test func displayModeStartFailureStatesEitherReason() {
     #expect(render(DisplayModeCopy.startFailure).contains("could not switch this display"))
-    // The readback can fail on a commit that went through, so no "nothing changed".
-    #expect(!render(DisplayModeCopy.startFailure).contains("Nothing changed"))
-    #expect(render(DisplayModeCopy.startFailure).contains("Check what it is showing"))
+    // Nothing committed on this route, so the sentence says so instead of
+    // sending the reader off to inspect a screen that did not change.
+    #expect(render(DisplayModeCopy.startFailure).contains("Nothing changed"))
     #expect(
       render(DisplayModeCopy.startFailure(.failed(DisplayConfigError(cgErrorCode: 1001))))
         == render(DisplayModeCopy.startFailure))
@@ -459,6 +511,57 @@ struct CopyBuilderTests {
     #expect(unhonoured.contains(DisplayModeCopy.size(landed)))
     #expect(unhonoured.contains(DisplayModeCopy.refresh(landed.refreshHz)))
     #expect(!unhonoured.contains(DisplayModeCopy.size(Self.mode)))
+  }
+
+  /// The one route that reaches a start failure with a commit behind it is a
+  /// preview on ANOTHER display that could not be put back: `begin` returns
+  /// before it touches this one. So neither the sentence nor the tooltip may
+  /// describe this display's screen, and neither may say nothing changed.
+  @Test func displayModeStartFailureAfterACommitTalksAboutTheOtherDisplay() {
+    let error = DisplayConfigError(
+      unhonouredCommit: .init(requested: Self.mode, achieved: Self.landedMode))
+    let sentence = render(DisplayModeCopy.startFailure(.failed(error)))
+    #expect(sentence == render(DisplayModeCopy.startFailureAfterACommit))
+    #expect(sentence.contains("another display"))
+    #expect(!sentence.contains("Nothing changed"))
+    #expect(sentence != render(DisplayModeCopy.startFailure))
+
+    let diagnostic = DisplayModeCopy.startFailureDiagnostic(.failed(error))
+    #expect(diagnostic.hasPrefix("Another display: "))
+    #expect(diagnostic.contains(DisplayModeCopy.size(Self.landedMode)))
+    // The shared tooltip carries no display: only this route knows which one it
+    // is about, which is why the naming lives here.
+    #expect(!DisplayModeCopy.diagnostic(error).contains("Another display"))
+  }
+
+  /// The floating card's three lines are one story: a title about this display,
+  /// a subject, then a sentence about a second display. The subject names both
+  /// exactly where the sentence does.
+  @Test func displayModeStartFailureSubjectNamesBothDisplaysOnlyWhenItCommitted() {
+    let committed = DisplayModeCoordinator.StartFailure.Reason.failed(
+      DisplayConfigError(unhonouredCommit: .init(requested: Self.mode, achieved: Self.landedMode)))
+    #expect(
+      DisplayModeCopy.startFailureSubject(displayName: "MAG 341C OLED", reason: committed)
+        == "MAG 341C OLED and another display")
+    // The card omits an empty subject, so the second display would go unnamed
+    // if this arm handed back nothing.
+    #expect(
+      DisplayModeCopy.startFailureSubject(displayName: "", reason: committed)
+        == "This display and another display")
+
+    // Every other reason is about this display alone, and the subject is its
+    // name unchanged.
+    for reason in Self.allStartFailureReasons where !Self.commits(reason) {
+      #expect(
+        DisplayModeCopy.startFailureSubject(displayName: "DELL U2725QE", reason: reason)
+          == "DELL U2725QE")
+      #expect(DisplayModeCopy.startFailureSubject(displayName: "", reason: reason).isEmpty)
+    }
+  }
+
+  private static func commits(_ reason: DisplayModeCoordinator.StartFailure.Reason) -> Bool {
+    guard case let .failed(error) = reason else { return false }
+    return error.didCommit
   }
 
   /// Every tooltip that renders a `DisplayConfigError` calls this, so the
@@ -936,11 +1039,26 @@ struct CopyBuilderTests {
         DisplayModeCopy.previewAnnouncement(mode: Self.mode, seconds: seconds))
     }
     add("DisplayModeCopy.startFailure", DisplayModeCopy.startFailure)
+    add("DisplayModeCopy.startFailureAfterACommit", DisplayModeCopy.startFailureAfterACommit)
+    add(
+      "DisplayModeCopy.achievedGeometry",
+      DisplayModeCopy.achievedGeometry(.init(requested: Self.mode, achieved: Self.landedMode)))
+    add(
+      "DisplayModeCopy.achievedGeometry(unreadable)",
+      DisplayModeCopy.achievedGeometry(.init(requested: Self.mode, achieved: nil)))
     add("DisplayModeCopy.resolveFailure", DisplayModeCopy.resolveFailure)
     add("DisplayModeCopy.expiryAlreadyRan", DisplayModeCopy.expiryAlreadyRan)
     for reason in Self.allStartFailureReasons {
       add("DisplayModeCopy.startFailure(reason)", DisplayModeCopy.startFailure(reason))
       add("DisplayModeCopy.startFailureDiagnostic(reason)", DisplayModeCopy.startFailureDiagnostic(reason))
+      add(
+        "DisplayModeCopy.startFailureSubject(reason)",
+        DisplayModeCopy.startFailureSubject(displayName: "MAG 341C OLED", reason: reason))
+    }
+    for achieved: OnboardingAchievedSize in [
+      .size(width: 1920, height: 1080, refreshHz: 30), .unreadable,
+    ] {
+      add("OnboardingSizePage.achievedCaption", OnboardingSizePage.achievedCaption(achieved))
     }
     for notice in Self.allModeReapplyNotices {
       add(
@@ -1228,8 +1346,14 @@ struct CopyBuilderTests {
     }
   }
 
+  /// Both shapes of `.failed`: the sentence and the tooltip each branch on
+  /// whether a commit went through, so one sample cannot cover the pair.
   private static let allStartFailureReasons: [DisplayModeCoordinator.StartFailure.Reason] =
-    [.failed(DisplayConfigError(cgErrorCode: 1001))]
+    [
+      .failed(DisplayConfigError(cgErrorCode: 1001)),
+      .failed(DisplayConfigError(unhonouredCommit: .init(requested: mode, achieved: landedMode))),
+      .failed(DisplayConfigError(unhonouredCommit: .init(requested: mode, achieved: nil))),
+    ]
       + ReconfigurationClaimant.allCases.map { .blocked(by: $0) }
 
   private static func guardStartFailureReason(_ reason: DisplayModeCoordinator.StartFailure.Reason) -> Int {

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -1326,7 +1326,8 @@ struct CopyBuilderTests {
     }
   }
 
-  private static let allReadEvidence: [DDCReadEvidence] = [.notAttempted, .answered, .allZeros, .noReply]
+  private static let allReadEvidence: [DDCReadEvidence] =
+    [.notAttempted, .answered, .allZeros, .noReply, .refused]
 
   private static func guardReadEvidence(_ evidence: DDCReadEvidence) -> Int {
     switch evidence {
@@ -1334,6 +1335,7 @@ struct CopyBuilderTests {
     case .answered: 1
     case .allZeros: 2
     case .noReply: 3
+    case .refused: 4
     }
   }
 
@@ -1493,7 +1495,7 @@ struct CopyBuilderTests {
     #expect(Set(Self.allApplyNotices.map(Self.guardApplyNotice)).count == 2)
     #expect(Set(Self.allProblemShapes.flatMap { $0 }.map(Self.guardProblem)).count == 2)
     #expect(Set(Self.allBrightnessPaths.map(Self.guardBrightnessPath)).count == 8)
-    #expect(Set(Self.allReadEvidence.map(Self.guardReadEvidence)).count == 4)
+    #expect(Set(Self.allReadEvidence.map(Self.guardReadEvidence)).count == 5)
     #expect(Set(Self.allMirrorRefusals.map(Self.guardMirrorRefusal)).count == 8)
     #expect(Set(Self.allRotationRefusals.map(Self.guardRotationRefusal)).count == 6)
     #expect(Set(Self.allModeReapplyNotices.map(Self.guardModeReapplyNotice)).count == 3)

--- a/CandelaAppTests/Fakes/SynthesisFakes.swift
+++ b/CandelaAppTests/Fakes/SynthesisFakes.swift
@@ -171,6 +171,8 @@ final class FakeSynthesisDisplayConfigurator: DisplayConfiguring, @unchecked Sen
   var onMirrorApplied: (@Sendable () -> Void)?
   /// Throw from `apply`, to reach the engage tail's bounce fallback.
   var refusesModeApplies = false
+  /// A committed mode failure for coordinator recovery tests, consumed once.
+  var nextModeApplyFailure: DisplayConfigError?
 
   init(_ world: FakeDisplayWorld) { self.world = world }
 
@@ -196,6 +198,16 @@ final class FakeSynthesisDisplayConfigurator: DisplayConfiguring, @unchecked Sen
   func apply(_ mode: DisplayMode, to displayID: CGDirectDisplayID, scope _: DisplayConfigScope) throws {
     if refusesModeApplies { throw DisplayConfigError(cgErrorCode: CGError.failure.rawValue) }
     world.recordApply(mode, to: displayID)
+    if let failure = nextModeApplyFailure {
+      nextModeApplyFailure = nil
+      if let achieved = failure.unhonouredCommit?.achieved,
+         let display = world.displays().first(where: { $0.id == displayID }) {
+        world.attach(
+          display, modes: world.modes(for: displayID), current: achieved,
+          nativePixels: world.nativePixels(for: displayID))
+      }
+      throw failure
+    }
   }
 
   func applyMirroring(_ changes: [MirrorChange], scope _: DisplayConfigScope) throws {

--- a/CandelaAppTests/OnboardingFlowModelTests.swift
+++ b/CandelaAppTests/OnboardingFlowModelTests.swift
@@ -78,6 +78,87 @@ struct OnboardingFlowModelTests {
     #expect(model.committed.isEmpty)
   }
 
+  // MARK: - What the display is actually showing
+
+  /// The unhonoured commit reaches the page. Without it the setup window asks
+  /// "keep it?" over a glyph naming a size the display is not showing, and the
+  /// person answering has no way to see the difference.
+  @Test func anAchievedSizeReportedWithATickReachesThePage() {
+    let model = modelOnSizePage()
+    model.applySize(displayKey: "dell", choice: .recommended)
+    // The ordinary case reports nothing, so no caption is drawn.
+    #expect(model.pendingAchievedSize(forKey: "dell") == nil)
+
+    model.applyCountdownTicked(
+      secondsRemaining: 12, achieved: .size(width: 1920, height: 1080, refreshHz: 30))
+    #expect(model.applyState == .counting(secondsRemaining: 12))
+    #expect(model.pendingAchievedSize(forKey: "dell")
+      == .size(width: 1920, height: 1080, refreshHz: 30))
+    // The question is still about the size that was asked for: the glyph reads
+    // this, and Keep re-applies it.
+    #expect(model.pendingAppliedSize(forKey: "dell")?.width == 2560)
+    // One display's divergence never captions another display's page.
+    #expect(model.pendingAchievedSize(forKey: "mag") == nil)
+  }
+
+  /// A commit that went through and could not be read back is its own case: a
+  /// failed readback is not evidence the size arrived, so it must not report as
+  /// the ordinary nothing-to-say.
+  @Test func anUnreadableAchievedSizeIsCarriedRatherThanDropped() {
+    let model = modelOnSizePage()
+    model.applySize(displayKey: "dell", choice: .recommended)
+    model.applyCountdownTicked(secondsRemaining: 12, achieved: .unreadable)
+    #expect(model.pendingAchievedSize(forKey: "dell") == .unreadable)
+  }
+
+  /// Reported per tick, so a later tick with nothing to say retires the caption
+  /// rather than leaving a sentence about a resolution no longer on the glass.
+  @Test func aLaterTickWithNothingToSayRetiresTheAchievedSize() {
+    let model = modelOnSizePage()
+    model.applySize(displayKey: "dell", choice: .recommended)
+    model.applyCountdownTicked(
+      secondsRemaining: 12, achieved: .size(width: 1920, height: 1080, refreshHz: 30))
+    model.applyCountdownTicked(secondsRemaining: 11)
+    #expect(model.pendingAchievedSize(forKey: "dell") == nil)
+  }
+
+  /// Every way an apply ends drops it, so the next question starts clean.
+  @Test func endingAnApplyDropsTheAchievedSize() {
+    for end in ["keep", "revert", "fail", "pick again"] {
+      let model = modelOnSizePage()
+      model.applySize(displayKey: "dell", choice: .recommended)
+      model.applyCountdownTicked(
+        secondsRemaining: 12, achieved: .size(width: 1920, height: 1080, refreshHz: 30))
+      switch end {
+      // A keep advances, and the per-apply state resets on navigation.
+      case "keep": model.applyKept()
+      case "revert": model.applyReverted()
+      case "fail": model.applyFailed()
+      default: model.applySize(displayKey: "dell", choice: .recommended)
+      }
+      #expect(model.pendingAchievedSize(forKey: "dell") == nil, "ended by \(end)")
+    }
+  }
+
+  /// The page's own mapping, so the setup window cannot word this differently
+  /// from the settings banner, the floating card and the menu bar. In this
+  /// page's dialect: it writes every size with an x and calls it a size, and a
+  /// caption arriving in the app windows' spelling reads as a line from
+  /// somewhere else.
+  @Test func theSizePageSpeaksTheSharedAchievedSentenceInItsOwnDialect() {
+    let named = OnboardingSizePage.achievedCaption(
+      .size(width: 1920, height: 1080, refreshHz: 30))
+    #expect(named == DisplayModeCopy.achievedGeometry(
+      width: 1920, height: 1080, refreshHz: 30, dialect: .size))
+    #expect(named.contains("1920 x 1080"))
+    #expect(!named.contains("×"))
+
+    let unreadable = OnboardingSizePage.achievedCaption(.unreadable)
+    #expect(unreadable == DisplayModeCopy.unreadableAchievedGeometry(dialect: .size))
+    #expect(unreadable.contains("size"))
+    #expect(!unreadable.contains("resolution"))
+  }
+
   @Test func keepRecordsTheChoiceEmitsTheRecordAndAdvances() {
     let model = modelOnSizePage()
     let pageIndex = model.index

--- a/CandelaAppTests/OnboardingFlowModelTests.swift
+++ b/CandelaAppTests/OnboardingFlowModelTests.swift
@@ -94,11 +94,34 @@ struct OnboardingFlowModelTests {
     #expect(model.applyState == .counting(secondsRemaining: 12))
     #expect(model.pendingAchievedSize(forKey: "dell")
       == .size(width: 1920, height: 1080, refreshHz: 30))
-    // The question is still about the size that was asked for: the glyph reads
-    // this, and Keep re-applies it.
+    // The glyph still identifies the requested size, while recovery explains
+    // that it did not arrive.
     #expect(model.pendingAppliedSize(forKey: "dell")?.width == 2560)
     // One display's divergence never captions another display's page.
     #expect(model.pendingAchievedSize(forKey: "mag") == nil)
+  }
+
+  @Test func recoveryCountdownNeverOffersKeepAndSpentCountdownOffersRetry() {
+    #expect(!OnboardingSizePage.countdownCaption(seconds: 12, canKeep: false).contains("keep"))
+    #expect(OnboardingSizePage.countdownCaption(seconds: 12, canKeep: false).contains("12s"))
+    #expect(OnboardingSizePage.countdownCaption(seconds: 0, canKeep: false).contains("Choose Revert"))
+    #expect(!OnboardingSizePage.countdownCaption(seconds: 0, canKeep: false).contains("0s"))
+    #expect(OnboardingSizePage.countdownCaption(seconds: 12, canKeep: true).contains("unless you keep it"))
+  }
+
+  @Test func anUnverifiedSizeAllowsOnlyRevert() {
+    let model = modelOnSizePage()
+    var keeps = 0
+    var reverts = 0
+    model.onKeepSize = { keeps += 1 }
+    model.onRevertSize = { reverts += 1 }
+    model.applySize(displayKey: "dell", choice: .recommended)
+    model.applyCountdownTicked(secondsRemaining: 12, achieved: .unreadable)
+    model.keepSize()
+    model.revertSize()
+    #expect(keeps == 0)
+    #expect(reverts == 1)
+    #expect(model.sizeChoices["dell"] == nil)
   }
 
   /// A commit that went through and could not be read back is its own case: a

--- a/CandelaAppTests/PreviewSurfaceOwnershipTests.swift
+++ b/CandelaAppTests/PreviewSurfaceOwnershipTests.swift
@@ -39,6 +39,18 @@ struct PreviewSurfaceOwnershipTests {
     )
   }
 
+  @Test func everySurfaceOffersKeepOnlyForAVerifiedPreview() {
+    for surface in [DisplayModeCoordinator.PreviewSurface.settingsBanner, .floatingPanel, .guidedSetup] {
+      var preview = Self.preview(surface: surface)
+      #expect(preview.canKeep)
+      preview.unhonouredCommit = .init(requested: Self.mode, achieved: nil)
+      #expect(!preview.canKeep)
+      preview.failure = DisplayConfigError(cgErrorCode: 1001)
+      #expect(!preview.canKeep)
+      #expect(!DisplayModeCopy.previewTitle(canKeep: preview.canKeep).contains("Keep"))
+    }
+  }
+
   // MARK: - The settings banner (BannerRegion.countdownForm)
 
   /// Both stack states, because the answerable placement follows the navigation
@@ -131,4 +143,64 @@ private final class FakeModeConfirmation: ModeConfirmationPresenting {
 
   func presentConfirmation(_ content: ModeConfirmationContent) { presented.append(content) }
   func dismissConfirmation() { dismissals += 1 }
+}
+
+extension PreviewSurfaceOwnershipTests {
+  @Test func coordinatorKeepsLatestRecoveryEvidenceAcrossFailures() async throws {
+    let fixture = SynthesisFixture(optedIn: false)
+    defer { fixture.forgetPrefs() }
+    let displayID = SynthesisFixture.panelID
+    let original = try #require(fixture.configurator.currentMode(for: displayID))
+    let requested = try #require(fixture.modes.catalogs[displayID]?.all.first { !$0.isNative })
+    let first = DisplayMode(
+      ioModeID: 80, logicalWidth: 1920, logicalHeight: 804,
+      pixelWidth: 3840, pixelHeight: 1608, refreshHz: 60, isNative: false)
+    let second = DisplayMode(
+      ioModeID: 81, logicalWidth: 1280, logicalHeight: 536,
+      pixelWidth: 2560, pixelHeight: 1072, refreshHz: 60, isNative: false)
+    fixture.configurator.nextModeApplyFailure = DisplayConfigError(
+      unhonouredCommit: .init(requested: requested, achieved: first))
+    fixture.modes.select(requested, on: displayID, from: .settings, surface: .settingsBanner)
+    await fixture.settle()
+    let recovery = try #require(fixture.modes.preview)
+    #expect(!recovery.canKeep)
+    #expect(recovery.unhonouredCommit?.achieved == first)
+
+    fixture.configurator.nextModeApplyFailure = DisplayConfigError(
+      unhonouredCommit: .init(requested: original, achieved: second))
+    _ = await fixture.modes.revert(recovery)
+    #expect(fixture.modes.preview?.unhonouredCommit?.achieved == second)
+    fixture.configurator.refusesModeApplies = true
+    _ = await fixture.modes.revert(recovery)
+    #expect(fixture.modes.preview?.unhonouredCommit?.achieved == second)
+    let beforeKeep = fixture.configurator.applies.count
+    #expect(await fixture.modes.confirm(recovery) != .committed)
+    #expect(fixture.configurator.applies.count == beforeKeep)
+    #expect(fixture.modes.preview?.isCountingDown == true)
+    fixture.configurator.refusesModeApplies = false
+    #expect(await fixture.modes.revert(recovery) == .reverted)
+    #expect(fixture.configurator.applies.last?.mode == original)
+  }
+
+  @Test func coordinatorDoesNotStripTheRecoveryAnswerBeforeAFreshSameModePreview() async throws {
+    let fixture = SynthesisFixture(optedIn: false)
+    defer { fixture.forgetPrefs() }
+    let displayID = SynthesisFixture.panelID
+    let requested = try #require(fixture.modes.catalogs[displayID]?.all.first { !$0.isNative })
+    let original = try #require(fixture.configurator.currentMode(for: displayID))
+    fixture.configurator.nextModeApplyFailure = DisplayConfigError(
+      unhonouredCommit: .init(requested: requested, achieved: original))
+    fixture.modes.select(requested, on: displayID, from: .settings, surface: .settingsBanner)
+    await fixture.settle()
+    let oldAnswer = try #require(fixture.modes.preview)
+    fixture.modes.select(requested, on: displayID, from: .settings, surface: .settingsBanner)
+    await fixture.settle()
+    let fresh = try #require(fixture.modes.preview)
+    #expect(fresh.canKeep)
+    let before = fixture.configurator.applies.count
+    #expect(await fixture.modes.confirm(oldAnswer) == .stale)
+    #expect(fixture.configurator.applies.count == before)
+    #expect(fixture.modes.preview != nil)
+    #expect(await fixture.modes.confirm(fresh) == .committed)
+  }
 }

--- a/CandelaAppTests/PreviewSurfaceOwnershipTests.swift
+++ b/CandelaAppTests/PreviewSurfaceOwnershipTests.swift
@@ -26,7 +26,8 @@ struct PreviewSurfaceOwnershipTests {
     DisplayModeCoordinator.Preview(
       displayID: displayID, mode: mode, surface: surface,
       secondsRemaining: isCountingDown ? 21 : 0, failure: nil,
-      isCountingDown: isCountingDown, synthesized: nil, synthesisFailure: nil
+      isCountingDown: isCountingDown, unhonouredCommit: nil,
+      synthesized: nil, synthesisFailure: nil
     )
   }
 

--- a/CandelaAppTests/SettingsActionsFanOutTests.swift
+++ b/CandelaAppTests/SettingsActionsFanOutTests.swift
@@ -1,0 +1,67 @@
+import CandelaKit
+import Testing
+
+// The app half of the propagation seam: `PrefPropagation` decides which effects a
+// pref carries and the engine suite pins that table; this asserts `SettingsActions`
+// actually runs them. `.restartBrightnessPoll` rebuilds a job nothing here can
+// read, so it is a hardware leg: turn sync on with nothing open and watch an
+// external follow the built-in without waiting out the slow interval.
+@Suite("Settings actions fan-out") @MainActor
+struct SettingsActionsFanOutTests {
+  private final class Counts {
+    var rearmTap = 0
+    var recheckPermissions = 0
+    var updateStatusItem = 0
+  }
+
+  private func makeActions(_ model: AppModel) -> (SettingsActions, Counts) {
+    let counts = Counts()
+    let actions = SettingsActions(model: model)
+    actions.rearmTap = { counts.rearmTap += 1 }
+    actions.recheckPermissions = { counts.recheckPermissions += 1 }
+    actions.updateStatusItem = { counts.updateStatusItem += 1 }
+    return (actions, counts)
+  }
+
+  @Test func aKeyModeWriteRearmsTheTapAndRechecksTheGrant() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    actions.prefDidChange(.keyboardBrightness)
+    #expect(counts.rearmTap == 1)
+    #expect(counts.recheckPermissions == 1)
+    #expect(counts.updateStatusItem == 0)
+  }
+
+  /// The control: a presentation-only pref must reach neither the tap nor the
+  /// permission check, or the assertions above pass for everything.
+  @Test func aPresentationPrefReachesNeitherOfThem() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    actions.prefDidChange(.showContrast)
+    #expect(counts.rearmTap == 0)
+    #expect(counts.recheckPermissions == 0)
+  }
+
+  /// A batch fans out the UNION, which is no single member's row.
+  @Test func aBatchFansOutEveryMembersEffects() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    actions.prefsDidChange([.keyboardBrightness, .hideDisplay])
+    #expect(counts.rearmTap == 1)
+    #expect(counts.recheckPermissions == 1)
+    #expect(counts.updateStatusItem == 1)
+  }
+
+  /// Turning brightness sync on carries the poll restart and nothing that writes
+  /// hardware. What is observable here is that it goes through the seam at all and
+  /// invalidates the surfaces; the restart itself is the hardware leg above.
+  @Test func turningSyncOnGoesThroughTheSeam() {
+    let model = TestFixtures.appModel()
+    let (actions, counts) = makeActions(model)
+    let before = model.prefsRevision
+    actions.prefDidChange(.enableBrightnessSync)
+    #expect(model.prefsRevision > before)
+    #expect(counts.rearmTap == 0)
+    #expect(counts.recheckPermissions == 0)
+  }
+}

--- a/CandelaAppTests/SettingsVisibilitySignalTests.swift
+++ b/CandelaAppTests/SettingsVisibilitySignalTests.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Testing
+
+/// The settings window's poll-consumer signal.
+///
+/// The window's own answer wins wherever there is one; activation is the fallback
+/// for the moment before a window has attached, and on its own it cannot tell a
+/// settings page open beside another app from a closed one (every window of a
+/// non-frontmost app reports `.inactive`).
+///
+/// The occlusion observation that produces the window's answer is AppKit window
+/// lifecycle no bundle test reaches. Its hardware leg: leave Settings open beside
+/// another frontmost app, move brightness in Control Center, and watch the hero
+/// slider follow within about a second rather than at the next slow tick.
+@Suite("Settings visibility signal") @MainActor
+struct SettingsVisibilitySignalTests {
+  private func onScreen(_ windowVisibility: Bool?, _ activeState: ControlActiveState) -> Bool {
+    SettingsRootView.isSettingsOnScreen(
+      windowVisibility: windowVisibility, activeState: activeState)
+  }
+
+  /// The finding this shape exists for.
+  @Test func aWindowThatSaysItIsOnScreenIsOnScreenWhileTheAppIsBehindAnother() {
+    #expect(onScreen(true, .inactive))
+  }
+
+  /// The other direction, and the one that pays for itself: a fully covered or
+  /// closed window is off screen however active the app is.
+  @Test func aWindowThatSaysItIsCoveredIsOffScreenHoweverActiveTheAppIs() {
+    #expect(onScreen(false, .key) == false)
+    #expect(onScreen(false, .active) == false)
+    #expect(onScreen(false, .inactive) == false)
+  }
+
+  /// Until a window has attached there is nothing to ask, so activation answers.
+  @Test func activationAnswersOnlyWhileNoWindowHasAttached() {
+    #expect(onScreen(nil, .key))
+    #expect(onScreen(nil, .active))
+    #expect(onScreen(nil, .inactive) == false)
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -601,10 +601,8 @@ public final class BrightnessController: PendingWireDraining {
     return value
   }
 
-  /// Quantization noise on a native read: Control Center's slider granularity plus
-  /// the float round-trip through DisplayServices. Same size and same reason as the
-  /// poller's echo tolerance; anything smaller is not a move somebody made.
-  private static let nativeReadNoise = 0.008
+  /// Shared with the poller's echo discard: both measure the same quantization noise.
+  private static let nativeReadNoise = BrightnessPoller.defaultTolerance
 
   /// Snaps published state onto the panel's live native value before a `step()`.
   /// The poller's idle cadence can leave that state tens of seconds stale, and a

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -604,17 +604,32 @@ public final class BrightnessController: PendingWireDraining {
   /// Shared with the poller's echo discard: both measure the same quantization noise.
   private static let nativeReadNoise = BrightnessPoller.defaultTolerance
 
+  /// The guarded native read both freshness routes take. Nil means there is nothing
+  /// to publish: no read is trustworthy right now, or published state already agrees
+  /// with the glass.
+  private func freshNativeRead() -> Double? {
+    // Under a temporary dim the read is our own write; folding it in corrupts what
+    // `endTemporaryDim` restores.
+    guard isNativeActive(), temporaryDimFactor == nil else { return nil }
+    // Mid-reconfigure and asleep, display state is being rebuilt and every read is
+    // suspect. The poller skips its whole tick on this same gate.
+    guard isWireOpen else { return nil }
+    // A key repeat can outrun the drain: with our own write still queued the panel
+    // has not moved yet, so reading here would snap published state back to the
+    // value the previous press just left and the repeat would re-step from it.
+    guard issuedGeneration <= coalescer.completedThrough() else { return nil }
+    guard let read = backends.readNative?(displayID) else { return nil }
+    let clamped = min(max(Double(read), 0), 1)
+    guard abs(clamped - brightness) > Self.nativeReadNoise else { return nil }
+    return clamped
+  }
+
   /// Snaps published state onto the panel's live native value before a `step()`.
   /// The poller's idle cadence can leave that state tens of seconds stale, and a
   /// step from it jumps a Control Center move back. Native path only, so never the
   /// DDC wire. No persist: the `step()` that follows writes the final value.
   public func syncFromNativeBeforeStep() {
-    // Under a temporary dim the read is our own write; folding it in corrupts what
-    // `endTemporaryDim` restores.
-    guard isNativeActive(), temporaryDimFactor == nil else { return }
-    guard let read = backends.readNative?(displayID) else { return }
-    let clamped = min(max(Double(read), 0), 1)
-    guard abs(clamped - brightness) > Self.nativeReadNoise else { return }
+    guard let clamped = freshNativeRead() else { return }
     brightness = clamped
     // Retire any adoption queued from an earlier poll tick; it describes an older read.
     echo.withLock { state in
@@ -622,6 +637,39 @@ public final class BrightnessController: PendingWireDraining {
       state.generation &+= 1
       state.converging = false
     }
+  }
+
+  /// The same read for a SURFACE about to draw (the menu-bar panel opening), which
+  /// has no `step()` behind it to write the value down.
+  ///
+  /// Takes the poller's adoption route rather than a bare snap: publish, persist,
+  /// and return the delta so the caller can fan it out to the other displays when
+  /// brightness sync is on. A bare snap published a value the store never saw and
+  /// stamped the echo slot with it, so the poller then discarded the panel's real
+  /// value as an echo of ours and the store kept a stale number for the launch
+  /// restore to write back to the glass.
+  ///
+  /// It snaps where `adoptExternal` eases: the easing exists so a continuous
+  /// Control Center drag does not step the other displays in jumps, and a surface
+  /// opening is one discrete event whose first frame has to be right.
+  ///
+  /// Returns 0 when nothing was adopted, the panel opening being the common case.
+  @discardableResult
+  public func adoptNativeForSurface() -> Double {
+    // A convergence in flight belongs to the poller, which lands it within a few
+    // ticks; ending it here would stop it fanning the rest of the move out.
+    guard !isConvergingFromExternal() else { return 0 }
+    guard let clamped = freshNativeRead() else { return 0 }
+    let previous = brightness
+    brightness = clamped
+    persist(clamped)
+    // Retire any adoption queued from an earlier poll tick; it describes an older read.
+    echo.withLock { state in
+      state.value = clamped
+      state.generation &+= 1
+      state.converging = false
+    }
+    return clamped - previous
   }
 
   // MARK: - Path selection
@@ -2352,6 +2400,15 @@ actor BrightnessWriteCoalescer {
     )
 
   private var completedGeneration: UInt64 = 0
+  /// Lock-backed mirror of `completedGeneration`, for readers that cannot suspend:
+  /// the freshness read runs on the key path, where an executor hop into this actor
+  /// would land after the key repeat it exists to protect.
+  ///
+  /// It mirrors the COMPLETED counter and not `appliedGeneration` because a failed
+  /// or epoch-skipped write never advances the applied one, so a reader gating on
+  /// that would stay gated for the rest of the session on a display whose wire went
+  /// quiet.
+  private nonisolated let completedMirror = OSAllocatedUnfairLock<UInt64>(initialState: 0)
   /// The highest generation that actually reached hardware, was skipped because
   /// its exact target was already there, or was superseded by a newer write
   /// that did one of those. Compare it against the submitter's own counter to
@@ -2458,6 +2515,11 @@ actor BrightnessWriteCoalescer {
   /// See `appliedGeneration`. Read AFTER a `waitUntilCompleted` for the
   /// generation in question, or it answers about a queue still in flight.
   func appliedThrough() -> UInt64 { appliedGeneration }
+
+  /// The highest generation the queue has finished with, applied or skipped, read
+  /// without an executor hop. `submissionMark`-style comparison against the
+  /// submitter's own counter answers "is a write of ours still in the queue".
+  nonisolated func completedThrough() -> UInt64 { completedMirror.withLock { $0 } }
 
   func waitUntilCompleted(through generation: UInt64) async {
     guard generation > completedGeneration else { return }
@@ -2572,6 +2634,8 @@ actor BrightnessWriteCoalescer {
 
   private func complete(_ generation: UInt64) {
     completedGeneration = max(completedGeneration, generation)
+    let completed = completedGeneration
+    completedMirror.withLock { $0 = completed }
     resumeSatisfiedWaiters()
   }
 

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -621,6 +621,9 @@ public final class BrightnessController: PendingWireDraining {
     guard let read = backends.readNative?(displayID) else { return nil }
     let clamped = min(max(Double(read), 0), 1)
     guard abs(clamped - brightness) > Self.nativeReadNoise else { return nil }
+    // The display moved outside our write path. A step back to the last successful
+    // target must reach hardware, even if a surface adopts this read before the key.
+    coalescer.resetDuplicateState()
     return clamped
   }
 

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -106,19 +106,25 @@ public final class BrightnessController: PendingWireDraining {
   /// not the worst thing ever observed on this display:
   ///
   /// - A pass that attempts nothing must not touch it. `refreshFromHardware` returns
-  ///   early under the native path, `unavailableDDC` and role `.builtIn`, so the
-  ///   assignments below sit AFTER every such return. Otherwise a display that
-  ///   answered zeros once looks pristine again because the next pass never reached
-  ///   the wire.
+  ///   early under the native path, `unavailableDDC`, role `.builtIn` and a standing
+  ///   silent verdict (below), so the assignments sit AFTER every such return.
+  ///   Otherwise a display that answered zeros once looks pristine again because the
+  ///   next pass never reached the wire.
   /// - A pass that does ask supersedes the previous pass's verdict. A worst-wins fold
   ///   across passes reads "this display does not reply" about a panel that just
   ///   replied. `worse` is still exactly right WITHIN a pass and across this display's
   ///   sibling controllers (`DDCReadEvidence.worst`); the scope of the fold was wrong,
   ///   never the ordering.
+  /// - It GATES the asking as well as recording it, so the clears carry as much
+  ///   weight as the assignments. `noReply` and `allZeros` stop `refreshFromHardware`
+  ///   at the top: a panel that said nothing is asked once per plug rather than on
+  ///   every menu close, and it gets another hearing only from wake, a
+  ///   reconfiguration, a rebind onto a different panel, or an HDR window closing.
+  ///   Nothing else in a session asks it again.
   ///
-  /// This controller reads one code, once, per pass, so the within-pass fold here is
-  /// trivial and the assignments are plain. `DDCValueController`, which retries, has
-  /// to spell the fold out.
+  /// This controller reads one code, at most once, per pass, so the within-pass fold
+  /// here is trivial and the assignments are plain. `DDCValueController`, which
+  /// retries, has to spell the fold out.
   public private(set) var readEvidence: DDCReadEvidence = .notAttempted
 
   /// Whether this display's DDC wire has stopped carrying writes
@@ -499,27 +505,37 @@ public final class BrightnessController: PendingWireDraining {
     guard !usesNative else { return }
     let tuning = prefs.tuning(for: .brightness)
     guard !tuning.unavailableDDC else { return }
+    // Asked once per plug, the same rule the capabilities probe follows and for
+    // the same reason: a panel that said nothing does not start answering between
+    // two menu closes, and every futile pass now walks the full retry ladder with
+    // the wire held, which is the menu-close stall a person feels. THIS
+    // controller's own verdict, never the folded worst across its display's
+    // siblings: volume and contrast can be silent on a panel whose brightness
+    // register answers. Cleared wherever the panel may have changed its mind, so
+    // the skip cannot outlive its cause.
+    switch readEvidence {
+    case .noReply, .allZeros: return
+    case .notAttempted, .answered: break
+    }
     // Fork parity: reads use only the FIRST remap code.
     //
     // Three named outcomes, so "the panel never replied" and "the panel replied
     // with zeros" do not collapse into the same silence. Only the second is the
-    // MAG 341C's write-only signature, and the diagnostics pane has to say which
-    // happened.
+    // write-only signature, and the diagnostics pane has to say which happened.
+    // The transport's reply sentinel is what tells them apart.
     //
     // Assignment, not a fold against the previous value: everything above this line
     // has already returned for the passes that ask nothing, so reaching here means
     // the panel WAS asked and this pass's answer is the current fact about it.
     // Folding across passes published "does not reply" about panels that had since
     // replied (see `readEvidence`).
-    guard let result = await writer.read(command: tuning.remapCodes.first ?? VCP.brightness) else {
-      readEvidence = .noReply
-      return
-    }
-    // `(0, 0)` and `max == 0` are FAILED reads, not a brightness of zero: the
-    // MAG341C answers every read this way, and the fork's unvalidated read clobbers
-    // saved values to 0. Recorded rather than merely rejected.
-    guard result.max > 0 else {
-      readEvidence = .allZeros
+    let outcome = await writer.readOutcome(command: tuning.remapCodes.first ?? VCP.brightness)
+    // A `max` of 0 is a FAILED read, not a brightness of zero: the fork's
+    // unvalidated read clobbers saved values to 0. Recorded rather than merely
+    // rejected, and it publishes `allZeros` like a buffer of zeros does, because
+    // it is the same admission.
+    guard let result = outcome.value, result.max > 0 else {
+      readEvidence = outcome.evidence
       return
     }
     readEvidence = .answered
@@ -820,6 +836,11 @@ public final class BrightnessController: PendingWireDraining {
   /// told us nothing yet.
   public func noteWake() {
     resetWireHealth()
+    // The read verdict deserves the same fresh hearing the wire health gets: a
+    // link rebuilt while the Mac slept has told us nothing yet, and without this
+    // one silent pass before a sleep would mean the panel is never asked again
+    // for the life of the plug.
+    readEvidence = .notAttempted
   }
 
   /// Where this display's pixels actually are: itself, or its mirror master. Read
@@ -1550,6 +1571,12 @@ public final class BrightnessController: PendingWireDraining {
     // moment a wire that stopped answering deserves to be asked again.
     let wasUnresponsive = isWireUnresponsive
     resetWireHealth()
+    // Same event, same reason, for the read verdict, and this is the only route
+    // that covers a REPLUG of the same monitor: `rebind` clears the verdict when
+    // the panel identity changes, and a new cable or a new port on the panel that
+    // was already here changes nothing it compares. Placed above the early
+    // returns below, which are about the dimming legs.
+    readEvidence = .notAttempted
     if wasUnresponsive, !usesNative {
       // The transition already ran the full reapply-after-pref-change re-evaluation,
       // which covers the
@@ -1641,6 +1668,12 @@ public final class BrightnessController: PendingWireDraining {
         "HDR window closed on display=\(self.displayID): dropping the wire's duplicate memos"
       )
       invalidateWireMemos()
+      // A silent verdict earned while HDR held the register is a fact about the
+      // window, not about the panel: DDC was dead, so the panel was never really
+      // asked, and the read skip would otherwise carry that answer for the rest
+      // of the plug. Same carve-out the capabilities probe makes for the same
+      // reason (`CapabilityProbePolicy`).
+      readEvidence = .notAttempted
     }
     updateNativeActive()
   }
@@ -1796,8 +1829,10 @@ public final class BrightnessController: PendingWireDraining {
   /// limitation is inherited: identical twins can share an EDID UUID and are not told
   /// apart here, though they already share a saved value and a prefs domain. The cost
   /// of the narrower trigger is that the SAME panel rebound through a DDC-hostile new
-  /// route keeps its old verdict until the next read pass supersedes it, which here is
-  /// the very next refresh.
+  /// route keeps its old verdict, and a silent one now GATES the next read, so no
+  /// later refresh would supersede it either. `handleReconfigure` is what covers that
+  /// case: a new cable or a new port arrives as a reconfiguration whether or not the
+  /// panel identity moved, and the verdict is cleared there.
   public func rebind(writer: any DDCWriting, panelIdentity: String?) {
     self.writer = writer
     if panelIdentity != boundPanelIdentity {

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -115,17 +115,21 @@ public final class BrightnessController: PendingWireDraining {
   ///   replied. `worse` is still exactly right WITHIN a pass and across this display's
   ///   sibling controllers (`DDCReadEvidence.worst`); the scope of the fold was wrong,
   ///   never the ordering.
-  /// - It GATES the asking as well as recording it, so the clears carry as much
-  ///   weight as the assignments. `noReply` and `allZeros` stop `refreshFromHardware`
-  ///   at the top: a panel that said nothing is asked once per plug rather than on
-  ///   every menu close, and it gets another hearing only from wake, a
-  ///   reconfiguration, a rebind onto a different panel, or an HDR window closing.
-  ///   Nothing else in a session asks it again.
+  /// - It does NOT gate the asking. `DDCReadSkipLatch` does, on two consecutive
+  ///   silent passes rather than on this value, so one bad pass still publishes the
+  ///   verdict diagnostics needs while the panel keeps its next hearing. Once the
+  ///   latch is set the panel is asked once per plug rather than on every menu
+  ///   close, and it gets another hearing only from wake, a reconfiguration, a
+  ///   rebind onto a different panel, or an HDR window closing.
   ///
   /// This controller reads one code, at most once, per pass, so the within-pass fold
   /// here is trivial and the assignments are plain. `DDCValueController`, which
   /// retries, has to spell the fold out.
   public private(set) var readEvidence: DDCReadEvidence = .notAttempted
+
+  /// Whether this display's reads are still worth attempting. Cleared with
+  /// `readEvidence` at every route that gives the panel another hearing.
+  @ObservationIgnored private var readSkip = DDCReadSkipLatch()
 
   /// Whether this display's DDC wire has stopped carrying writes
   /// (`DDCWireHealth`). An observable mirror of the health the coalescer
@@ -505,18 +509,11 @@ public final class BrightnessController: PendingWireDraining {
     guard !usesNative else { return }
     let tuning = prefs.tuning(for: .brightness)
     guard !tuning.unavailableDDC else { return }
-    // Asked once per plug, the same rule the capabilities probe follows and for
-    // the same reason: a panel that said nothing does not start answering between
-    // two menu closes, and every futile pass now walks the full retry ladder with
-    // the wire held, which is the menu-close stall a person feels. THIS
-    // controller's own verdict, never the folded worst across its display's
-    // siblings: volume and contrast can be silent on a panel whose brightness
-    // register answers. Cleared wherever the panel may have changed its mind, so
-    // the skip cannot outlive its cause.
-    switch readEvidence {
-    case .noReply, .allZeros: return
-    case .notAttempted, .answered: break
-    }
+    // Two silent passes and the panel is asked once per plug: every futile pass
+    // holds the wire for the full retry ladder, which is the menu-close stall a
+    // person feels. This controller's own verdict, not the siblings' fold: volume
+    // can be silent on a panel whose brightness register answers.
+    guard !readSkip.skipsRead else { return }
     // Fork parity: reads use only the FIRST remap code.
     //
     // Three named outcomes, so "the panel never replied" and "the panel replied
@@ -530,6 +527,8 @@ public final class BrightnessController: PendingWireDraining {
     // Folding across passes published "does not reply" about panels that had since
     // replied (see `readEvidence`).
     let outcome = await writer.readOutcome(command: tuning.remapCodes.first ?? VCP.brightness)
+    // One read per pass here, so the pass's verdict IS this attempt's.
+    readSkip.record(outcome.evidence)
     // A `max` of 0 is a FAILED read, not a brightness of zero: the fork's
     // unvalidated read clobbers saved values to 0. Recorded rather than merely
     // rejected, and it publishes `allZeros` like a buffer of zeros does, because
@@ -838,9 +837,35 @@ public final class BrightnessController: PendingWireDraining {
     resetWireHealth()
     // The read verdict deserves the same fresh hearing the wire health gets: a
     // link rebuilt while the Mac slept has told us nothing yet, and without this
-    // one silent pass before a sleep would mean the panel is never asked again
+    // two silent passes before a sleep would mean the panel is never asked again
     // for the life of the plug.
+    giveTheReadAnotherHearing()
+  }
+
+  /// Drops what this display's reads have proved, across its whole wire, but
+  /// only where a read can follow.
+  ///
+  /// Under the native path (an HDR window, or a panel driven by
+  /// DisplayServices) `refreshFromHardware` returns before reaching the wire, so
+  /// clearing here would replace a real write-only verdict with "nothing
+  /// attempted" in the diagnostics report and no pass would put it back for as
+  /// long as the window lasts. The HDR-off edge is that panel's next hearing,
+  /// and it clears unconditionally.
+  ///
+  /// The siblings clear on this display's condition rather than each on their
+  /// own: HDR locks the register for every command on the wire, and the sibling
+  /// controllers cannot see it.
+  private func giveTheReadAnotherHearing() {
+    guard !usesNative else { return }
     readEvidence = .notAttempted
+    readSkip.clear()
+    for sibling in wireSiblings { sibling.noteReadEvidenceStale() }
+  }
+
+  /// The sibling route into the same clear: a display's three controllers share
+  /// one wire, so a wake or a reconfiguration is an event about all of them.
+  public func noteReadEvidenceStale() {
+    giveTheReadAnotherHearing()
   }
 
   /// Where this display's pixels actually are: itself, or its mirror master. Read
@@ -1571,12 +1596,10 @@ public final class BrightnessController: PendingWireDraining {
     // moment a wire that stopped answering deserves to be asked again.
     let wasUnresponsive = isWireUnresponsive
     resetWireHealth()
-    // Same event, same reason, for the read verdict, and this is the only route
-    // that covers a REPLUG of the same monitor: `rebind` clears the verdict when
-    // the panel identity changes, and a new cable or a new port on the panel that
-    // was already here changes nothing it compares. Placed above the early
+    // The only route that covers a replug of the SAME monitor: `rebind` compares
+    // panel identity, which a new cable or port does not change. Above the early
     // returns below, which are about the dimming legs.
-    readEvidence = .notAttempted
+    giveTheReadAnotherHearing()
     if wasUnresponsive, !usesNative {
       // The transition already ran the full reapply-after-pref-change re-evaluation,
       // which covers the
@@ -1673,7 +1696,13 @@ public final class BrightnessController: PendingWireDraining {
       // asked, and the read skip would otherwise carry that answer for the rest
       // of the plug. Same carve-out the capabilities probe makes for the same
       // reason (`CapabilityProbePolicy`).
+      //
+      // Unconditional, unlike the wake and reconfiguration clears: this IS the
+      // edge that makes reads reachable again, and `usesNative` still describes
+      // the window that just closed until `updateNativeActive()` below runs.
       readEvidence = .notAttempted
+      readSkip.clear()
+      for sibling in wireSiblings { sibling.noteReadEvidenceStale() }
     }
     updateNativeActive()
   }
@@ -1840,6 +1869,7 @@ public final class BrightnessController: PendingWireDraining {
       maxDDCValue = Self.assumedMaxDDC
       didReadMaxDDC = false
       readEvidence = .notAttempted
+      readSkip.clear()
       // Sync's held movement is about the panel that was moving, not the one
       // now on the wire.
       syncDeadband.reset()

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -555,15 +555,18 @@ public final class BrightnessController: PendingWireDraining {
     // Recorded ahead of the fence, for the reason the latch above is: the panel
     // answered, and that stays true whether or not a write superseded the value.
     readEvidence = .answered
-    // Everything below ADOPTS: the panel's max, the published brightness and the
-    // store. A write issued since the read began is the newer intent, so the read
-    // is dropped and the next pass re-reads.
-    guard issuedGeneration == issuedAtStart else { return }
     maxDDCValue = result.max
-    // From here on `maxDDCValue` is the panel's own answer, not the 100
-    // default. Set only on the answered arm: every other exit leaves the
-    // assumption standing, and says so.
+    // Ahead of the fence too. The scale is a fact about the panel rather than
+    // about anyone's intent, so a key press landing mid-read supersedes the
+    // VALUE and not this; dropping it left the next writes scaled against the
+    // assumed 100. From here on `maxDDCValue` is the panel's own answer: set
+    // only on the answered arm, so every other exit leaves the assumption
+    // standing and says so.
     didReadMaxDDC = true
+    // Everything below ADOPTS: the published brightness and the store. A write
+    // issued since the read began is the newer intent, so the read is dropped and
+    // the next pass re-reads.
+    guard issuedGeneration == issuedAtStart else { return }
     // Read mirrors write (fork convDDCToValue): un-apply curve and invert through
     // the same tuning, or a tuned readable panel adopts a corrupted brightness at
     // every launch.

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -494,7 +494,13 @@ public final class BrightnessController: PendingWireDraining {
   /// `brightness` or the store, so adopting the register back would fold it in
   /// permanently and `endTemporaryDim` would then "restore" to the corrupted number.
   /// Reached on every reconfiguration, which a lock dim can outlast.
-  public func refreshFromHardware() async {
+  ///
+  /// `settling` marks a pass a topology change triggered, where the wire is still
+  /// busy renegotiating: the Dell answers silence on every such pass and a frame
+  /// on the next quiet one [MEASURED]. A silence there is evidence about the
+  /// moment, not the panel, so it is dropped whole rather than counted. A frame
+  /// or zeros still publish: those the wire did carry.
+  public func refreshFromHardware(settling: Bool = false) async {
     guard temporaryDimFactor == nil else { return }
     if role == .builtIn {
       // The built-in panel has no DDC wire, so the native read is the only truth
@@ -527,7 +533,16 @@ public final class BrightnessController: PendingWireDraining {
     // the panel WAS asked and this pass's answer is the current fact about it.
     // Folding across passes published "does not reply" about panels that had since
     // replied (see `readEvidence`); a lone silence holds the previous verdict.
+    //
+    // Staleness fence, the same one `DDCValueController.refreshFromHardware`
+    // takes: a read on a wedged bus spans hundreds of milliseconds, and a write
+    // submitted meanwhile (a key press, the panel's surface fan-out) is newer
+    // than anything this read can be carrying. Any submit bumps the generation.
+    let issuedAtStart = issuedGeneration
     let outcome = await writer.readOutcome(command: tuning.remapCodes.first ?? VCP.brightness)
+    // Dropped before the latch sees it, so a settling pass leaves the count, the
+    // verdict and the skip exactly as it found them.
+    if settling, outcome.evidence == .noReply { return }
     // One read per pass, so this attempt's verdict is the pass's. The latch says
     // whether it publishes.
     let publishes = readSkip.record(outcome.evidence)
@@ -537,10 +552,16 @@ public final class BrightnessController: PendingWireDraining {
       if publishes { readEvidence = outcome.evidence }
       return
     }
+    // Recorded ahead of the fence, for the reason the latch above is: the panel
+    // answered, and that stays true whether or not a write superseded the value.
     readEvidence = .answered
+    // Everything below ADOPTS: the panel's max, the published brightness and the
+    // store. A write issued since the read began is the newer intent, so the read
+    // is dropped and the next pass re-reads.
+    guard issuedGeneration == issuedAtStart else { return }
     maxDDCValue = result.max
     // From here on `maxDDCValue` is the panel's own answer, not the 100
-    // default. Set only on the answered arm — every other exit leaves the
+    // default. Set only on the answered arm: every other exit leaves the
     // assumption standing, and says so.
     didReadMaxDDC = true
     // Read mirrors write (fork convDDCToValue): un-apply curve and invert through

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -601,6 +601,31 @@ public final class BrightnessController: PendingWireDraining {
     return value
   }
 
+  /// Quantization noise on a native read: Control Center's slider granularity plus
+  /// the float round-trip through DisplayServices. Same size and same reason as the
+  /// poller's echo tolerance; anything smaller is not a move somebody made.
+  private static let nativeReadNoise = 0.008
+
+  /// Snaps published state onto the panel's live native value before a `step()`.
+  /// The poller's idle cadence can leave that state tens of seconds stale, and a
+  /// step from it jumps a Control Center move back. Native path only, so never the
+  /// DDC wire. No persist: the `step()` that follows writes the final value.
+  public func syncFromNativeBeforeStep() {
+    // Under a temporary dim the read is our own write; folding it in corrupts what
+    // `endTemporaryDim` restores.
+    guard isNativeActive(), temporaryDimFactor == nil else { return }
+    guard let read = backends.readNative?(displayID) else { return }
+    let clamped = min(max(Double(read), 0), 1)
+    guard abs(clamped - brightness) > Self.nativeReadNoise else { return }
+    brightness = clamped
+    // Retire any adoption queued from an earlier poll tick; it describes an older read.
+    echo.withLock { state in
+      state.value = clamped
+      state.generation &+= 1
+      state.converging = false
+    }
+  }
+
   // MARK: - Path selection
 
   /// The four-way fork contract, decided synchronously from cached state:

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -110,17 +110,18 @@ public final class BrightnessController: PendingWireDraining {
   ///   silent verdict (below), so the assignments sit AFTER every such return.
   ///   Otherwise a display that answered zeros once looks pristine again because the
   ///   next pass never reached the wire.
-  /// - A pass that does ask supersedes the previous pass's verdict. A worst-wins fold
-  ///   across passes reads "this display does not reply" about a panel that just
-  ///   replied. `worse` is still exactly right WITHIN a pass and across this display's
+  /// - A pass that does ask, and gets an answer, supersedes the previous pass's
+  ///   verdict. A worst-wins fold across passes reads "this display does not reply"
+  ///   about a panel that just replied. `worse` is still exactly right WITHIN a pass and across this display's
   ///   sibling controllers (`DDCReadEvidence.worst`); the scope of the fold was wrong,
   ///   never the ordering.
-  /// - It does NOT gate the asking. `DDCReadSkipLatch` does, on two consecutive
-  ///   silent passes rather than on this value, so one bad pass still publishes the
-  ///   verdict diagnostics needs while the panel keeps its next hearing. Once the
-  ///   latch is set the panel is asked once per plug rather than on every menu
-  ///   close, and it gets another hearing only from wake, a reconfiguration, a
-  ///   rebind onto a different panel, or an HDR window closing.
+  /// - It does not gate the asking; `DDCReadSkipLatch` does, on two consecutive
+  ///   silent passes.
+  /// - A single silent pass does not supersede it: silence publishes only on the
+  ///   pass that trips the latch. Wake, reconfiguration and HDR-off clear the skip
+  ///   and leave this standing, because the read pass runs BEFORE the
+  ///   reconfiguration clear and a clear there wiped its verdict [MEASURED]. Only
+  ///   `rebind` onto a different panel resets it.
   ///
   /// This controller reads one code, at most once, per pass, so the within-pass fold
   /// here is trivial and the assignments are plain. `DDCValueController`, which
@@ -525,16 +526,15 @@ public final class BrightnessController: PendingWireDraining {
     // has already returned for the passes that ask nothing, so reaching here means
     // the panel WAS asked and this pass's answer is the current fact about it.
     // Folding across passes published "does not reply" about panels that had since
-    // replied (see `readEvidence`).
+    // replied (see `readEvidence`); a lone silence holds the previous verdict.
     let outcome = await writer.readOutcome(command: tuning.remapCodes.first ?? VCP.brightness)
-    // One read per pass here, so the pass's verdict IS this attempt's.
-    readSkip.record(outcome.evidence)
+    // One read per pass, so this attempt's verdict is the pass's. The latch says
+    // whether it publishes.
+    let publishes = readSkip.record(outcome.evidence)
     // A `max` of 0 is a FAILED read, not a brightness of zero: the fork's
-    // unvalidated read clobbers saved values to 0. Recorded rather than merely
-    // rejected, and it publishes `allZeros` like a buffer of zeros does, because
-    // it is the same admission.
+    // unvalidated read clobbered saved values to 0. Publishes as `allZeros`.
     guard let result = outcome.value, result.max > 0 else {
-      readEvidence = outcome.evidence
+      if publishes { readEvidence = outcome.evidence }
       return
     }
     readEvidence = .answered
@@ -835,36 +835,27 @@ public final class BrightnessController: PendingWireDraining {
   /// told us nothing yet.
   public func noteWake() {
     resetWireHealth()
-    // The read verdict deserves the same fresh hearing the wire health gets: a
-    // link rebuilt while the Mac slept has told us nothing yet, and without this
-    // two silent passes before a sleep would mean the panel is never asked again
-    // for the life of the plug.
+    // Same fresh hearing as the wire health: without it, two silent passes before
+    // sleep would mean the panel is never asked again this plug.
     giveTheReadAnotherHearing()
   }
 
-  /// Drops what this display's reads have proved, across its whole wire, but
-  /// only where a read can follow.
+  /// Clears the read skip on this display's whole wire and leaves `readEvidence`
+  /// alone: the read pass runs BEFORE `handleReconfigure`, so clearing the verdict
+  /// here wiped what that pass had just earned [MEASURED].
   ///
-  /// Under the native path (an HDR window, or a panel driven by
-  /// DisplayServices) `refreshFromHardware` returns before reaching the wire, so
-  /// clearing here would replace a real write-only verdict with "nothing
-  /// attempted" in the diagnostics report and no pass would put it back for as
-  /// long as the window lasts. The HDR-off edge is that panel's next hearing,
-  /// and it clears unconditionally.
-  ///
-  /// The siblings clear on this display's condition rather than each on their
-  /// own: HDR locks the register for every command on the wire, and the sibling
-  /// controllers cannot see it.
+  /// Guarded on the native path because no read reaches the wire there; the
+  /// HDR-off edge clears unconditionally. Siblings clear on this display's
+  /// condition because they cannot see the HDR window that locked the register.
   private func giveTheReadAnotherHearing() {
     guard !usesNative else { return }
-    readEvidence = .notAttempted
     readSkip.clear()
-    for sibling in wireSiblings { sibling.noteReadEvidenceStale() }
+    for sibling in wireSiblings { sibling.noteReadWorthRetrying() }
   }
 
   /// The sibling route into the same clear: a display's three controllers share
   /// one wire, so a wake or a reconfiguration is an event about all of them.
-  public func noteReadEvidenceStale() {
+  public func noteReadWorthRetrying() {
     giveTheReadAnotherHearing()
   }
 
@@ -1691,18 +1682,13 @@ public final class BrightnessController: PendingWireDraining {
         "HDR window closed on display=\(self.displayID): dropping the wire's duplicate memos"
       )
       invalidateWireMemos()
-      // A silent verdict earned while HDR held the register is a fact about the
-      // window, not about the panel: DDC was dead, so the panel was never really
-      // asked, and the read skip would otherwise carry that answer for the rest
-      // of the plug. Same carve-out the capabilities probe makes for the same
-      // reason (`CapabilityProbePolicy`).
-      //
-      // Unconditional, unlike the wake and reconfiguration clears: this IS the
-      // edge that makes reads reachable again, and `usesNative` still describes
-      // the window that just closed until `updateNativeActive()` below runs.
-      readEvidence = .notAttempted
+      // A skip earned while HDR held the register is a fact about the window, not
+      // the panel (same carve-out as `CapabilityProbePolicy`). Written out rather
+      // than routed through the `usesNative` guard, so this edge stays correct on
+      // its own and not through `cachedHDRActive` having just been reassigned.
+      // The skip only: the verdict stands until the first pass after the window.
       readSkip.clear()
-      for sibling in wireSiblings { sibling.noteReadEvidenceStale() }
+      for sibling in wireSiblings { sibling.noteReadWorthRetrying() }
     }
     updateNativeActive()
   }
@@ -1835,6 +1821,8 @@ public final class BrightnessController: PendingWireDraining {
   /// - `readEvidence` back to `.notAttempted`, the floor: we have asked THIS
   ///   panel nothing. Not a weakening of worst-wins, which folds within a pass and
   ///   across sibling controllers, neither of which survives a swapped monitor.
+  ///   The only route that resets the verdict; every other clear reaches the
+  ///   skip alone.
   /// - `maxDDCValue` back to `assumedMaxDDC`. Resetting the provenance flag and
   ///   leaving the number keeps the motivating scenario alive on the write path
   ///   itself: a previous panel that reported 80 leaves the NEW panel's writes scaled
@@ -1858,10 +1846,9 @@ public final class BrightnessController: PendingWireDraining {
   /// limitation is inherited: identical twins can share an EDID UUID and are not told
   /// apart here, though they already share a saved value and a prefs domain. The cost
   /// of the narrower trigger is that the SAME panel rebound through a DDC-hostile new
-  /// route keeps its old verdict, and a silent one now GATES the next read, so no
-  /// later refresh would supersede it either. `handleReconfigure` is what covers that
-  /// case: a new cable or a new port arrives as a reconfiguration whether or not the
-  /// panel identity moved, and the verdict is cleared there.
+  /// route keeps its old verdict, and a silent one gates the next read. A new cable
+  /// or port arrives as a reconfiguration either way, and `handleReconfigure` clears
+  /// the skip there.
   public func rebind(writer: any DDCWriting, panelIdentity: String?) {
     self.writer = writer
     if panelIdentity != boundPanelIdentity {

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -121,15 +121,15 @@ public final class BrightnessController: PendingWireDraining {
   ///   pass that trips the latch. Wake, reconfiguration and HDR-off clear the skip
   ///   and leave this standing, because the read pass runs BEFORE the
   ///   reconfiguration clear and a clear there wiped its verdict [MEASURED]. Only
-  ///   `rebind` onto a different panel resets it.
+  ///   a different panel or read register resets it.
   ///
   /// This controller reads one code, at most once, per pass, so the within-pass fold
   /// here is trivial and the assignments are plain. `DDCValueController`, which
   /// retries, has to spell the fold out.
   public private(set) var readEvidence: DDCReadEvidence = .notAttempted
 
-  /// Whether this display's reads are still worth attempting. Cleared with
-  /// `readEvidence` at every route that gives the panel another hearing.
+  /// Whether the current read register is still worth attempting. Wake and
+  /// reconfiguration clear the skip; a register change also resets its evidence.
   @ObservationIgnored private var readSkip = DDCReadSkipLatch()
 
   /// Whether this display's DDC wire has stopped carrying writes
@@ -516,6 +516,9 @@ public final class BrightnessController: PendingWireDraining {
     guard !usesNative else { return }
     let tuning = prefs.tuning(for: .brightness)
     guard !tuning.unavailableDDC else { return }
+    // Reads use only the first remap code; trailing codes affect writes alone.
+    let readCode = tuning.remapCodes.first ?? VCP.brightness
+    bindReadRegister(to: readCode)
     // Two silent passes and the panel is asked once per plug: every futile pass
     // holds the wire for the full retry ladder, which is the menu-close stall a
     // person feels. This controller's own verdict, not the siblings' fold: volume
@@ -539,7 +542,12 @@ public final class BrightnessController: PendingWireDraining {
     // submitted meanwhile (a key press, the panel's surface fan-out) is newer
     // than anything this read can be carrying. Any submit bumps the generation.
     let issuedAtStart = issuedGeneration
-    let outcome = await writer.readOutcome(command: tuning.remapCodes.first ?? VCP.brightness)
+    let registerAtStart = readSkip.registerGeneration
+    let outcome = await writer.readOutcome(command: readCode)
+    // Preferences can change while the wire is busy, with or without another
+    // refresh. Evidence and scale from the old register belong to that register.
+    bindReadRegister(to: prefs.tuning(for: .brightness).remapCodes.first ?? VCP.brightness)
+    guard readSkip.registerGeneration == registerAtStart else { return }
     // Dropped before the latch sees it, so a settling pass leaves the count, the
     // verdict and the skip exactly as it found them.
     if settling, outcome.evidence == .noReply { return }
@@ -844,6 +852,13 @@ public final class BrightnessController: PendingWireDraining {
     // mirror above is still updated: the panel says what it knows either way.
     guard !usesNative else { return }
     reapplyAfterPrefChange()
+  }
+
+  private func bindReadRegister(to code: UInt8) {
+    guard readSkip.bind(to: code) else { return }
+    readEvidence = .notAttempted
+    maxDDCValue = Self.assumedMaxDDC
+    didReadMaxDDC = false
   }
 
   /// The wire-health reset, from every route that means the wire deserves a fresh

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPollCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPollCadence.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// How often the native poller looks, decided fresh on every tick.
+///
+/// Never STOPPED while a display exists: an external entering HDR flips onto the
+/// native path through no call of ours, and only a running poller notices. An
+/// idle rig pays a longer interval, never no poller.
+public enum BrightnessPollCadence: Sendable, Equatable, CaseIterable {
+  /// A value is moving: chase it, as the fork did.
+  case fast
+  /// Something is consuming the value right now.
+  case idle
+  /// Nothing is consuming it, on mains.
+  case slowIdle
+  /// Nothing is consuming it, on battery.
+  case batterySlowIdle
+
+  /// For the log line that makes the cadence readable from outside the process.
+  public var name: String {
+    switch self {
+    case .fast: "fast"
+    case .idle: "idle"
+    case .slowIdle: "slow"
+    case .batterySlowIdle: "slow-on-battery"
+    }
+  }
+
+  /// `isExternalNativeActive` ignores the built-in on purpose: it is always native
+  /// and would pin every laptop to the short interval. Its only consumer with no
+  /// surface open is a brightness key, which takes its own read before stepping.
+  /// `isOnBattery` is an autoclosure: the power-source read costs something and
+  /// only the slow branch needs it.
+  public static func choose(
+    isMoving: Bool,
+    isSyncEnabled: Bool,
+    isSurfaceVisible: Bool,
+    isExternalNativeActive: Bool,
+    isOnBattery: @autoclosure () -> Bool
+  ) -> BrightnessPollCadence {
+    if isMoving { return .fast }
+    if isSyncEnabled || isSurfaceVisible || isExternalNativeActive { return .idle }
+    return isOnBattery() ? .batterySlowIdle : .slowIdle
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
@@ -68,13 +68,18 @@ public actor BrightnessPoller {
   /// Returns on cancellation.
   public func run() async {
     while !Task.isCancelled {
-      let moving = tick()
+      let delay = pollOnce()
       do {
-        try await Task.sleep(for: moving ? fastInterval : idleInterval)
+        try await Task.sleep(for: delay)
       } catch {
         return
       }
     }
+  }
+
+  /// Performs one poll and returns the delay before the next one.
+  func pollOnce() -> Duration {
+    tick() ? fastInterval : idleInterval
   }
 
   /// Returns true when any target moved this tick (drives the fast cadence).

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
@@ -65,13 +65,14 @@ public actor BrightnessPoller {
   /// Last cadence reported to the log, so a steady state costs no lines.
   private var lastLoggedCadence: BrightnessPollCadence?
 
-  /// `tolerance` covers Control Center's slider quantization plus the float
-  /// round-trip through DisplayServices; larger swallows real external moves.
-  ///
-  /// The two consumer signals are read LIVE on every tick, like the per-target
-  /// native gate: a surface opening or a pref changing must not need the poll job
-  /// rebuilt, because rebuilding it is what would drop the HDR edges nothing else
-  /// reports.
+  /// Control Center's slider quantization plus the float round-trip through
+  /// DisplayServices; larger swallows real external moves. Public so the pre-step
+  /// freshness read shares it.
+  public static let defaultTolerance = 0.008
+
+  /// `tolerance` is per instance so a test can widen or narrow it. The consumer
+  /// signals are read LIVE on every tick, like the native gate, so a surface
+  /// opening or a pref write never needs the job rebuilt.
   public init(
     targets: [Target],
     read: @escaping @Sendable (CGDirectDisplayID) -> Double?,
@@ -83,7 +84,7 @@ public actor BrightnessPoller {
     idleInterval: Duration = .seconds(1),
     slowIdleInterval: Duration = .seconds(10),
     batteryIdleInterval: Duration = .seconds(30),
-    tolerance: Double = 0.008
+    tolerance: Double = BrightnessPoller.defaultTolerance
   ) {
     self.targets = targets
     self.read = read

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
@@ -1,14 +1,21 @@
 import CoreGraphics
 import Foundation
+import os
+
+let pollLog = Logger(subsystem: "com.rydersel.Candela", category: "poll")
 
 /// Polls native brightness for displays whose controller is HDR-native,
 /// discards echoes of our own writes, and reports real external deltas to the
 /// controller. Ported from the MonitorControl fork's `refreshBrightness` poll
-/// job, the behavior oracle for both the cadence and the echo discard.
+/// job, the behavior oracle for the echo discard and for the moving/idle pair at
+/// the top of the cadence.
 ///
 /// It never smooths, never writes hardware and never decides staleness:
 /// `BrightnessController.adoptExternal` owns the easing and the generation
 /// discard.
+///
+/// Unlike the fork, the idle cadence is not one interval: `BrightnessPollCadence`
+/// lengthens it when nothing consumes the value. The task itself never stops.
 public actor BrightnessPoller {
   public struct Target: Sendable {
     public let displayID: CGDirectDisplayID
@@ -24,44 +31,70 @@ public actor BrightnessPoller {
     /// True while an earlier adoption is still easing toward its target: the
     /// echo discard must be bypassed or the chase never terminates.
     public let isConverging: @Sendable () -> Bool
+    /// Only externals vote on the cadence; see `BrightnessPollCadence.choose`.
+    public let isExternal: Bool
 
     public init(
       displayID: CGDirectDisplayID,
       expected: @escaping @Sendable () -> (value: Double?, generation: UInt64),
       isNativeActive: @escaping @Sendable () -> Bool,
       adopt: @escaping @Sendable (Double, UInt64) -> Void,
-      isConverging: @escaping @Sendable () -> Bool
+      isConverging: @escaping @Sendable () -> Bool,
+      isExternal: Bool
     ) {
       self.displayID = displayID
       self.expected = expected
       self.isNativeActive = isNativeActive
       self.adopt = adopt
       self.isConverging = isConverging
+      self.isExternal = isExternal
     }
   }
 
   private let targets: [Target]
   private let read: @Sendable (CGDirectDisplayID) -> Double?
   private let isEpochCurrent: @Sendable () -> Bool
+  private let isSyncEnabled: @Sendable () -> Bool
+  private let isSurfaceVisible: @Sendable () -> Bool
+  private let isOnBattery: @Sendable () -> Bool
   private let fastInterval: Duration
   private let idleInterval: Duration
+  private let slowIdleInterval: Duration
+  private let batteryIdleInterval: Duration
   private let tolerance: Double
+  /// Last cadence reported to the log, so a steady state costs no lines.
+  private var lastLoggedCadence: BrightnessPollCadence?
 
   /// `tolerance` covers Control Center's slider quantization plus the float
   /// round-trip through DisplayServices; larger swallows real external moves.
+  ///
+  /// The two consumer signals are read LIVE on every tick, like the per-target
+  /// native gate: a surface opening or a pref changing must not need the poll job
+  /// rebuilt, because rebuilding it is what would drop the HDR edges nothing else
+  /// reports.
   public init(
     targets: [Target],
     read: @escaping @Sendable (CGDirectDisplayID) -> Double?,
     isEpochCurrent: @escaping @Sendable () -> Bool,
+    isSyncEnabled: @escaping @Sendable () -> Bool,
+    isSurfaceVisible: @escaping @Sendable () -> Bool,
+    isOnBattery: @escaping @Sendable () -> Bool = { PowerSource.isOnBattery() },
     fastInterval: Duration = .milliseconds(100),
     idleInterval: Duration = .seconds(1),
+    slowIdleInterval: Duration = .seconds(10),
+    batteryIdleInterval: Duration = .seconds(30),
     tolerance: Double = 0.008
   ) {
     self.targets = targets
     self.read = read
     self.isEpochCurrent = isEpochCurrent
+    self.isSyncEnabled = isSyncEnabled
+    self.isSurfaceVisible = isSurfaceVisible
+    self.isOnBattery = isOnBattery
     self.fastInterval = fastInterval
     self.idleInterval = idleInterval
+    self.slowIdleInterval = slowIdleInterval
+    self.batteryIdleInterval = batteryIdleInterval
     self.tolerance = tolerance
   }
 
@@ -69,11 +102,47 @@ public actor BrightnessPoller {
   public func run() async {
     while !Task.isCancelled {
       let moving = tick()
+      let cadence = BrightnessPollCadence.choose(
+        isMoving: moving,
+        isSyncEnabled: isSyncEnabled(),
+        isSurfaceVisible: isSurfaceVisible(),
+        // Outside `tick`, which returns early mid-reconfigure: a burst must not
+        // decide the cadence after it.
+        isExternalNativeActive: externalNativeActive(),
+        isOnBattery: isOnBattery()
+      )
+      let sleep = interval(for: cadence)
+      log(cadence, sleeping: sleep)
       do {
-        try await Task.sleep(for: moving ? fastInterval : idleInterval)
+        try await Task.sleep(for: sleep)
       } catch {
         return
       }
+    }
+  }
+
+  /// The idle intervals are otherwise unobservable from outside the process.
+  /// `.fast` is not logged: it flips on every adopted value during a drag.
+  private func log(_ cadence: BrightnessPollCadence, sleeping: Duration) {
+    guard cadence != .fast, cadence != lastLoggedCadence else { return }
+    lastLoggedCadence = cadence
+    let ms = sleeping.components.seconds * 1000
+      + sleeping.components.attoseconds / 1_000_000_000_000_000
+    pollLog.info(
+      "native poll cadence \(cadence.name, privacy: .public) interval=\(ms, privacy: .public)ms"
+    )
+  }
+
+  private func externalNativeActive() -> Bool {
+    targets.contains { $0.isExternal && $0.isNativeActive() }
+  }
+
+  private func interval(for cadence: BrightnessPollCadence) -> Duration {
+    switch cadence {
+    case .fast: fastInterval
+    case .idle: idleInterval
+    case .slowIdle: slowIdleInterval
+    case .batterySlowIdle: batteryIdleInterval
     }
   }
 

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessPoller.swift
@@ -102,24 +102,29 @@ public actor BrightnessPoller {
   /// Returns on cancellation.
   public func run() async {
     while !Task.isCancelled {
-      let moving = tick()
-      let cadence = BrightnessPollCadence.choose(
-        isMoving: moving,
-        isSyncEnabled: isSyncEnabled(),
-        isSurfaceVisible: isSurfaceVisible(),
-        // Outside `tick`, which returns early mid-reconfigure: a burst must not
-        // decide the cadence after it.
-        isExternalNativeActive: externalNativeActive(),
-        isOnBattery: isOnBattery()
-      )
-      let sleep = interval(for: cadence)
-      log(cadence, sleeping: sleep)
+      let delay = pollOnce()
       do {
-        try await Task.sleep(for: sleep)
+        try await Task.sleep(for: delay)
       } catch {
         return
       }
     }
+  }
+
+  /// Performs one poll and returns the delay before the next one.
+  func pollOnce() -> Duration {
+    let moving = tick()
+    let cadence = BrightnessPollCadence.choose(
+      isMoving: moving,
+      isSyncEnabled: isSyncEnabled(),
+      isSurfaceVisible: isSurfaceVisible(),
+      // A reconfiguration can skip the read without removing its consumers.
+      isExternalNativeActive: externalNativeActive(),
+      isOnBattery: isOnBattery()
+    )
+    let delay = interval(for: cadence)
+    log(cadence, sleeping: delay)
+    return delay
   }
 
   /// The idle intervals are otherwise unobservable from outside the process.

--- a/CandelaKit/Sources/CandelaKit/Brightness/DDCWriting.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/DDCWriting.swift
@@ -50,15 +50,10 @@ public protocol PendingWireDraining {
   /// HDR window certifies values that never landed. Anything that knows the
   /// panel may have moved out from under the memo has to say so here.
   func resetWriteMemo()
-  /// Forgets what this controller's own DDC READS have proved, so a panel that
-  /// went quiet is asked again.
-  ///
-  /// Same events as `resetWriteMemo`, for the mirrored reason: a wake, a
-  /// reconfiguration or an HDR window closing can all change the answer, and a
-  /// skip that outlives its cause leaves a panel unread for the rest of the
-  /// plug. Defaulted to nothing for conformers with no read of their own to
-  /// forget.
-  func noteReadEvidenceStale()
+  /// Makes this controller's own DDC reads worth attempting again. Same events as
+  /// `resetWriteMemo`: a skip that outlives its cause leaves a panel unread for
+  /// the rest of the plug. Clears the skip only; what the reads proved stands.
+  func noteReadWorthRetrying()
   /// Waits the queue out and reports whether everything submitted has reached
   /// hardware. A target the queue completed WITHOUT applying is submitted again
   /// with a fresh epoch stamp, so one closed reconfiguration window is recovered
@@ -70,7 +65,7 @@ public protocol PendingWireDraining {
 }
 
 public extension PendingWireDraining {
-  func noteReadEvidenceStale() {}
+  func noteReadWorthRetrying() {}
 }
 
 /// Drives a set of write queues to a state where nothing is owed to the panel.

--- a/CandelaKit/Sources/CandelaKit/Brightness/DDCWriting.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/DDCWriting.swift
@@ -2,6 +2,9 @@
 public protocol DDCWriting: Sendable {
   func write(command: UInt8, value: UInt16) async -> Bool
   func read(command: UInt8) async -> (current: UInt16, max: UInt16)?
+  /// `read` plus what the transport saw. Every site that publishes
+  /// `DDCReadEvidence` uses this one.
+  func readOutcome(command: UInt8) async -> DDCReadOutcome
   /// The display's MCCS capability string (VCP 0xF3), reassembled from its
   /// fragments. `nil` means the TRANSACTION failed — never read that as "this
   /// display has no capabilities" (unknown resolves to enabled).
@@ -9,6 +12,13 @@ public protocol DDCWriting: Sendable {
 }
 
 public extension DDCWriting {
+  /// Writers with no transport of their own cannot tell silence from zeros, so
+  /// nil keeps its old meaning: nothing came back.
+  func readOutcome(command: UInt8) async -> DDCReadOutcome {
+    guard let value = await read(command: command) else { return .noReply }
+    return .frame(current: value.current, max: value.max)
+  }
+
   /// Writers with no capabilities path — the built-in's `NoopDDCWriter`, test
   /// fakes — inherit the honest answer: we do not know.
   func readCapabilityString() async -> String? { nil }

--- a/CandelaKit/Sources/CandelaKit/Brightness/DDCWriting.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/DDCWriting.swift
@@ -50,6 +50,15 @@ public protocol PendingWireDraining {
   /// HDR window certifies values that never landed. Anything that knows the
   /// panel may have moved out from under the memo has to say so here.
   func resetWriteMemo()
+  /// Forgets what this controller's own DDC READS have proved, so a panel that
+  /// went quiet is asked again.
+  ///
+  /// Same events as `resetWriteMemo`, for the mirrored reason: a wake, a
+  /// reconfiguration or an HDR window closing can all change the answer, and a
+  /// skip that outlives its cause leaves a panel unread for the rest of the
+  /// plug. Defaulted to nothing for conformers with no read of their own to
+  /// forget.
+  func noteReadEvidenceStale()
   /// Waits the queue out and reports whether everything submitted has reached
   /// hardware. A target the queue completed WITHOUT applying is submitted again
   /// with a fresh epoch stamp, so one closed reconfiguration window is recovered
@@ -58,6 +67,10 @@ public protocol PendingWireDraining {
   /// "Reached hardware" is bounded by the panel: the applier ran and reported
   /// success. On a write-only display that is the end of the evidence.
   func drainPendingWrites() async -> Bool
+}
+
+public extension PendingWireDraining {
+  func noteReadEvidenceStale() {}
 }
 
 /// Drives a set of write queues to a state where nothing is owed to the panel.

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupLiveRunners.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupLiveRunners.swift
@@ -113,6 +113,18 @@ public actor CheckupLiveModeRunner: CheckupModeRunning {
     return String(describing: error)
   }
 
+  /// The verdict for an apply that threw. An unhonoured commit is not a refusal
+  /// (nothing said no), so it records as not observed with the achieved geometry.
+  static func applyFailure(_ error: any Error, prefix: String = "") -> CheckupVerdict {
+    guard let unhonoured = (error as? DisplayConfigError)?.unhonouredCommit else {
+      return .refused("\(prefix)apply refused: \(reason(error))")
+    }
+    return .notObserved("""
+      \(prefix)applied \(describe(unhonoured.requested)); macOS reports \
+      \(unhonoured.achieved.map(describe) ?? "no current mode")
+      """)
+  }
+
   /// Geometry and quantized rate, never `ioModeID`: that number is positional,
   /// and after a reconfiguration it can resolve to a different mode while the
   /// apply still reports success. The sweep reconfigures once per rate.
@@ -142,7 +154,7 @@ public actor CheckupLiveModeRunner: CheckupModeRunning {
       return [
         CheckupClaim(
           family: .nativeMode, id: CheckupCheckID.nativeMode,
-          verdict: .refused("apply refused: \(Self.reason(error))"))
+          verdict: Self.applyFailure(error))
       ]
     }
     guard let achieved = configurator.currentMode(for: displayID) else {
@@ -195,7 +207,7 @@ public actor CheckupLiveModeRunner: CheckupModeRunning {
         claims.append(
           CheckupClaim(
             family: .refresh, id: id,
-            verdict: .refused("\(Self.hz(rate)) Hz: apply refused: \(Self.reason(error))")))
+            verdict: Self.applyFailure(error, prefix: "\(Self.hz(rate)) Hz: ")))
         continue
       }
       guard let achieved = configurator.currentMode(for: displayID)?.refreshHz else {

--- a/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
+++ b/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
@@ -85,16 +85,19 @@ public final class DDCValueController: PendingWireDraining {
   /// them: the display-level verdict is `DDCReadEvidence.worst` of the three,
   /// folded at whatever reads them.
   ///
-  /// Scope: the most recent pass that actually asked the panel something,
-  /// folded worst-wins over the FAILED attempts within that pass, so a late
-  /// `continue` cannot erase an earlier zeros observation and a pass that
-  /// returns early leaves the previous verdict standing.
+  /// Scope: the most recent pass that actually asked the panel something AND
+  /// concluded with an answer, folded worst-wins over the FAILED attempts within
+  /// that pass, so a late `continue` cannot erase an earlier zeros observation
+  /// and a pass that returns early leaves the previous verdict standing.
   ///
   /// Deliberately NOT a fold across passes and retries. DDC reads are flaky, so
   /// the common healthy case is attempt 1 returning nil and attempt 2
   /// answering; folding those publishes "this display does not reply" about a
   /// panel that just replied. A successful attempt supersedes the failures
   /// before it in its pass.
+  ///
+  /// A pass that ends in silence does not supersede this either: `DDCReadSkipLatch`
+  /// decides, on two consecutive silent passes. Clears reach only the skip.
   public private(set) var readEvidence: DDCReadEvidence = .notAttempted
 
   /// Whether this register is still worth asking about. Its own, never the
@@ -385,9 +388,6 @@ public final class DDCValueController: PendingWireDraining {
     return true
   }
 
-  /// `.read`: validated DDC readback. `(0, 0)` and `max == 0` are FAILED reads,
-  /// not a value of zero: a write-only panel produces nothing usable from any
-  /// read, and the fork's unvalidated read clobbers saved values to 0.
   /// `.read`: validated DDC readback. `max == 0` is a FAILED read, not a value
   /// of zero: the fork's unvalidated read clobbered saved values to 0.
   ///
@@ -416,30 +416,24 @@ public final class DDCValueController: PendingWireDraining {
     // what the last pass concluded (see `readEvidence`). Only the FAILED
     // attempts fold, worst-wins; a success supersedes them outright.
     var passEvidence = DDCReadEvidence.notAttempted
-    // One pass, one hearing: the retries inside it are the reliability
-    // mechanism, so the latch counts what the pass concluded and not what each
-    // attempt did.
+    // The latch counts passes, not attempts: the retries are the reliability
+    // mechanism.
     var answered = false
     for _ in 0 ..< tries {
-      // A silent bus and a panel that answers zeros are different facts, and the
-      // transport is where they are now told apart: it carries a non-zero
-      // sentinel into the reply buffer, so zeros are the panel's word and not a
-      // buffer the read call never wrote to. A frame whose `max` is 0 is the
-      // same admission, and `outcome.evidence` is the one place that mapping
-      // lives, shared with the brightness read site.
+      // Silence and zeros are different facts; the transport tells them apart, and
+      // `outcome.evidence` is the one place `max == 0` folds into zeros.
       let outcome = await writer.readOutcome(command: readCode)
       guard let result = outcome.value, result.max > 0 else {
+        // Held, not published: the latch below decides once the pass concludes.
         passEvidence = DDCReadEvidence.worse(passEvidence, outcome.evidence)
-        readEvidence = passEvidence
         continue
       }
       // Recorded BEFORE the staleness fence: the panel answered, and that is
       // true whether or not user input superseded the value we were about to
       // adopt. Returning here without recording would hide a good panel behind
-      // a race. The latch is cleared at the same point and for the same reason:
-      // the pass below can still `return` before its own recording runs.
-      readEvidence = .answered
+      // a race. The latch is recorded here for the same reason.
       readSkip.record(.answered)
+      readEvidence = .answered
       answered = true
       guard issuedGeneration == issuedAtStart else { return }
       // The max is real information on every validated read (the loop guard
@@ -462,7 +456,8 @@ public final class DDCValueController: PendingWireDraining {
       persist(adopted)
       break
     }
-    if !answered { readSkip.record(passEvidence) }
+    // No answer this pass. Zeros publish at once; a lone silence waits for a second.
+    if !answered, readSkip.record(passEvidence) { readEvidence = passEvidence }
     // The strategy in force, not the pref: 0x8D is where this display's mute
     // lives only if the display takes 0x8D. Asking a register the display
     // denies and adopting its answer would write a mute state nothing ever
@@ -618,15 +613,10 @@ public final class DDCValueController: PendingWireDraining {
     muteCoalescer.resetDuplicateState()
   }
 
-  /// Wake, reconfiguration and the HDR-off edge, all of which reach this
-  /// controller through the display's brightness controller: its three
-  /// controllers share one wire, and this one has no observers of its own.
-  ///
-  /// The verdict goes with the latch. Keeping it while the skip is cleared would
-  /// leave the diagnostics report asserting a write-only panel over a register
-  /// nothing has asked since.
-  public func noteReadEvidenceStale() {
-    readEvidence = .notAttempted
+  /// Reached through the display's brightness controller, which owns the wire's
+  /// observers. The skip only: the read pass runs before the reconfiguration fans
+  /// out, so dropping the verdict here wiped what it had just earned [MEASURED].
+  public func noteReadWorthRetrying() {
     readSkip.clear()
   }
 

--- a/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
+++ b/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
@@ -97,6 +97,10 @@ public final class DDCValueController: PendingWireDraining {
   /// before it in its pass.
   public private(set) var readEvidence: DDCReadEvidence = .notAttempted
 
+  /// Whether this register is still worth asking about. Its own, never the
+  /// display's fold: volume can be silent on a panel whose brightness answers.
+  @ObservationIgnored private var readSkip = DDCReadSkipLatch()
+
   public init(
     writer: any DDCWriting,
     command: DDCCommand,
@@ -384,14 +388,16 @@ public final class DDCValueController: PendingWireDraining {
   /// `.read`: validated DDC readback. `(0, 0)` and `max == 0` are FAILED reads,
   /// not a value of zero: a write-only panel produces nothing usable from any
   /// read, and the fork's unvalidated read clobbers saved values to 0.
+  /// `.read`: validated DDC readback. `max == 0` is a FAILED read, not a value
+  /// of zero: the fork's unvalidated read clobbered saved values to 0.
   ///
-  /// Unlike the brightness controller, this one has no once-per-plug skip. It is
-  /// gated on `startupAction == .read`, which is not the default, so a silent
-  /// panel here costs `pollingTries` full transactions per pass.
+  /// Skipped after two silent passes (`DDCReadSkipLatch`). It matters more here
+  /// than for brightness: this loop spends `pollingTries` transactions per pass.
   public func refreshFromHardware() async {
     guard prefs.startupAction == .read, isAvailable else { return }
     let tries = prefs.pollingTries
     guard tries > 0 else { return }
+    guard !readSkip.skipsRead else { return }
     let tuning = prefs.tuning(for: command)
     // Fork parity: reads use only the FIRST remap code.
     let readCode = tuning.remapCodes.first ?? command.code
@@ -410,6 +416,10 @@ public final class DDCValueController: PendingWireDraining {
     // what the last pass concluded (see `readEvidence`). Only the FAILED
     // attempts fold, worst-wins; a success supersedes them outright.
     var passEvidence = DDCReadEvidence.notAttempted
+    // One pass, one hearing: the retries inside it are the reliability
+    // mechanism, so the latch counts what the pass concluded and not what each
+    // attempt did.
+    var answered = false
     for _ in 0 ..< tries {
       // A silent bus and a panel that answers zeros are different facts, and the
       // transport is where they are now told apart: it carries a non-zero
@@ -426,8 +436,11 @@ public final class DDCValueController: PendingWireDraining {
       // Recorded BEFORE the staleness fence: the panel answered, and that is
       // true whether or not user input superseded the value we were about to
       // adopt. Returning here without recording would hide a good panel behind
-      // a race.
+      // a race. The latch is cleared at the same point and for the same reason:
+      // the pass below can still `return` before its own recording runs.
       readEvidence = .answered
+      readSkip.record(.answered)
+      answered = true
       guard issuedGeneration == issuedAtStart else { return }
       // The max is real information on every validated read (the loop guard
       // proved `max > 0`); learn it BEFORE the artifact skip below, which
@@ -449,6 +462,7 @@ public final class DDCValueController: PendingWireDraining {
       persist(adopted)
       break
     }
+    if !answered { readSkip.record(passEvidence) }
     // The strategy in force, not the pref: 0x8D is where this display's mute
     // lives only if the display takes 0x8D. Asking a register the display
     // denies and adopting its answer would write a mute state nothing ever
@@ -580,6 +594,7 @@ public final class DDCValueController: PendingWireDraining {
       boundPanelIdentity = panelIdentity
       readMax = nil
       readEvidence = .notAttempted
+      readSkip.clear()
     }
     coalescer.resetDuplicateState()
     muteCoalescer.resetDuplicateState()
@@ -601,6 +616,18 @@ public final class DDCValueController: PendingWireDraining {
   public func resetWriteMemo() {
     coalescer.resetDuplicateState()
     muteCoalescer.resetDuplicateState()
+  }
+
+  /// Wake, reconfiguration and the HDR-off edge, all of which reach this
+  /// controller through the display's brightness controller: its three
+  /// controllers share one wire, and this one has no observers of its own.
+  ///
+  /// The verdict goes with the latch. Keeping it while the skip is cleared would
+  /// leave the diagnostics report asserting a write-only panel over a register
+  /// nothing has asked since.
+  public func noteReadEvidenceStale() {
+    readEvidence = .notAttempted
+    readSkip.clear()
   }
 
   /// Whether the wire is open right now: the same gate the coalescer consults

--- a/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
+++ b/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
@@ -381,9 +381,13 @@ public final class DDCValueController: PendingWireDraining {
     return true
   }
 
-  /// `.read`: validated DDC readback. `(0, 0)` and `max == 0` are FAILED
-  /// reads — the MAG341C answers every read with zeros, and the fork's
-  /// unvalidated read clobbers saved values to 0.
+  /// `.read`: validated DDC readback. `(0, 0)` and `max == 0` are FAILED reads,
+  /// not a value of zero: a write-only panel produces nothing usable from any
+  /// read, and the fork's unvalidated read clobbers saved values to 0.
+  ///
+  /// Unlike the brightness controller, this one has no once-per-plug skip. It is
+  /// gated on `startupAction == .read`, which is not the default, so a silent
+  /// panel here costs `pollingTries` full transactions per pass.
   public func refreshFromHardware() async {
     guard prefs.startupAction == .read, isAvailable else { return }
     let tries = prefs.pollingTries
@@ -407,16 +411,15 @@ public final class DDCValueController: PendingWireDraining {
     // attempts fold, worst-wins; a success supersedes them outright.
     var passEvidence = DDCReadEvidence.notAttempted
     for _ in 0 ..< tries {
-      // Two guards, not one: a silent bus and a panel that answers zeros
-      // are different facts. Only the second is the write-only signature, and
-      // it is the one the MAG 341C produces on every one of `tries` attempts.
-      guard let result = await writer.read(command: readCode) else {
-        passEvidence = DDCReadEvidence.worse(passEvidence, .noReply)
-        readEvidence = passEvidence
-        continue
-      }
-      guard result.max > 0 else {
-        passEvidence = DDCReadEvidence.worse(passEvidence, .allZeros)
+      // A silent bus and a panel that answers zeros are different facts, and the
+      // transport is where they are now told apart: it carries a non-zero
+      // sentinel into the reply buffer, so zeros are the panel's word and not a
+      // buffer the read call never wrote to. A frame whose `max` is 0 is the
+      // same admission, and `outcome.evidence` is the one place that mapping
+      // lives, shared with the brightness read site.
+      let outcome = await writer.readOutcome(command: readCode)
+      guard let result = outcome.value, result.max > 0 else {
+        passEvidence = DDCReadEvidence.worse(passEvidence, outcome.evidence)
         readEvidence = passEvidence
         continue
       }

--- a/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
+++ b/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
@@ -391,9 +391,12 @@ public final class DDCValueController: PendingWireDraining {
   /// `.read`: validated DDC readback. `max == 0` is a FAILED read, not a value
   /// of zero: the fork's unvalidated read clobbered saved values to 0.
   ///
-  /// Skipped after two silent passes (`DDCReadSkipLatch`). It matters more here
-  /// than for brightness: this loop spends `pollingTries` transactions per pass,
-  /// which is also why a refusal ends the loop on the try that carried it.
+  /// The value read is skipped after two silent passes (`DDCReadSkipLatch`). It
+  /// matters more here than for brightness: this loop spends `pollingTries`
+  /// transactions per pass, which is also why a refusal ends the loop on the try
+  /// that carried it. The skip covers that register alone; the VCP 0x8D mute
+  /// readback asks a different register, and a latched value register says
+  /// nothing about it.
   ///
   /// `settling` marks a pass a topology change triggered, where the wire is still
   /// renegotiating and a silence is evidence about the moment rather than the
@@ -403,83 +406,95 @@ public final class DDCValueController: PendingWireDraining {
     guard prefs.startupAction == .read, isAvailable else { return }
     let tries = prefs.pollingTries
     guard tries > 0 else { return }
-    guard !readSkip.skipsRead else { return }
-    let tuning = prefs.tuning(for: command)
-    // Fork parity: reads use only the FIRST remap code.
-    let readCode = tuning.remapCodes.first ?? command.code
-    // Staleness fence (the I9 doctrine): the read loop can
-    // span seconds on a wedged bus — a slider drag or key that lands
-    // mid-flight must win over the stale read, INCLUDING in the persisted
-    // store. Any submit bumps the generation, so a mismatch means user
-    // input superseded this read.
-    let issuedAtStart = issuedGeneration
-    // Captured HERE, not after the value loop: a toggleMute
-    // landing mid-value-loop bumps the mute generation, and a later capture
-    // would blind the 0x8D-readback guard to it — the readback could then
-    // setMuted(false)+persist over the user's fresh mute.
+    // Captured before the value loop below: a toggleMute landing mid-loop bumps
+    // the mute generation, and a later capture would blind the 0x8D-readback
+    // guard to it; the readback could then setMuted(false) and persist over the
+    // user's fresh mute.
     let muteIssuedAtStart = issuedMuteGeneration
-    // This pass's own evidence, folded from `.notAttempted` rather than from
-    // what the last pass concluded (see `readEvidence`). Only the FAILED
-    // attempts fold, worst-wins; a success supersedes them outright.
-    var passEvidence = DDCReadEvidence.notAttempted
-    // The latch counts passes, not attempts: the retries are the reliability
-    // mechanism.
-    var answered = false
-    for _ in 0 ..< tries {
-      // Silence and zeros are different facts; the transport tells them apart, and
-      // `outcome.evidence` is the one place `max == 0` folds into zeros.
-      let outcome = await writer.readOutcome(command: readCode)
-      // A refusal ends the pass the way it ends the transport's own ladder: the
-      // panel read the request and said this register is not one it carries, and
-      // no retry can change that. Assigned rather than folded, because
-      // worst-wins ranks a silence above it: with the fold, one contended try
-      // among four refusals branded the whole pass silent, and two such passes
-      // published "Not answering" about a display that had replied every time.
-      if outcome.evidence == .refused {
-        passEvidence = .refused
+    // The skip is the VALUE register's own. VCP 0x8D is a separate register with
+    // a separate answer, so a latched 0x62 must not stop the mute readback at
+    // the end of this pass.
+    if !readSkip.skipsRead {
+      let tuning = prefs.tuning(for: command)
+      // Fork parity: reads use only the FIRST remap code.
+      let readCode = tuning.remapCodes.first ?? command.code
+      // Staleness fence. A read that began before a newer write must not
+      // overwrite it: the loop can span seconds on a wedged bus, and a slider
+      // drag or key that lands mid-flight must win over the stale read,
+      // INCLUDING in the persisted store. Any submit bumps the generation, so a
+      // mismatch means user input superseded this read.
+      let issuedAtStart = issuedGeneration
+      // This pass's own evidence, folded from `.notAttempted` rather than from
+      // what the last pass concluded (see `readEvidence`). Only the FAILED
+      // attempts fold; a success supersedes them outright.
+      var passEvidence = DDCReadEvidence.notAttempted
+      // The latch counts passes, not attempts: the retries are the reliability
+      // mechanism.
+      var answered = false
+      for _ in 0 ..< tries {
+        // Silence and zeros are different facts; the transport tells them apart, and
+        // `outcome.evidence` is the one place `max == 0` folds into zeros.
+        let outcome = await writer.readOutcome(command: readCode)
+        // A refusal ends the pass the way it ends the transport's own ladder: the
+        // panel read the request and said this register is not one it carries,
+        // and no retry can change that.
+        //
+        // The ordering is the transport's, not `DDCReadEvidence.worse`: a
+        // refusal supersedes a silence and loses to zeros, because the more
+        // specific observation about the register wins and a panel that put
+        // zeros on the bus said something about every code. `worse` ranks a
+        // refusal below both silences, which is right for the fold ACROSS a
+        // display's controllers, where a refused register must never speak for
+        // the display. Inside the pass it is wrong twice over: one contended try
+        // ahead of the refusal would publish `.noReply` about a panel that
+        // replied every time, and the latch would then close on a finding the
+        // panel never gave.
+        if outcome.evidence == .refused {
+          passEvidence = passEvidence == .allZeros ? .allZeros : .refused
+          break
+        }
+        guard let result = outcome.value, result.max > 0 else {
+          // Held, not published: the latch below decides once the pass concludes.
+          passEvidence = DDCReadEvidence.worse(passEvidence, outcome.evidence)
+          continue
+        }
+        // Recorded BEFORE the staleness fence: the panel answered, and that is
+        // true whether or not user input superseded the value we were about to
+        // adopt. Returning here without recording would hide a good panel behind
+        // a race. The latch is recorded here for the same reason.
+        readSkip.record(.answered)
+        readEvidence = .answered
+        answered = true
+        // The max is real information on every validated read (the loop guard
+        // proved `max > 0`), and it is a fact about the panel rather than about
+        // anyone's intent, so it is learned before BOTH exits below: the staleness
+        // fence, which supersedes the value alone, and the artifact skip, which
+        // concerns `current` only. Either one taking the max with it leaves
+        // `readMax` nil and later writes scaled against the assumed 100.
+        readMax = Int(result.max)
+        guard issuedGeneration == issuedAtStart else { return }
+        // Muted default-strategy register 0 is the mute ARTIFACT, not
+        // information: adopting/persisting it would destroy the
+        // unmute restore target.
+        if command == .volume, isMuted, result.current == 0 { break }
+        let adopted = DimmingMath.ddcToValue(
+          result.current,
+          minDDC: Double(tuning.minDDCOverride),
+          maxDDC: Double(tuning.effectiveMaxDDC(readMax: Int(result.max))),
+          curve: tuning.curveMultiplier,
+          invert: tuning.invert
+        )
+        value = adopted
+        persist(adopted)
         break
       }
-      guard let result = outcome.value, result.max > 0 else {
-        // Held, not published: the latch below decides once the pass concludes.
-        passEvidence = DDCReadEvidence.worse(passEvidence, outcome.evidence)
-        continue
-      }
-      // Recorded BEFORE the staleness fence: the panel answered, and that is
-      // true whether or not user input superseded the value we were about to
-      // adopt. Returning here without recording would hide a good panel behind
-      // a race. The latch is recorded here for the same reason.
-      readSkip.record(.answered)
-      readEvidence = .answered
-      answered = true
-      // The max is real information on every validated read (the loop guard
-      // proved `max > 0`), and it is a fact about the panel rather than about
-      // anyone's intent, so it is learned before BOTH exits below: the staleness
-      // fence, which supersedes the value alone, and the artifact skip, which
-      // concerns `current` only. Either one taking the max with it leaves
-      // `readMax` nil and later writes scaled against the assumed 100.
-      readMax = Int(result.max)
-      guard issuedGeneration == issuedAtStart else { return }
-      // Muted default-strategy register 0 is the mute ARTIFACT, not
-      // information: adopting/persisting it would destroy the
-      // unmute restore target.
-      if command == .volume, isMuted, result.current == 0 { break }
-      let adopted = DimmingMath.ddcToValue(
-        result.current,
-        minDDC: Double(tuning.minDDCOverride),
-        maxDDC: Double(tuning.effectiveMaxDDC(readMax: Int(result.max))),
-        curve: tuning.curveMultiplier,
-        invert: tuning.invert
-      )
-      value = adopted
-      persist(adopted)
-      break
+      // No answer this pass. Zeros publish at once; a lone silence waits for a
+      // second. A settling pass that only ever heard silence is dropped instead:
+      // the latch never sees it, so it cannot pair with a contended pass to brand
+      // a panel that answers.
+      if !answered, !(settling && passEvidence == .noReply),
+         readSkip.record(passEvidence) { readEvidence = passEvidence }
     }
-    // No answer this pass. Zeros publish at once; a lone silence waits for a
-    // second. A settling pass that only ever heard silence is dropped instead:
-    // the latch never sees it, so it cannot pair with a contended pass to brand
-    // a panel that answers.
-    if !answered, !(settling && passEvidence == .noReply),
-       readSkip.record(passEvidence) { readEvidence = passEvidence }
     // The strategy in force, not the pref: 0x8D is where this display's mute
     // lives only if the display takes 0x8D. Asking a register the display
     // denies and adopting its answer would write a mute state nothing ever

--- a/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
+++ b/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
@@ -97,7 +97,8 @@ public final class DDCValueController: PendingWireDraining {
   /// before it in its pass.
   ///
   /// A pass that ends in silence does not supersede this either: `DDCReadSkipLatch`
-  /// decides, on two consecutive silent passes. Clears reach only the skip.
+  /// decides, on two consecutive silent passes. Wake and reconfiguration clear
+  /// only the skip; a different panel or read register also resets its evidence.
   public private(set) var readEvidence: DDCReadEvidence = .notAttempted
 
   /// Whether this register is still worth asking about. Its own, never the
@@ -411,13 +412,15 @@ public final class DDCValueController: PendingWireDraining {
     // guard to it; the readback could then setMuted(false) and persist over the
     // user's fresh mute.
     let muteIssuedAtStart = issuedMuteGeneration
+    let tuning = prefs.tuning(for: command)
+    // Reads use only the first remap code; trailing codes affect writes alone.
+    let readCode = tuning.remapCodes.first ?? command.code
+    bindReadRegister(to: readCode)
     // The skip is the VALUE register's own. VCP 0x8D is a separate register with
     // a separate answer, so a latched 0x62 must not stop the mute readback at
     // the end of this pass.
     if !readSkip.skipsRead {
-      let tuning = prefs.tuning(for: command)
-      // Fork parity: reads use only the FIRST remap code.
-      let readCode = tuning.remapCodes.first ?? command.code
+      let registerAtStart = readSkip.registerGeneration
       // Staleness fence. A read that began before a newer write must not
       // overwrite it: the loop can span seconds on a wedged bus, and a slider
       // drag or key that lands mid-flight must win over the stale read,
@@ -435,6 +438,10 @@ public final class DDCValueController: PendingWireDraining {
         // Silence and zeros are different facts; the transport tells them apart, and
         // `outcome.evidence` is the one place `max == 0` folds into zeros.
         let outcome = await writer.readOutcome(command: readCode)
+        // An old register's answer must not affect the new register's latch,
+        // evidence or scale, even if preferences changed without a refresh.
+        bindReadRegister(to: prefs.tuning(for: command).remapCodes.first ?? command.code)
+        guard readSkip.registerGeneration == registerAtStart else { return }
         // A refusal ends the pass the way it ends the transport's own ladder: the
         // panel read the request and said this register is not one it carries,
         // and no retry can change that.
@@ -648,6 +655,12 @@ public final class DDCValueController: PendingWireDraining {
   public func resetWriteMemo() {
     coalescer.resetDuplicateState()
     muteCoalescer.resetDuplicateState()
+  }
+
+  private func bindReadRegister(to code: UInt8) {
+    guard readSkip.bind(to: code) else { return }
+    readEvidence = .notAttempted
+    readMax = nil
   }
 
   /// Reached through the display's brightness controller, which owns the wire's

--- a/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
+++ b/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
@@ -393,7 +393,12 @@ public final class DDCValueController: PendingWireDraining {
   ///
   /// Skipped after two silent passes (`DDCReadSkipLatch`). It matters more here
   /// than for brightness: this loop spends `pollingTries` transactions per pass.
-  public func refreshFromHardware() async {
+  ///
+  /// `settling` marks a pass a topology change triggered, where the wire is still
+  /// renegotiating and a silence is evidence about the moment rather than the
+  /// panel. Such a pass is dropped whole: not counted, not published, the skip
+  /// untouched. Zeros and frames publish as they always did.
+  public func refreshFromHardware(settling: Bool = false) async {
     guard prefs.startupAction == .read, isAvailable else { return }
     let tries = prefs.pollingTries
     guard tries > 0 else { return }
@@ -456,8 +461,12 @@ public final class DDCValueController: PendingWireDraining {
       persist(adopted)
       break
     }
-    // No answer this pass. Zeros publish at once; a lone silence waits for a second.
-    if !answered, readSkip.record(passEvidence) { readEvidence = passEvidence }
+    // No answer this pass. Zeros publish at once; a lone silence waits for a
+    // second. A settling pass that only ever heard silence is dropped instead:
+    // the latch never sees it, so it cannot pair with a contended pass to brand
+    // a panel that answers.
+    if !answered, !(settling && passEvidence == .noReply),
+       readSkip.record(passEvidence) { readEvidence = passEvidence }
     // The strategy in force, not the pref: 0x8D is where this display's mute
     // lives only if the display takes 0x8D. Asking a register the display
     // denies and adopting its answer would write a mute state nothing ever

--- a/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
+++ b/CandelaKit/Sources/CandelaKit/Commands/DDCValueController.swift
@@ -392,7 +392,8 @@ public final class DDCValueController: PendingWireDraining {
   /// of zero: the fork's unvalidated read clobbered saved values to 0.
   ///
   /// Skipped after two silent passes (`DDCReadSkipLatch`). It matters more here
-  /// than for brightness: this loop spends `pollingTries` transactions per pass.
+  /// than for brightness: this loop spends `pollingTries` transactions per pass,
+  /// which is also why a refusal ends the loop on the try that carried it.
   ///
   /// `settling` marks a pass a topology change triggered, where the wire is still
   /// renegotiating and a silence is evidence about the moment rather than the
@@ -428,6 +429,16 @@ public final class DDCValueController: PendingWireDraining {
       // Silence and zeros are different facts; the transport tells them apart, and
       // `outcome.evidence` is the one place `max == 0` folds into zeros.
       let outcome = await writer.readOutcome(command: readCode)
+      // A refusal ends the pass the way it ends the transport's own ladder: the
+      // panel read the request and said this register is not one it carries, and
+      // no retry can change that. Assigned rather than folded, because
+      // worst-wins ranks a silence above it: with the fold, one contended try
+      // among four refusals branded the whole pass silent, and two such passes
+      // published "Not answering" about a display that had replied every time.
+      if outcome.evidence == .refused {
+        passEvidence = .refused
+        break
+      }
       guard let result = outcome.value, result.max > 0 else {
         // Held, not published: the latch below decides once the pass concludes.
         passEvidence = DDCReadEvidence.worse(passEvidence, outcome.evidence)
@@ -440,12 +451,14 @@ public final class DDCValueController: PendingWireDraining {
       readSkip.record(.answered)
       readEvidence = .answered
       answered = true
-      guard issuedGeneration == issuedAtStart else { return }
       // The max is real information on every validated read (the loop guard
-      // proved `max > 0`); learn it BEFORE the artifact skip below, which
-      // concerns `current` only — otherwise the skip path leaves `readMax`
-      // nil and later writes scale against the assumed 100.
+      // proved `max > 0`), and it is a fact about the panel rather than about
+      // anyone's intent, so it is learned before BOTH exits below: the staleness
+      // fence, which supersedes the value alone, and the artifact skip, which
+      // concerns `current` only. Either one taking the max with it leaves
+      // `readMax` nil and later writes scaled against the assumed 100.
       readMax = Int(result.max)
+      guard issuedGeneration == issuedAtStart else { return }
       // Muted default-strategy register 0 is the mute ARTIFACT, not
       // information: adopting/persisting it would destroy the
       // unmute restore target.

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -8,14 +8,11 @@ import CandelaPrivateAPIs
 let ARM64_DDC_7BIT_ADDRESS: UInt8 = 0x37 // This works with DisplayPort devices
 let ARM64_DDC_DATA_ADDRESS: UInt8 = 0x51
 
-/// The floor between two packets on ONE display's I2C bus, measured from when
-/// the last call on that bus returned rather than paid before every packet.
+/// The floor between two packets on one display's I2C bus, measured from the
+/// last call's return rather than paid before every packet. Paying it up front
+/// cost every command 10 ms of dead time on a transaction measured at about
+/// 14 ms, even on a bus idle for minutes; measuring keeps every gap that exists.
 ///
-/// Paying it up front cost every command 10 ms of dead time even when the bus
-/// had been idle for minutes, which on a transaction measured at about 14 ms is
-/// most of it. Measuring it instead keeps every gap that exists today (a burst
-/// of writes, a read followed at once by a write) and drops only the wait
-/// nothing was waiting for.
 /// One per display for the life of the process (`DDCBusPacerRegistry`), so two
 /// panels never pace each other and two services for one panel never race.
 ///
@@ -56,7 +53,8 @@ final class DDCBusPacer: @unchecked Sendable {
   }
 }
 
-/// One pacer per display, held for the life of the process.
+/// One pacer per display, held for the life of the process. Services are rebuilt
+/// on every refresh while the retired one can still drain a queued write
 /// (`DDCCommandApplier` holds its writer as a `let`), so a per-service pacer let
 /// two pacers each believe one bus was quiet.
 ///
@@ -246,15 +244,9 @@ public class Arm64DDC: NSObject {
     case silent
   }
 
-  /// The non-zero fill the reply buffer carries into every read call.
-  ///
-  /// `IOAVServiceReadI2C` can return success without writing the buffer, so with
-  /// the zero-filled buffer this used to hand it, "the panel answered with
-  /// eleven zeros" and "nothing was written here at all" were the same bytes and
-  /// the write-only verdict was a claim the instrument could not support. Only a
-  /// buffer that CHANGED to zeros is evidence about the panel. 0xFF is also what
-  /// an idle I2C line reads as, so a floating read lands in the same bucket as an
-  /// untouched buffer, which is where it belongs.
+  /// The reply buffer's fill before every read call. `IOAVServiceReadI2C` can
+  /// return success without writing the buffer, so a zero fill made "answered
+  /// zeros" and "wrote nothing" the same bytes. 0xFF is also what an idle I2C
   /// line reads as, so a floating read counts as untouched.
   static let replySentinel: UInt8 = 0xFF
 

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -16,28 +16,21 @@ let ARM64_DDC_DATA_ADDRESS: UInt8 = 0x51
 /// most of it. Measuring it instead keeps every gap that exists today (a burst
 /// of writes, a read followed at once by a write) and drops only the wait
 /// nothing was waiting for.
+/// One per display for the life of the process (`DDCBusPacerRegistry`), so two
+/// panels never pace each other and two services for one panel never race.
 ///
-/// One per display: `Arm64DDCService` is the per-display actor and owns one of
-/// these, so two panels never pace each other.
-///
-/// `@unchecked Sendable`: the two fields are confined by `lock`, and the clock
-/// is a `@Sendable` closure. The actor serializes its own display's calls, but
-/// the entry points below are static and reachable from anywhere.
+/// `@unchecked Sendable`: both fields are confined by `lock` and the clock is a
+/// `@Sendable` closure; the static entry points and the registry share it
+/// across actors.
 final class DDCBusPacer: @unchecked Sendable {
   private let now: @Sendable () -> UInt64
   private let lock = NSLock()
   private var lastCallEnd: UInt64
 
-  /// The clock is injected so a test can pin all three gap cases without
-  /// spending real time.
-  ///
-  /// The bus starts SEEN, not quiet. A pacer's lifetime is its service object's,
-  /// and `DisplayDiscovery.discover()` builds a fresh `Arm64DDCService` on every
-  /// refresh (wake, reconfiguration, a menu open), so an empty pacer would let
-  /// the first packet after a refresh follow the retired service's traffic by
-  /// microseconds. That is the one direction this change must never go, and on
-  /// the write-only MAG it would be silent. The cost is one floor's wait per
-  /// fresh service; every quiet-bus win survives it.
+  /// Injected clock so tests spend no real time. The bus starts SEEN, not quiet:
+  /// another writer may have used it microseconds ago, and on a write-only panel
+  /// a packet inside the floor fails silently. Costs one floor's wait per display
+  /// per process.
   init(now: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }) {
     self.now = now
     self.lastCallEnd = now()
@@ -60,6 +53,34 @@ final class DDCBusPacer: @unchecked Sendable {
     self.lock.lock()
     self.lastCallEnd = self.now()
     self.lock.unlock()
+  }
+}
+
+/// One pacer per display, held for the life of the process.
+/// (`DDCCommandApplier` holds its writer as a `let`), so a per-service pacer let
+/// two pacers each believe one bus was quiet.
+///
+/// Keyed on display ID, which a replug can reassign; that costs at most one
+/// misattributed floor across an interval measured in seconds.
+/// `@unchecked Sendable`: the table is confined by `lock`.
+final class DDCBusPacerRegistry: @unchecked Sendable {
+  static let shared = DDCBusPacerRegistry()
+
+  private let lock = NSLock()
+  private var pacers: [CGDirectDisplayID: DDCBusPacer] = [:]
+
+  /// `now` seeds a pacer on first sight only: a rebuilt service does not restart
+  /// the clock.
+  func pacer(
+    for displayID: CGDirectDisplayID,
+    now: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+  ) -> DDCBusPacer {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    if let existing = self.pacers[displayID] { return existing }
+    let fresh = DDCBusPacer(now: now)
+    self.pacers[displayID] = fresh
+    return fresh
   }
 }
 
@@ -257,12 +278,9 @@ public class Arm64DDC: NSObject {
     return .ok
   }
 
-  /// One attempt's verdict folded into the transaction's.
-  ///
-  /// `answeredZeros` is the more specific finding and outlives a later attempt
-  /// that got nothing at all, the ordering `DDCReadEvidence.worse` uses for the
-  /// same reason. Only a valid frame supersedes it, and the ladder returns on
-  /// that outright rather than folding it.
+  /// One attempt's verdict folded into the transaction's: `answeredZeros` outlives
+  /// a later silence, the ordering `DDCReadEvidence.worse` uses. The ladder returns
+  /// on `.ok` rather than folding it; the `.ok` arms only keep this total.
   static func fold(_ transaction: TransactionOutcome, _ attempt: TransactionOutcome) -> TransactionOutcome {
     switch (transaction, attempt) {
     case (.ok, _), (_, .ok): .ok

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -63,31 +63,39 @@ public class Arm64DDC: NSObject {
   }
 
   public static func read(service: IOAVService?, command: UInt8, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> (current: UInt16, max: UInt16)? {
-    var values: (UInt16, UInt16)?
+    self.readOutcome(service: service, command: command, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime).value
+  }
+
+  /// The same Get VCP transaction, keeping what the wire proved.
+  ///
+  /// `command` goes down into the ladder so every ATTEMPT is validated against
+  /// it. A frame that arrives and answers something else is retried like any
+  /// other failed read and, if nothing better comes back, reports `noReply`
+  /// rather than earning a fourth case: the panel said something, but nothing
+  /// about the code that was asked, which is what that verdict has always
+  /// covered.
+  public static func readOutcome(service: IOAVService?, command: UInt8, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> DDCReadOutcome {
     var send: [UInt8] = [command]
-    var reply = [UInt8](repeating: 0, count: 11)
-    if Self.performDDCCommunication(service: service, send: &send, reply: &reply, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime) {
-      // The checksum alone is a 1-in-256 guard. Without the op-code and
-      // result-code check the Intel transport has always made, a display
-      // answering with stale bytes, or answering a DIFFERENT VCP code than the
-      // one asked for, produces a plausible `max` that silently compresses the
-      // whole range.
-      if DDCReplyFrame.rejection(for: reply, command: command) != nil {
-        return nil
-      }
-      let max = DDCReplyFrame.value(high: reply[6], low: reply[7])
-      let current = DDCReplyFrame.value(high: reply[8], low: reply[9])
-      values = (current, max)
-    } else {
-      values = nil
+    var reply = [UInt8](repeating: 0, count: DDCReplyFrame.expectedLength)
+    switch Self.performDDCCommunication(service: service, send: &send, reply: &reply, replyCommand: command, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime) {
+    case .ok:
+      // Validated per attempt inside the ladder, so `.ok` here means a frame
+      // that answered THIS code, not merely one whose checksum added up.
+      return .frame(
+        current: DDCReplyFrame.value(high: reply[8], low: reply[9]),
+        max: DDCReplyFrame.value(high: reply[6], low: reply[7])
+      )
+    case .answeredZeros:
+      return .allZeros
+    case .silent:
+      return .noReply
     }
-    return values
   }
 
   public static func write(service: IOAVService?, command: UInt8, value: UInt16, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> Bool {
     var send: [UInt8] = [command, UInt8(value >> 8), UInt8(value & 255)]
     var reply: [UInt8] = []
-    return Self.performDDCCommunication(service: service, send: &send, reply: &reply, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime)
+    return Self.performDDCCommunication(service: service, send: &send, reply: &reply, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime) == .ok
   }
 
   /// One DDC/CI Capabilities Request (op 0xF3) at `offset`.
@@ -141,14 +149,98 @@ public class Arm64DDC: NSObject {
     return nil
   }
 
-  static func performDDCCommunication(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> Bool {
-    let dataAddress = ARM64_DDC_DATA_ADDRESS
-    var success = false
-    guard service != nil else {
-      return success
+  /// What one DDC transaction proved. `write` collapses it back to a Bool;
+  /// `readOutcome` keeps the distinction the sentinel below buys.
+  enum TransactionOutcome: Equatable {
+    /// The write was acknowledged and, where a reply was expected, a
+    /// checksum-clean frame came back.
+    case ok
+    /// The panel wrote zeros over the sentinel: it is on the bus and saying
+    /// nothing. The write-only signature.
+    case answeredZeros
+    /// Nothing usable: a refused write, a failed read call, a buffer the read
+    /// left untouched, or a frame that failed its checksum.
+    case silent
+  }
+
+  /// The non-zero fill the reply buffer carries into every read call.
+  ///
+  /// `IOAVServiceReadI2C` can return success without writing the buffer, so with
+  /// the zero-filled buffer this used to hand it, "the panel answered with
+  /// eleven zeros" and "nothing was written here at all" were the same bytes and
+  /// the write-only verdict was a claim the instrument could not support. Only a
+  /// buffer that CHANGED to zeros is evidence about the panel. 0xFF is also what
+  /// an idle I2C line reads as, so a floating read lands in the same bucket as an
+  /// untouched buffer, which is where it belongs.
+  /// line reads as, so a floating read counts as untouched.
+  static let replySentinel: UInt8 = 0xFF
+
+  /// Verdict for a reply buffer whose read call reported success. Validated here,
+  /// inside the ladder, so a frame answering a DIFFERENT code gets the same retry
+  /// as any failed read.
+  static func replyVerdict(_ reply: [UInt8], command: UInt8? = nil) -> TransactionOutcome {
+    guard reply.count >= 2 else { return .silent }
+    var frame = reply
+    guard self.checksum(chk: 0x50, data: &frame, start: 0, end: frame.count - 2) == frame[frame.count - 1] else {
+      return reply.allSatisfy { $0 == 0 } ? .answeredZeros : .silent
     }
+    // The checksum alone is a 1-in-256 guard. Without the op-code and
+    // result-code check the Intel transport has always made, a display
+    // answering with stale bytes, or answering a DIFFERENT VCP code than the
+    // one asked for, produces a plausible `max` that silently compresses the
+    // whole range.
+    if let command, DDCReplyFrame.rejection(for: reply, command: command) != nil {
+      return .silent
+    }
+    return .ok
+  }
+
+  /// One attempt's verdict folded into the transaction's.
+  ///
+  /// `answeredZeros` is the more specific finding and outlives a later attempt
+  /// that got nothing at all, the ordering `DDCReadEvidence.worse` uses for the
+  /// same reason. Only a valid frame supersedes it, and the ladder returns on
+  /// that outright rather than folding it.
+  static func fold(_ transaction: TransactionOutcome, _ attempt: TransactionOutcome) -> TransactionOutcome {
+    switch (transaction, attempt) {
+    case (.ok, _), (_, .ok): .ok
+    case (.answeredZeros, _), (_, .answeredZeros): .answeredZeros
+    default: .silent
+    }
+  }
+
+  /// The two I2C calls a transaction makes, injected so the retry ladder, the
+  /// sentinel fill and the verdict folding can be driven from a test. `live` is
+  /// the private API itself; nothing but a test passes anything else.
+  struct I2CTransport: Sendable {
+    var write: @Sendable (IOAVService?, UnsafeMutableRawPointer, UInt32) -> Int32
+    var read: @Sendable (IOAVService?, UnsafeMutableRawPointer, UInt32) -> Int32
+
+    static let live = I2CTransport(
+      write: { service, bytes, count in
+        IOAVServiceWriteI2C(service, UInt32(ARM64_DDC_7BIT_ADDRESS), UInt32(ARM64_DDC_DATA_ADDRESS), bytes, count)
+      },
+      read: { service, bytes, count in
+        IOAVServiceReadI2C(service, UInt32(ARM64_DDC_7BIT_ADDRESS), 0, bytes, count)
+      }
+    )
+  }
+
+  static func performDDCCommunication(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], replyCommand: UInt8? = nil, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> TransactionOutcome {
+    guard service != nil else {
+      return .silent
+    }
+    return self.runTransaction(service: service, send: &send, reply: &reply, replyCommand: replyCommand, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime, transport: .live)
+  }
+
+  /// The retry ladder itself. Split from the entry point above only so the nil
+  /// service can be refused before any sleep is spent, and so a test can hand it
+  /// a panel.
+  static func runTransaction(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], replyCommand: UInt8?, writeSleepTime: UInt32?, numOfWriteCycles: UInt8?, readSleepTime: UInt32?, numOfRetryAttemps: UInt8?, retrySleepTime: UInt32?, transport: I2CTransport) -> TransactionOutcome {
+    let dataAddress = ARM64_DDC_DATA_ADDRESS
     var packet: [UInt8] = [UInt8(0x80 | (send.count + 1)), UInt8(send.count)] + send + [0] // Note: the last byte is the place of the checksum, see next line!
     packet[packet.count - 1] = self.checksum(chk: send.count == 1 ? ARM64_DDC_7BIT_ADDRESS << 1 : ARM64_DDC_7BIT_ADDRESS << 1 ^ dataAddress, data: &packet, start: 0, end: packet.count - 2)
+    var outcome = TransactionOutcome.silent
     for _ in 1 ... (numOfRetryAttemps ?? 4) + 1 {
       // ONE packet per logical write. The inherited default of 2 put two
       // identical packets on the bus for every write and cost 20 ms of sleep
@@ -156,22 +248,31 @@ public class Arm64DDC: NSObject {
       // the apply; measured, halving the traffic halved the on-wire time, and
       // the Dell's readback confirms the value ACHIEVED at 1 cycle. Retries
       // above are the reliability mechanism, not a blind second copy.
+      var wrote = false
       for _ in 1 ... max(numOfWriteCycles ?? 1, 1) {
         usleep(writeSleepTime ?? 10000)
-        success = IOAVServiceWriteI2C(service, UInt32(ARM64_DDC_7BIT_ADDRESS), UInt32(dataAddress), &packet, UInt32(packet.count)) == 0
+        wrote = transport.write(service, &packet, UInt32(packet.count)) == 0
       }
-      if !reply.isEmpty {
+      if reply.isEmpty {
+        if wrote { return .ok }
+      } else {
+        // Tracked apart from `wrote` deliberately. A write that lands and a
+        // reply read that fails is a failed READ and retries like one; carrying
+        // the write's success forward returned on attempt one and handed the
+        // caller a buffer the panel had never touched. The read is attempted
+        // whatever the write reported, as it always was: a NAKed write followed
+        // by a clean frame is still an answer.
+        for index in reply.indices { reply[index] = Self.replySentinel }
         usleep(readSleepTime ?? 50000)
-        if IOAVServiceReadI2C(service, UInt32(ARM64_DDC_7BIT_ADDRESS), 0, &reply, UInt32(reply.count)) == 0 {
-          success = self.checksum(chk: 0x50, data: &reply, start: 0, end: reply.count - 2) == reply[reply.count - 1]
+        if transport.read(service, &reply, UInt32(reply.count)) == 0 {
+          let verdict = Self.replyVerdict(reply, command: replyCommand)
+          if verdict == .ok { return .ok }
+          outcome = Self.fold(outcome, verdict)
         }
-      }
-      if success {
-        return success
       }
       usleep(retrySleepTime ?? 20000)
     }
-    return success
+    return outcome
   }
 
   /// DDC checksum calculator

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -380,13 +380,18 @@ public class Arm64DDC: NSObject {
           if verdict == .refused { return outcome }
         } else {
           failedReadCalls += 1
-          // A read CALL that failed never reached a panel, so the four remaining
+          // A read CALL that failed never reached a panel, so the remaining
           // attempts re-ask a wire that is not carrying reads, at about 80 ms
-          // each, on every pass for the life of the install. One retry, because a
-          // single dropped call on a busy bus is real and the next one usually
-          // lands. A frame that arrives and fails VALIDATION keeps the full
-          // ladder: there the panel did answer, and a garbled answer is the case
-          // retries exist for.
+          // each, on every pass for the life of the install. Two, not one: the
+          // inherited ladder stopped after a single attempt only because a failed
+          // read call left the WRITE result standing as the transaction's
+          // verdict, so the caller parsed a buffer the read never touched.
+          // Counting that call as a read failure is the fix, and this cap is the
+          // one extra attempt it costs, spent because a single dropped call on a
+          // busy bus is real and the next one usually lands. A read call that
+          // SUCCEEDS and leaves the buffer untouched, or brings back a frame
+          // that fails VALIDATION, keeps the full ladder: the wire is carrying
+          // reads there, and a garbled answer is the case retries exist for.
           if failedReadCalls >= Self.maxFailedReadCalls { return outcome }
         }
       }

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -146,7 +146,8 @@ public class Arm64DDC: NSObject {
 
   /// `read`, keeping what the wire proved. `command` goes into the ladder so every
   /// ATTEMPT is validated against it; a frame answering another code retries like
-  /// a failed read and ends as `noReply` rather than a fourth case.
+  /// a failed read and ends as `noReply`, while the panel's own result code for
+  /// the code asked about ends as `refused`.
   public static func readOutcome(service: IOAVService?, command: UInt8, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> DDCReadOutcome {
     self.readOutcome(service: service, command: command, pacer: nil, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime)
   }
@@ -166,6 +167,8 @@ public class Arm64DDC: NSObject {
       return .allZeros
     case .silent:
       return .noReply
+    case .refused:
+      return .refused
     }
   }
 
@@ -239,9 +242,14 @@ public class Arm64DDC: NSObject {
     /// The panel wrote zeros over the sentinel: it is on the bus and saying
     /// nothing. The write-only signature.
     case answeredZeros
-    /// Nothing usable: a refused write, a failed read call, a buffer the read
+    /// Nothing usable: a NAKed write, a failed read call, a buffer the read
     /// left untouched, or a frame that failed its checksum.
     case silent
+    /// The panel's own result code for the code asked about: it parsed the
+    /// request and answered that the register is not one it carries. Its own
+    /// outcome rather than a shade of `silent`, because it is a reply, and a
+    /// display that replies must not be reported as one that went quiet.
+    case refused
   }
 
   /// The reply buffer's fill before every read call. `IOAVServiceReadI2C` can
@@ -256,27 +264,14 @@ public class Arm64DDC: NSObject {
   /// other attempts went.
   static let maxFailedReadCalls = 2
 
-  /// What one attempt proved, and whether the ladder may stop on it.
-  struct AttemptVerdict: Equatable {
-    let outcome: TransactionOutcome
-    /// The panel's own result code for the code asked about. NOT an outcome of
-    /// its own: a refused register is still not a readable one, so the evidence
-    /// stays `.silent` and the read-skip latch counts it exactly as before. What
-    /// it buys is the four remaining attempts, which on a polling pass are four
-    /// ladders of dead bus time spent re-asking a question already answered.
-    let isRefusal: Bool
-  }
-
   /// Verdict for a reply buffer whose read call reported success. Validated here,
   /// inside the ladder, so a frame answering a DIFFERENT code gets the same retry
   /// as any failed read.
-  static func attemptVerdict(_ reply: [UInt8], command: UInt8? = nil) -> AttemptVerdict {
-    guard reply.count >= 2 else { return AttemptVerdict(outcome: .silent, isRefusal: false) }
+  static func replyVerdict(_ reply: [UInt8], command: UInt8? = nil) -> TransactionOutcome {
+    guard reply.count >= 2 else { return .silent }
     var frame = reply
     guard self.checksum(chk: 0x50, data: &frame, start: 0, end: frame.count - 2) == frame[frame.count - 1] else {
-      return AttemptVerdict(
-        outcome: reply.allSatisfy { $0 == 0 } ? .answeredZeros : .silent, isRefusal: false
-      )
+      return reply.allSatisfy { $0 == 0 } ? .answeredZeros : .silent
     }
     // The checksum alone is a 1-in-256 guard. Without the op-code and
     // result-code check the Intel transport has always made, a display
@@ -284,28 +279,27 @@ public class Arm64DDC: NSObject {
     // one asked for, produces a plausible `max` that silently compresses the
     // whole range.
     //
-    // The refusal is read only from a frame that PASSED the checksum, so the
+    // A refusal is read only from a frame that PASSED the checksum, so the
     // result code is a byte the panel meant to send rather than one landing
     // there by luck.
     if let command, DDCReplyFrame.rejection(for: reply, command: command) != nil {
-      return AttemptVerdict(
-        outcome: .silent, isRefusal: DDCReplyFrame.isRefusal(reply, of: command)
-      )
+      return DDCReplyFrame.isRefusal(reply, of: command) ? .refused : .silent
     }
-    return AttemptVerdict(outcome: .ok, isRefusal: false)
-  }
-
-  static func replyVerdict(_ reply: [UInt8], command: UInt8? = nil) -> TransactionOutcome {
-    self.attemptVerdict(reply, command: command).outcome
+    return .ok
   }
 
   /// One attempt's verdict folded into the transaction's: `answeredZeros` outlives
   /// a later silence, the ordering `DDCReadEvidence.worse` uses. The ladder returns
   /// on `.ok` rather than folding it; the `.ok` arms only keep this total.
+  ///
+  /// A refusal outlives a silence and loses to zeros, for the same reason zeros
+  /// beat silence: the more specific observation about the register wins, and a
+  /// panel that put zeros on the bus said something about every code.
   static func fold(_ transaction: TransactionOutcome, _ attempt: TransactionOutcome) -> TransactionOutcome {
     switch (transaction, attempt) {
     case (.ok, _), (_, .ok): .ok
     case (.answeredZeros, _), (_, .answeredZeros): .answeredZeros
+    case (.refused, _), (_, .refused): .refused
     default: .silent
     }
   }
@@ -377,13 +371,13 @@ public class Arm64DDC: NSObject {
         // Recorded whatever it returned: the bus was busy either way.
         pacer?.recordBusUse()
         if answered == 0 {
-          let verdict = Self.attemptVerdict(reply, command: replyCommand)
-          if verdict.outcome == .ok { return .ok }
-          outcome = Self.fold(outcome, verdict.outcome)
+          let verdict = Self.replyVerdict(reply, command: replyCommand)
+          if verdict == .ok { return .ok }
+          outcome = Self.fold(outcome, verdict)
           // The panel answered, and the answer was no. Retrying a refused code
           // cannot change it, and the caller polls this ladder several times a
           // pass. Folded first, so an earlier attempt's zeros still outlive it.
-          if verdict.isRefusal { return outcome }
+          if verdict == .refused { return outcome }
         } else {
           failedReadCalls += 1
           // A read CALL that failed never reached a panel, so the four remaining

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -8,6 +8,61 @@ import CandelaPrivateAPIs
 let ARM64_DDC_7BIT_ADDRESS: UInt8 = 0x37 // This works with DisplayPort devices
 let ARM64_DDC_DATA_ADDRESS: UInt8 = 0x51
 
+/// The floor between two packets on ONE display's I2C bus, measured from when
+/// the last call on that bus returned rather than paid before every packet.
+///
+/// Paying it up front cost every command 10 ms of dead time even when the bus
+/// had been idle for minutes, which on a transaction measured at about 14 ms is
+/// most of it. Measuring it instead keeps every gap that exists today (a burst
+/// of writes, a read followed at once by a write) and drops only the wait
+/// nothing was waiting for.
+///
+/// One per display: `Arm64DDCService` is the per-display actor and owns one of
+/// these, so two panels never pace each other.
+///
+/// `@unchecked Sendable`: the two fields are confined by `lock`, and the clock
+/// is a `@Sendable` closure. The actor serializes its own display's calls, but
+/// the entry points below are static and reachable from anywhere.
+final class DDCBusPacer: @unchecked Sendable {
+  private let now: @Sendable () -> UInt64
+  private let lock = NSLock()
+  private var lastCallEnd: UInt64
+
+  /// The clock is injected so a test can pin all three gap cases without
+  /// spending real time.
+  ///
+  /// The bus starts SEEN, not quiet. A pacer's lifetime is its service object's,
+  /// and `DisplayDiscovery.discover()` builds a fresh `Arm64DDCService` on every
+  /// refresh (wake, reconfiguration, a menu open), so an empty pacer would let
+  /// the first packet after a refresh follow the retired service's traffic by
+  /// microseconds. That is the one direction this change must never go, and on
+  /// the write-only MAG it would be silent. The cost is one floor's wait per
+  /// fresh service; every quiet-bus win survives it.
+  init(now: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }) {
+    self.now = now
+    self.lastCallEnd = now()
+  }
+
+  /// Microseconds still owed before the next packet may go out. Zero once the
+  /// bus has been quiet longer than the floor.
+  func deficit(floor: UInt32) -> UInt32 {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    let current = self.now()
+    // A clock that went backwards pays the full floor: the conservative direction.
+    let elapsed = current > self.lastCallEnd ? (current - self.lastCallEnd) / 1000 : 0
+    return elapsed >= UInt64(floor) ? 0 : floor - UInt32(elapsed)
+  }
+
+  /// Call after every I2C call on this display, whatever it returned: the bus
+  /// was busy either way.
+  func recordBusUse() {
+    self.lock.lock()
+    self.lastCallEnd = self.now()
+    self.lock.unlock()
+  }
+}
+
 public class Arm64DDC: NSObject {
   static let MAX_MATCH_SCORE: Int = 20
 
@@ -62,25 +117,28 @@ public class Arm64DDC: NSObject {
     return matchedDisplayServices
   }
 
+  // WARNING: these pacer-less entry points neither pace from the bus nor record
+  // use of it, so calling one for a display an `Arm64DDCService` also drives
+  // leaves that actor's pacer believing the bus was quiet. Route DDC through
+  // the actor.
   public static func read(service: IOAVService?, command: UInt8, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> (current: UInt16, max: UInt16)? {
     self.readOutcome(service: service, command: command, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime).value
   }
 
-  /// The same Get VCP transaction, keeping what the wire proved.
-  ///
-  /// `command` goes down into the ladder so every ATTEMPT is validated against
-  /// it. A frame that arrives and answers something else is retried like any
-  /// other failed read and, if nothing better comes back, reports `noReply`
-  /// rather than earning a fourth case: the panel said something, but nothing
-  /// about the code that was asked, which is what that verdict has always
-  /// covered.
+  /// `read`, keeping what the wire proved. `command` goes into the ladder so every
+  /// ATTEMPT is validated against it; a frame answering another code retries like
+  /// a failed read and ends as `noReply` rather than a fourth case.
   public static func readOutcome(service: IOAVService?, command: UInt8, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> DDCReadOutcome {
+    self.readOutcome(service: service, command: command, pacer: nil, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime)
+  }
+
+  static func readOutcome(service: IOAVService?, command: UInt8, pacer: DDCBusPacer?, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> DDCReadOutcome {
     var send: [UInt8] = [command]
     var reply = [UInt8](repeating: 0, count: DDCReplyFrame.expectedLength)
-    switch Self.performDDCCommunication(service: service, send: &send, reply: &reply, replyCommand: command, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime) {
+    switch Self.performDDCCommunication(service: service, send: &send, reply: &reply, replyCommand: command, pacer: pacer, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime) {
     case .ok:
-      // Validated per attempt inside the ladder, so `.ok` here means a frame
-      // that answered THIS code, not merely one whose checksum added up.
+      // Validated per attempt inside the ladder: `.ok` means a frame answering
+      // THIS code.
       return .frame(
         current: DDCReplyFrame.value(high: reply[8], low: reply[9]),
         max: DDCReplyFrame.value(high: reply[6], low: reply[7])
@@ -93,9 +151,13 @@ public class Arm64DDC: NSObject {
   }
 
   public static func write(service: IOAVService?, command: UInt8, value: UInt16, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> Bool {
+    self.write(service: service, command: command, value: value, pacer: nil, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime)
+  }
+
+  static func write(service: IOAVService?, command: UInt8, value: UInt16, pacer: DDCBusPacer?, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> Bool {
     var send: [UInt8] = [command, UInt8(value >> 8), UInt8(value & 255)]
     var reply: [UInt8] = []
-    return Self.performDDCCommunication(service: service, send: &send, reply: &reply, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime) == .ok
+    return Self.performDDCCommunication(service: service, send: &send, reply: &reply, pacer: pacer, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime) == .ok
   }
 
   /// One DDC/CI Capabilities Request (op 0xF3) at `offset`.
@@ -209,12 +271,15 @@ public class Arm64DDC: NSObject {
     }
   }
 
-  /// The two I2C calls a transaction makes, injected so the retry ladder, the
-  /// sentinel fill and the verdict folding can be driven from a test. `live` is
-  /// the private API itself; nothing but a test passes anything else.
+  /// The two I2C calls and the sleep between them, injected so a test can drive
+  /// the retry ladder and see the ORDER of sleeps against packets. `live` is the
+  /// private API; nothing but a test passes anything else.
   struct I2CTransport: Sendable {
     var write: @Sendable (IOAVService?, UnsafeMutableRawPointer, UInt32) -> Int32
     var read: @Sendable (IOAVService?, UnsafeMutableRawPointer, UInt32) -> Int32
+    /// A recorded call, because where a sleep falls relative to a packet is the
+    /// write path's whole latency.
+    var sleep: @Sendable (UInt32) -> Void = { usleep($0) }
 
     static let live = I2CTransport(
       write: { service, bytes, count in
@@ -226,21 +291,25 @@ public class Arm64DDC: NSObject {
     )
   }
 
-  static func performDDCCommunication(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], replyCommand: UInt8? = nil, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> TransactionOutcome {
+  static func performDDCCommunication(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], replyCommand: UInt8? = nil, pacer: DDCBusPacer? = nil, writeSleepTime: UInt32? = nil, numOfWriteCycles: UInt8? = nil, readSleepTime: UInt32? = nil, numOfRetryAttemps: UInt8? = nil, retrySleepTime: UInt32? = nil) -> TransactionOutcome {
     guard service != nil else {
       return .silent
     }
-    return self.runTransaction(service: service, send: &send, reply: &reply, replyCommand: replyCommand, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime, transport: .live)
+    return self.runTransaction(service: service, send: &send, reply: &reply, replyCommand: replyCommand, writeSleepTime: writeSleepTime, numOfWriteCycles: numOfWriteCycles, readSleepTime: readSleepTime, numOfRetryAttemps: numOfRetryAttemps, retrySleepTime: retrySleepTime, pacer: pacer, transport: .live)
   }
 
-  /// The retry ladder itself. Split from the entry point above only so the nil
-  /// service can be refused before any sleep is spent, and so a test can hand it
-  /// a panel.
-  static func runTransaction(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], replyCommand: UInt8?, writeSleepTime: UInt32?, numOfWriteCycles: UInt8?, readSleepTime: UInt32?, numOfRetryAttemps: UInt8?, retrySleepTime: UInt32?, transport: I2CTransport) -> TransactionOutcome {
+  /// The retry ladder. Split from the entry point so a nil service is refused
+  /// before any sleep, and so a test can hand it a panel.
+  static func runTransaction(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], replyCommand: UInt8?, writeSleepTime: UInt32?, numOfWriteCycles: UInt8?, readSleepTime: UInt32?, numOfRetryAttemps: UInt8?, retrySleepTime: UInt32?, pacer: DDCBusPacer?, transport: I2CTransport) -> TransactionOutcome {
     let dataAddress = ARM64_DDC_DATA_ADDRESS
     var packet: [UInt8] = [UInt8(0x80 | (send.count + 1)), UInt8(send.count)] + send + [0] // Note: the last byte is the place of the checksum, see next line!
     packet[packet.count - 1] = self.checksum(chk: send.count == 1 ? ARM64_DDC_7BIT_ADDRESS << 1 : ARM64_DDC_7BIT_ADDRESS << 1 ^ dataAddress, data: &packet, start: 0, end: packet.count - 2)
     var outcome = TransactionOutcome.silent
+    let pacing = writeSleepTime ?? 10000
+    // Only the FIRST packet is paced from the bus; a second write cycle or a
+    // retry keeps the full sleep it always had. With no pacer the floor is paid
+    // in full.
+    var firstPacket = true
     for _ in 1 ... (numOfRetryAttemps ?? 4) + 1 {
       // ONE packet per logical write. The inherited default of 2 put two
       // identical packets on the bus for every write and cost 20 ms of sleep
@@ -250,27 +319,30 @@ public class Arm64DDC: NSObject {
       // above are the reliability mechanism, not a blind second copy.
       var wrote = false
       for _ in 1 ... max(numOfWriteCycles ?? 1, 1) {
-        usleep(writeSleepTime ?? 10000)
+        let owed = firstPacket ? (pacer?.deficit(floor: pacing) ?? pacing) : pacing
+        firstPacket = false
+        if owed > 0 { transport.sleep(owed) }
         wrote = transport.write(service, &packet, UInt32(packet.count)) == 0
+        pacer?.recordBusUse()
       }
       if reply.isEmpty {
         if wrote { return .ok }
       } else {
-        // Tracked apart from `wrote` deliberately. A write that lands and a
-        // reply read that fails is a failed READ and retries like one; carrying
-        // the write's success forward returned on attempt one and handed the
-        // caller a buffer the panel had never touched. The read is attempted
-        // whatever the write reported, as it always was: a NAKed write followed
-        // by a clean frame is still an answer.
+        // Not carried from `wrote`: a landed write with a failed reply read is a
+        // failed READ and retries like one. The read still runs after a NAKed
+        // write, as it always did: a clean frame behind it is still an answer.
         for index in reply.indices { reply[index] = Self.replySentinel }
-        usleep(readSleepTime ?? 50000)
-        if transport.read(service, &reply, UInt32(reply.count)) == 0 {
+        transport.sleep(readSleepTime ?? 50000)
+        let answered = transport.read(service, &reply, UInt32(reply.count))
+        // Recorded whatever it returned: the bus was busy either way.
+        pacer?.recordBusUse()
+        if answered == 0 {
           let verdict = Self.replyVerdict(reply, command: replyCommand)
           if verdict == .ok { return .ok }
           outcome = Self.fold(outcome, verdict)
         }
       }
-      usleep(retrySleepTime ?? 20000)
+      transport.sleep(retrySleepTime ?? 20000)
     }
     return outcome
   }

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -250,24 +250,47 @@ public class Arm64DDC: NSObject {
   /// line reads as, so a floating read counts as untouched.
   static let replySentinel: UInt8 = 0xFF
 
+  /// What one attempt proved, and whether the ladder may stop on it.
+  struct AttemptVerdict: Equatable {
+    let outcome: TransactionOutcome
+    /// The panel's own result code for the code asked about. NOT an outcome of
+    /// its own: a refused register is still not a readable one, so the evidence
+    /// stays `.silent` and the read-skip latch counts it exactly as before. What
+    /// it buys is the four remaining attempts, which on a polling pass are four
+    /// ladders of dead bus time spent re-asking a question already answered.
+    let isRefusal: Bool
+  }
+
   /// Verdict for a reply buffer whose read call reported success. Validated here,
   /// inside the ladder, so a frame answering a DIFFERENT code gets the same retry
   /// as any failed read.
-  static func replyVerdict(_ reply: [UInt8], command: UInt8? = nil) -> TransactionOutcome {
-    guard reply.count >= 2 else { return .silent }
+  static func attemptVerdict(_ reply: [UInt8], command: UInt8? = nil) -> AttemptVerdict {
+    guard reply.count >= 2 else { return AttemptVerdict(outcome: .silent, isRefusal: false) }
     var frame = reply
     guard self.checksum(chk: 0x50, data: &frame, start: 0, end: frame.count - 2) == frame[frame.count - 1] else {
-      return reply.allSatisfy { $0 == 0 } ? .answeredZeros : .silent
+      return AttemptVerdict(
+        outcome: reply.allSatisfy { $0 == 0 } ? .answeredZeros : .silent, isRefusal: false
+      )
     }
     // The checksum alone is a 1-in-256 guard. Without the op-code and
     // result-code check the Intel transport has always made, a display
     // answering with stale bytes, or answering a DIFFERENT VCP code than the
     // one asked for, produces a plausible `max` that silently compresses the
     // whole range.
+    //
+    // The refusal is read only from a frame that PASSED the checksum, so the
+    // result code is a byte the panel meant to send rather than one landing
+    // there by luck.
     if let command, DDCReplyFrame.rejection(for: reply, command: command) != nil {
-      return .silent
+      return AttemptVerdict(
+        outcome: .silent, isRefusal: DDCReplyFrame.isRefusal(reply, of: command)
+      )
     }
-    return .ok
+    return AttemptVerdict(outcome: .ok, isRefusal: false)
+  }
+
+  static func replyVerdict(_ reply: [UInt8], command: UInt8? = nil) -> TransactionOutcome {
+    self.attemptVerdict(reply, command: command).outcome
   }
 
   /// One attempt's verdict folded into the transaction's: `answeredZeros` outlives
@@ -347,9 +370,13 @@ public class Arm64DDC: NSObject {
         // Recorded whatever it returned: the bus was busy either way.
         pacer?.recordBusUse()
         if answered == 0 {
-          let verdict = Self.replyVerdict(reply, command: replyCommand)
-          if verdict == .ok { return .ok }
-          outcome = Self.fold(outcome, verdict)
+          let verdict = Self.attemptVerdict(reply, command: replyCommand)
+          if verdict.outcome == .ok { return .ok }
+          outcome = Self.fold(outcome, verdict.outcome)
+          // The panel answered, and the answer was no. Retrying a refused code
+          // cannot change it, and the caller polls this ladder several times a
+          // pass. Folded first, so an earlier attempt's zeros still outlive it.
+          if verdict.isRefusal { return outcome }
         }
       }
       transport.sleep(retrySleepTime ?? 20000)

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -250,6 +250,12 @@ public class Arm64DDC: NSObject {
   /// line reads as, so a floating read counts as untouched.
   static let replySentinel: UInt8 = 0xFF
 
+  /// How many failed reply-read CALLS one transaction pays for before it stops.
+  /// Counted across the whole ladder rather than consecutively: a transaction
+  /// that has seen two calls fail has learned what the wire is doing however the
+  /// other attempts went.
+  static let maxFailedReadCalls = 2
+
   /// What one attempt proved, and whether the ladder may stop on it.
   struct AttemptVerdict: Equatable {
     let outcome: TransactionOutcome
@@ -343,6 +349,7 @@ public class Arm64DDC: NSObject {
     // retry keeps the full sleep it always had. With no pacer the floor is paid
     // in full.
     var firstPacket = true
+    var failedReadCalls = 0
     for _ in 1 ... (numOfRetryAttemps ?? 4) + 1 {
       // ONE packet per logical write. The inherited default of 2 put two
       // identical packets on the bus for every write and cost 20 ms of sleep
@@ -377,6 +384,16 @@ public class Arm64DDC: NSObject {
           // cannot change it, and the caller polls this ladder several times a
           // pass. Folded first, so an earlier attempt's zeros still outlive it.
           if verdict.isRefusal { return outcome }
+        } else {
+          failedReadCalls += 1
+          // A read CALL that failed never reached a panel, so the four remaining
+          // attempts re-ask a wire that is not carrying reads, at about 80 ms
+          // each, on every pass for the life of the install. One retry, because a
+          // single dropped call on a busy bus is real and the next one usually
+          // lands. A frame that arrives and fails VALIDATION keeps the full
+          // ladder: there the panel did answer, and a garbled answer is the case
+          // retries exist for.
+          if failedReadCalls >= Self.maxFailedReadCalls { return outcome }
         }
       }
       transport.sleep(retrySleepTime ?? 20000)

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -15,9 +15,6 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   private let box: ServiceBox
-  /// This display's bus floor, and only this display's, shared with every other
-  /// service ever built for it: a write to one panel never delays a write to
-  /// another, and a service retired mid-drain cannot spend the new one's floor.
   /// This display's bus floor, shared with every service ever built for it: a
   /// service retired mid-drain cannot spend the new one's floor.
   private let pacer: DDCBusPacer

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -1,6 +1,10 @@
 import CandelaPrivateAPIs
 import os
 
+/// One line per DDC read. Nothing else reports which of the two silent verdicts
+/// a panel earned, and that is the whole of a write-only panel's signature.
+let ddcReadLog = Logger(subsystem: "com.rydersel.Candela", category: "ddcread")
+
 /// Serializes DDC I/O for one display's IOAVService (spec §5: serial per-display actor).
 public actor Arm64DDCService: DDCWriting {
   /// Wraps CFTypeRef to satisfy strict concurrency: the actor serializes all access,
@@ -30,7 +34,23 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   public func read(command: UInt8) async -> (current: UInt16, max: UInt16)? {
-    Arm64DDC.read(service: box.service, command: command)
+    await readOutcome(command: command).value
+  }
+
+  public func readOutcome(command: UInt8) async -> DDCReadOutcome {
+    let outcome = Arm64DDC.readOutcome(service: box.service, command: command)
+    // The rig's only instrument for which branch a silent panel takes. A read
+    // costs a menu open or a wake, not a drag, so one line per read is cheap;
+    // `.info` because `log show` does not persist `.debug`.
+    switch outcome {
+    case let .frame(current, max):
+      ddcReadLog.info("ddc.read command=0x\(UInt(command), format: .hex) outcome=frame current=\(current) max=\(max)")
+    case .allZeros:
+      ddcReadLog.info("ddc.read command=0x\(UInt(command), format: .hex) outcome=zeros")
+    case .noReply:
+      ddcReadLog.info("ddc.read command=0x\(UInt(command), format: .hex) outcome=silent")
+    }
+    return outcome
   }
 
   public func readCapabilityString() async -> String? {

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -1,4 +1,5 @@
 import CandelaPrivateAPIs
+import CoreGraphics
 import os
 
 /// One line per DDC read. Nothing else reports which of the two silent verdicts
@@ -14,16 +15,32 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   private let box: ServiceBox
-  /// This display's bus floor, and only this display's: the pacer is per actor,
-  /// so a write to one panel never delays a write to another.
-  private let pacer = DDCBusPacer()
+  /// This display's bus floor, and only this display's, shared with every other
+  /// service ever built for it: a write to one panel never delays a write to
+  /// another, and a service retired mid-drain cannot spend the new one's floor.
+  /// This display's bus floor, shared with every service ever built for it: a
+  /// service retired mid-drain cannot spend the new one's floor.
+  private let pacer: DDCBusPacer
+  /// Hashed: a raw persistence key can embed the panel's serial number and
+  /// these log lines are `.public`.
+  private let logTag: String
 
-  private init(box: ServiceBox) {
+  private init(box: ServiceBox, pacer: DDCBusPacer, logTag: String) {
     self.box = box
+    self.pacer = pacer
+    self.logTag = logTag
   }
 
-  nonisolated static func create(service: IOAVService?) -> Arm64DDCService {
-    Arm64DDCService(box: ServiceBox(service: service))
+  /// `displayID` keys the shared pacer; `logTag` is `DisplayLogging.tag(for:)` of
+  /// the persistence key, so a read verdict is attributable with two panels.
+  nonisolated static func create(
+    service: IOAVService?, displayID: CGDirectDisplayID, logTag: String
+  ) -> Arm64DDCService {
+    Arm64DDCService(
+      box: ServiceBox(service: service),
+      pacer: DDCBusPacerRegistry.shared.pacer(for: displayID),
+      logTag: logTag
+    )
   }
 
   public func write(command: UInt8, value: UInt16) async -> Bool {
@@ -43,16 +60,16 @@ public actor Arm64DDCService: DDCWriting {
 
   public func readOutcome(command: UInt8) async -> DDCReadOutcome {
     let outcome = Arm64DDC.readOutcome(service: box.service, command: command, pacer: pacer)
-    // The rig's only instrument for which branch a silent panel takes. A read
-    // costs a menu open or a wake, not a drag, so one line per read is cheap;
-    // `.info` because `log show` does not persist `.debug`.
+    // The only instrument for which silent branch a panel takes. Reads happen on
+    // menu open or wake, not at drag rate, so one line each is cheap; `.info`
+    // because `log show` does not persist `.debug`.
     switch outcome {
     case let .frame(current, max):
-      ddcReadLog.info("ddc.read command=0x\(UInt(command), format: .hex) outcome=frame current=\(current) max=\(max)")
+      ddcReadLog.info("ddc.read display=\(self.logTag, privacy: .public) command=0x\(UInt(command), format: .hex) outcome=frame current=\(current) max=\(max)")
     case .allZeros:
-      ddcReadLog.info("ddc.read command=0x\(UInt(command), format: .hex) outcome=zeros")
+      ddcReadLog.info("ddc.read display=\(self.logTag, privacy: .public) command=0x\(UInt(command), format: .hex) outcome=zeros")
     case .noReply:
-      ddcReadLog.info("ddc.read command=0x\(UInt(command), format: .hex) outcome=silent")
+      ddcReadLog.info("ddc.read display=\(self.logTag, privacy: .public) command=0x\(UInt(command), format: .hex) outcome=silent")
     }
     return outcome
   }

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -57,7 +57,7 @@ public actor Arm64DDCService: DDCWriting {
 
   public func readOutcome(command: UInt8) async -> DDCReadOutcome {
     let outcome = Arm64DDC.readOutcome(service: box.service, command: command, pacer: pacer)
-    // The only instrument for which silent branch a panel takes. Reads happen on
+    // The only instrument for which branch a panel takes. Reads happen on
     // menu open or wake, not at drag rate, so one line each is cheap; `.info`
     // because `log show` does not persist `.debug`.
     switch outcome {
@@ -67,6 +67,8 @@ public actor Arm64DDCService: DDCWriting {
       ddcReadLog.info("ddc.read display=\(self.logTag, privacy: .public) command=0x\(UInt(command), format: .hex) outcome=zeros")
     case .noReply:
       ddcReadLog.info("ddc.read display=\(self.logTag, privacy: .public) command=0x\(UInt(command), format: .hex) outcome=silent")
+    case .refused:
+      ddcReadLog.info("ddc.read display=\(self.logTag, privacy: .public) command=0x\(UInt(command), format: .hex) outcome=refused")
     }
     return outcome
   }

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -14,6 +14,9 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   private let box: ServiceBox
+  /// This display's bus floor, and only this display's: the pacer is per actor,
+  /// so a write to one panel never delays a write to another.
+  private let pacer = DDCBusPacer()
 
   private init(box: ServiceBox) {
     self.box = box
@@ -24,11 +27,12 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   public func write(command: UInt8, value: UInt16) async -> Bool {
-    // start/end pair also exposes the per-transaction duration (~30 ms).
+    // start/end pair also exposes the per-transaction duration: ~14 ms, from
+    // the MAG's nine-write ramp measured at 0.129 s.
     // `.info`: the default level persists every one of these to disk at drag
     // rate, and `.debug` is invisible to the `log show` the regression rig parses.
     dragPerfLog.info("ddc.write.start value=\(value)")
-    let ok = Arm64DDC.write(service: box.service, command: command, value: value)
+    let ok = Arm64DDC.write(service: box.service, command: command, value: value, pacer: pacer)
     dragPerfLog.info("ddc.write.end value=\(value) ok=\(ok)")
     return ok
   }
@@ -38,7 +42,7 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   public func readOutcome(command: UInt8) async -> DDCReadOutcome {
-    let outcome = Arm64DDC.readOutcome(service: box.service, command: command)
+    let outcome = Arm64DDC.readOutcome(service: box.service, command: command, pacer: pacer)
     // The rig's only instrument for which branch a silent panel takes. A read
     // costs a menu open or a wake, not a drag, so one line per read is cheap;
     // `.info` because `log show` does not persist `.debug`.
@@ -54,6 +58,9 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   public func readCapabilityString() async -> String? {
+    // The fragment loop paces itself, but it leaves the bus busy: without this
+    // the next write would see an idle bus and skip the floor.
+    defer { pacer.recordBusUse() }
     var bytes: [UInt8] = []
     var offset: UInt16 = 0
     // Real strings run 200–800 bytes. The caps exist so a panel that never

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadEvidence.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadEvidence.swift
@@ -8,9 +8,11 @@
 /// answered with nothing. Wiring it up needs a decision about what a truncated
 /// string proves.
 ///
-/// [MEASURED] The MAG 341C answers every DDC read with zeros — verified across
-/// 13 timing/buffer combinations and 5 VCP codes. Silence about this is what
-/// let the fork's unvalidated reads clobber saved values to 0.
+/// [MEASURED] No DDC read of the MAG 341C returns anything usable: verified
+/// across 13 timing/buffer combinations and 5 VCP codes, into a zero-filled
+/// buffer that could not tell "answered zeros" from "wrote nothing". Which of the
+/// two verdicts below it earns is the transport's call, not assumed here.
+/// Silence about the failure is what let the fork clobber saved values to 0.
 ///
 /// Deliberately a pure value, not state on a controller-owner:
 /// `AppModel.DisplayState` holds `controller`, `volume` and `contrast` as
@@ -22,9 +24,11 @@ public enum DDCReadEvidence: Sendable, Equatable {
   case notAttempted
   /// At least one read came back with `max > 0`. This panel answers.
   case answered
-  /// Reads returned `(0, 0)` / `max == 0` — the write-only signature.
+  /// The panel wrote nothing but zeros over the transport's sentinel, or
+  /// answered a frame whose `max` is 0. The write-only signature either way.
   case allZeros
-  /// Reads returned nil: no reply, bad checksum, wrong opcode or wrong offset.
+  /// Nothing usable came back: a silent bus, a read call that left the reply
+  /// buffer untouched, or a frame that failed its checksum, op code or offset.
   case noReply
 
   /// Worst-wins ordering. `allZeros` outranks `noReply` because it is the more

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadEvidence.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadEvidence.swift
@@ -30,16 +30,29 @@ public enum DDCReadEvidence: Sendable, Equatable {
   /// Nothing usable came back: a silent bus, a read call that left the reply
   /// buffer untouched, or a frame that failed its checksum, op code or offset.
   case noReply
+  /// The panel answered with a result code: it parsed the request and said this
+  /// register is not one it carries. The Dell answers VCP 0x62 that way.
+  ///
+  /// An ANSWER, not a fault. The value is unreadable, but the wire carried a
+  /// reply, so a display whose volume register is refused is not a display that
+  /// stopped answering, and the two must not read the same.
+  case refused
 
   /// Worst-wins ordering. `allZeros` outranks `noReply` because it is the more
   /// SPECIFIC finding — the panel is on the bus and talking, it just never
   /// says anything true — and that is the sentence the user needs.
+  ///
+  /// `refused` sits between the floor and `answered`: it is a real finding, so it
+  /// supersedes "nothing asked yet", and it is the panel replying, so a sibling
+  /// that returned a value speaks for the display instead. Below both silences on
+  /// purpose, which is what keeps a refused register out of "not answering".
   private var severity: Int {
     switch self {
     case .notAttempted: 0
-    case .answered: 1
-    case .noReply: 2
-    case .allZeros: 3
+    case .refused: 1
+    case .answered: 2
+    case .noReply: 3
+    case .allZeros: 4
     }
   }
 

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadOutcome.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadOutcome.swift
@@ -1,0 +1,28 @@
+/// What one DDC read transaction got back. An optional tuple could not separate
+/// a panel that puts zeros on the bus from one that never answers, and only the
+/// first is the write-only signature. Transports that cannot tell say `noReply`.
+public enum DDCReadOutcome: Sendable, Equatable {
+  /// A checksum-clean Get VCP reply for the code that was asked. A `max` of 0 is
+  /// still a refusal; what this case carries is that a FRAME arrived.
+  case frame(current: UInt16, max: UInt16)
+  /// The panel wrote zeros over the transport's sentinel: it is on the bus and
+  /// saying nothing.
+  case allZeros
+  /// Nothing usable came back: a silent bus, a reply that failed validation, or
+  /// a read call that reported success and left the buffer untouched.
+  case noReply
+
+  public var value: (current: UInt16, max: UInt16)? {
+    guard case let .frame(current, max) = self else { return nil }
+    return (current, max)
+  }
+
+  /// `max == 0` folds to `allZeros` here, once, so the two read sites cannot drift.
+  public var evidence: DDCReadEvidence {
+    switch self {
+    case let .frame(_, max): max > 0 ? .answered : .allZeros
+    case .allZeros: .allZeros
+    case .noReply: .noReply
+    }
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadOutcome.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadOutcome.swift
@@ -2,8 +2,8 @@
 /// a panel that puts zeros on the bus from one that never answers, and only the
 /// first is the write-only signature. Transports that cannot tell say `noReply`.
 public enum DDCReadOutcome: Sendable, Equatable {
-  /// A checksum-clean Get VCP reply for the code that was asked. A `max` of 0 is
-  /// still a refusal; what this case carries is that a FRAME arrived.
+  /// A checksum-clean Get VCP reply for the code that was asked. A `max` of 0
+  /// carries no value; what this case carries is that a FRAME arrived.
   case frame(current: UInt16, max: UInt16)
   /// The panel wrote zeros over the transport's sentinel: it is on the bus and
   /// saying nothing.
@@ -11,6 +11,10 @@ public enum DDCReadOutcome: Sendable, Equatable {
   /// Nothing usable came back: a silent bus, a reply that failed validation, or
   /// a read call that reported success and left the buffer untouched.
   case noReply
+  /// The panel's own result code for this register: it read the request and
+  /// answered that it does not carry the code. Separate from `noReply` because
+  /// it is a reply, and separate from `frame` because there is no value in it.
+  case refused
 
   public var value: (current: UInt16, max: UInt16)? {
     guard case let .frame(current, max) = self else { return nil }
@@ -23,6 +27,7 @@ public enum DDCReadOutcome: Sendable, Equatable {
     case let .frame(_, max): max > 0 ? .answered : .allZeros
     case .allZeros: .allZeros
     case .noReply: .noReply
+    case .refused: .refused
     }
   }
 }

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
@@ -11,7 +11,8 @@
 /// answering" on a single bad pass.
 ///
 /// Counts passes, never attempts. Also decides when silence becomes a VERDICT:
-/// a frame or zeros publish at once, silence only on the pass that trips the latch.
+/// a frame, zeros or a refusal publish at once, silence only on the pass that
+/// trips the latch.
 struct DDCReadSkipLatch: Sendable, Equatable {
   static let latchAfter = 2
 
@@ -25,21 +26,27 @@ struct DDCReadSkipLatch: Sendable, Equatable {
 
   /// Records one pass and answers whether the caller should PUBLISH it, in one
   /// call so no site can ask before recording. `notAttempted` is not a pass and
-  /// changes nothing. A frame or zeros supersede at once; silence only once it
-  /// has happened twice running, and a zeros pass in between breaks the run.
+  /// changes nothing. A frame, zeros or a refusal supersede at once; silence only
+  /// once it has happened twice running, and a different pass in between breaks
+  /// the run.
+  ///
+  /// A refusal counts toward the skip even though it is an answer: it is the
+  /// panel's settled word about that register, so re-asking spends the wire on a
+  /// question already answered. It publishes on its first pass for the same
+  /// reason zeros do, being the panel's own word rather than a busy bus.
   @discardableResult
   mutating func record(_ evidence: DDCReadEvidence) -> Bool {
     switch evidence {
-    case .noReply, .allZeros:
+    case .noReply, .allZeros, .refused:
       if runningNonAnswer == evidence {
         // Capped so a long-silent panel cannot count past the latch.
         consecutiveNonAnswers = min(consecutiveNonAnswers + 1, Self.latchAfter)
       } else {
-        // A different nothing starts its own run; one of each is contention.
+        // A different finding starts its own run; one of each is contention.
         runningNonAnswer = evidence
         consecutiveNonAnswers = 1
       }
-      return evidence == .allZeros || skipsRead
+      return evidence != .noReply || skipsRead
     case .answered:
       runningNonAnswer = nil
       consecutiveNonAnswers = 0

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
@@ -16,6 +16,20 @@
 struct DDCReadSkipLatch: Sendable, Equatable {
   static let latchAfter = 2
 
+  private var readCode: UInt8?
+  private(set) var registerGeneration: UInt64 = 0
+
+  /// A remap asks a different register, even on the same panel. The generation
+  /// also rejects an old in-flight answer after observing a change away and back.
+  @discardableResult
+  mutating func bind(to code: UInt8) -> Bool {
+    guard readCode != code else { return false }
+    readCode = code
+    registerGeneration &+= 1
+    clear()
+    return true
+  }
+
   /// Which nothing the current run is made of, so a run is only ever the same
   /// finding repeating. nil once a pass has answered.
   private var runningNonAnswer: DDCReadEvidence?

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
@@ -1,0 +1,47 @@
+/// When a display's DDC reads stop being worth attempting.
+///
+/// A read pass on a silent panel walks the whole retry ladder with the wire
+/// held, which is the menu-close stall a person feels, so a panel that says
+/// nothing is asked once per plug rather than on every pass. What decides that
+/// is TWO consecutive silent passes, not one: bus contention, the probe holding
+/// the wire, another panel entering HDR and a wedged transaction all produce one
+/// bad pass on a display that answers perfectly on the next, and latching on the
+/// first would publish "does not answer reads" about the Dell for the rest of
+/// the plug. The cost of the second pass is one more futile read pass per plug
+/// on a genuinely write-only panel.
+///
+/// Counts PASSES, never attempts: a pass that retries internally is one
+/// hearing, and the retries are the reliability mechanism rather than evidence
+/// of their own.
+///
+/// Separate from `DDCReadEvidence`, which is what diagnostics reports. The
+/// verdict is published from the first silent pass; only the asking waits for
+/// the second.
+struct DDCReadSkipLatch: Sendable, Equatable {
+  static let latchAfter = 2
+
+  private(set) var consecutiveSilentPasses = 0
+
+  /// Whether the next pass should skip the wire entirely.
+  var skipsRead: Bool { consecutiveSilentPasses >= Self.latchAfter }
+
+  /// One pass's verdict. `notAttempted` is not a pass and leaves the count
+  /// alone: a controller that returned before reaching the wire has learned
+  /// nothing about the panel either way.
+  mutating func record(_ evidence: DDCReadEvidence) {
+    switch evidence {
+    case .noReply, .allZeros:
+      // Capped so a long-lived silent panel cannot count past the latch and
+      // make the value itself unstable.
+      consecutiveSilentPasses = min(consecutiveSilentPasses + 1, Self.latchAfter)
+    case .answered:
+      consecutiveSilentPasses = 0
+    case .notAttempted:
+      break
+    }
+  }
+
+  /// Anything that may have changed the panel's mind: a wake, a
+  /// reconfiguration, a rebind onto another panel, an HDR window closing.
+  mutating func clear() { consecutiveSilentPasses = 0 }
+}

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReadSkipLatch.swift
@@ -1,47 +1,60 @@
 /// When a display's DDC reads stop being worth attempting.
 ///
-/// A read pass on a silent panel walks the whole retry ladder with the wire
-/// held, which is the menu-close stall a person feels, so a panel that says
-/// nothing is asked once per plug rather than on every pass. What decides that
-/// is TWO consecutive silent passes, not one: bus contention, the probe holding
-/// the wire, another panel entering HDR and a wedged transaction all produce one
-/// bad pass on a display that answers perfectly on the next, and latching on the
-/// first would publish "does not answer reads" about the Dell for the rest of
-/// the plug. The cost of the second pass is one more futile read pass per plug
-/// on a genuinely write-only panel.
+/// A read pass on a panel that gives nothing back holds the wire for the whole
+/// retry ladder, which is the menu-close stall a person feels, so such a panel
+/// is asked once per plug. Two consecutive passes of the SAME nothing, not one:
+/// bus contention, the probe holding the wire and another panel entering HDR
+/// all produce one bad pass on a display that answers on the next, and the
+/// Dell has answered silence on a plug-in pass and right after a mode change.
+/// Zeros and silence are different findings, so one of each is contention, not
+/// a run: taking them as a pair flipped the MAG from "Write-only" to "Not
+/// answering" on a single bad pass.
 ///
-/// Counts PASSES, never attempts: a pass that retries internally is one
-/// hearing, and the retries are the reliability mechanism rather than evidence
-/// of their own.
-///
-/// Separate from `DDCReadEvidence`, which is what diagnostics reports. The
-/// verdict is published from the first silent pass; only the asking waits for
-/// the second.
+/// Counts passes, never attempts. Also decides when silence becomes a VERDICT:
+/// a frame or zeros publish at once, silence only on the pass that trips the latch.
 struct DDCReadSkipLatch: Sendable, Equatable {
   static let latchAfter = 2
 
-  private(set) var consecutiveSilentPasses = 0
+  /// Which nothing the current run is made of, so a run is only ever the same
+  /// finding repeating. nil once a pass has answered.
+  private var runningNonAnswer: DDCReadEvidence?
+  private(set) var consecutiveNonAnswers = 0
 
   /// Whether the next pass should skip the wire entirely.
-  var skipsRead: Bool { consecutiveSilentPasses >= Self.latchAfter }
+  var skipsRead: Bool { consecutiveNonAnswers >= Self.latchAfter }
 
-  /// One pass's verdict. `notAttempted` is not a pass and leaves the count
-  /// alone: a controller that returned before reaching the wire has learned
-  /// nothing about the panel either way.
-  mutating func record(_ evidence: DDCReadEvidence) {
+  /// Records one pass and answers whether the caller should PUBLISH it, in one
+  /// call so no site can ask before recording. `notAttempted` is not a pass and
+  /// changes nothing. A frame or zeros supersede at once; silence only once it
+  /// has happened twice running, and a zeros pass in between breaks the run.
+  @discardableResult
+  mutating func record(_ evidence: DDCReadEvidence) -> Bool {
     switch evidence {
     case .noReply, .allZeros:
-      // Capped so a long-lived silent panel cannot count past the latch and
-      // make the value itself unstable.
-      consecutiveSilentPasses = min(consecutiveSilentPasses + 1, Self.latchAfter)
+      if runningNonAnswer == evidence {
+        // Capped so a long-silent panel cannot count past the latch.
+        consecutiveNonAnswers = min(consecutiveNonAnswers + 1, Self.latchAfter)
+      } else {
+        // A different nothing starts its own run; one of each is contention.
+        runningNonAnswer = evidence
+        consecutiveNonAnswers = 1
+      }
+      return evidence == .allZeros || skipsRead
     case .answered:
-      consecutiveSilentPasses = 0
+      runningNonAnswer = nil
+      consecutiveNonAnswers = 0
+      return true
     case .notAttempted:
-      break
+      return false
     }
   }
 
-  /// Anything that may have changed the panel's mind: a wake, a
-  /// reconfiguration, a rebind onto another panel, an HDR window closing.
-  mutating func clear() { consecutiveSilentPasses = 0 }
+  /// Anything that may have changed the panel's mind: wake, reconfiguration,
+  /// rebind, an HDR window closing. Clears the skip only: the read pass runs
+  /// before the reconfiguration clear, and wiping the verdict here left the hub
+  /// reading "Not asked yet" on both panels after every reconfiguration [MEASURED].
+  mutating func clear() {
+    runningNonAnswer = nil
+    consecutiveNonAnswers = 0
+  }
 }

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCReplyFrame.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCReplyFrame.swift
@@ -45,6 +45,27 @@ enum DDCReplyFrame {
     return nil
   }
 
+  /// Whether this frame is the display's OWN refusal of `command`: it parsed the
+  /// request and filled in a result code saying no.
+  ///
+  /// True only for a frame addressed to us, carrying a VCP reply op code, a
+  /// non-zero result code, and echoing the code that was asked about. Every
+  /// other rejection is malformed, stale or mis-addressed, says nothing about
+  /// the register, and is worth asking again; this one is an answer, so asking
+  /// again asks a question the panel has already answered.
+  ///
+  /// Byte 4 is part of the test on purpose. `rejection` reports the result code
+  /// before it looks at the echo, so a non-zero result on a frame naming ANOTHER
+  /// code would otherwise pass for an answer about this one. A stale reply is
+  /// the likelier reading, and retrying is the conservative direction.
+  ///
+  /// The checksum is deliberately NOT checked here: this answers what a frame
+  /// says, and whether its bytes can be believed is the caller's own question.
+  static func isRefusal(_ reply: [UInt8], of command: UInt8) -> Bool {
+    guard case .displayReportedError = rejection(for: reply, command: command) else { return false }
+    return reply[4] == command
+  }
+
   /// Big-endian 16-bit read.
   ///
   /// Spelled with the widening BEFORE the shift: `UInt16(high << 8)` shifts in

--- a/CandelaKit/Sources/CandelaKit/DDC/DDCWireHealth.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/DDCWireHealth.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Whether this display's DDC wire is still carrying writes, counted from what
 /// the applies ACTUALLY reported.
 ///
-/// Keyed on writes, not reads: the MAG341C answers every read with zeros and
-/// honours every write, so a rule keyed on read evidence would demote the panel
-/// it looks worst on.
+/// Keyed on writes, not reads: a write-only panel honours every write and returns
+/// nothing usable from any read, so a rule keyed on read evidence would demote the
+/// panel it looks worst on.
 ///
 /// No clock and no display in it, so the rule is tested without hardware; the
 /// controller decides which applies reach it.

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
@@ -202,14 +202,17 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
         \(mode.ioModeID, privacy: .public), reports \(achieved ?? -1, privacy: .public)
         """
       )
-      // Deliberately not a platform error code: the platform did not report
-      // one, which is the entire point of this check.
-      throw DisplayConfigError(cgErrorCode: CGError.failure.rawValue)
+      // This commit went through, so the same error as the published path:
+      // callers must revert, not report "nothing changed". The id compare is
+      // sound here because CoreGraphics and CGS share one mode-ID space.
+      throw DisplayConfigError(
+        unhonouredCommit: .init(requested: mode, achieved: achievedMode(displayID)))
     }
   }
 
   /// The public path: resolve the `CGDisplayMode`, cross-check the geometry it
-  /// actually denotes, then stage and commit.
+  /// actually denotes, stage, commit, then read back what the display is
+  /// actually running.
   private func applyPublishedMode(
     _ mode: DisplayMode, to displayID: CGDirectDisplayID, scope: DisplayConfigScope
   ) throws {
@@ -250,6 +253,62 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
     guard result == .success else {
       throw DisplayConfigError(cgErrorCode: result.rawValue)
     }
+
+    // THE RETURN CODE IS NOT THE EVIDENCE, the achieved mode is. The cross-check
+    // above proves the id still denotes the geometry asked for; it proves
+    // nothing about what the commit then did with it.
+    //
+    // Bounded settle rather than one immediate read, the shape `applyRotation`
+    // uses: the window server lands a mode change asynchronously, so a single
+    // read can still describe the outgoing mode and report a false miss. Half a
+    // second, because a change that has not landed by then is not landing.
+    //
+    // The first read is taken BEFORE any sleep and an honoured commit returns on
+    // it, so a caller on the main actor pays this block only on the failure
+    // path. 50 ms between polls for the same reason: ten reads is ample
+    // resolution for a settle measured in tens of milliseconds, and a tighter
+    // loop only spends more of a blocked main thread on a case already lost.
+    let deadline = Date().addingTimeInterval(0.5)
+    var achieved = achievedMode(displayID)
+    while ModeApplyVerification.verdict(requested: mode, achieved: achieved) == .unhonoured,
+      Date() < deadline
+    {
+      Thread.sleep(forTimeInterval: 0.05)
+      achieved = achievedMode(displayID)
+    }
+    guard ModeApplyVerification.verdict(requested: mode, achieved: achieved) == .honoured else {
+      // Both geometries, here and in the error: a code alone says nothing about
+      // which mode is on the glass.
+      Logger(subsystem: "com.rydersel.Candela", category: "topology").error(
+        """
+        CoreGraphics returned success for a mode it did not apply: display \
+        \(displayID, privacy: .public) asked for \
+        \(Self.geometry(of: mode), privacy: .public), reports \
+        \(achieved.map(Self.geometry) ?? "nothing", privacy: .public)
+        """
+      )
+      // Its own error, not a platform code: THIS one committed, so a caller
+      // holding a fallback must use it.
+      throw DisplayConfigError(
+        unhonouredCommit: .init(requested: mode, achieved: achieved))
+    }
+  }
+
+  /// The live mode as CoreGraphics reports it, deliberately NOT through
+  /// Not `currentMode(for:)`: that resolves against the deduplicated list and
+  /// answers nil for anything missing from it, which the settle loop would read
+  /// as a mode that never landed. It also re-enumerates every CGS descriptor.
+  private func achievedMode(_ displayID: CGDirectDisplayID) -> DisplayMode? {
+    CGDisplayCopyDisplayMode(displayID).map {
+      Self.displayMode(ioModeID: $0.ioDisplayModeID, mode: $0)
+    }
+  }
+
+  private static func geometry(of mode: DisplayMode) -> String {
+    """
+    \(mode.logicalWidth)x\(mode.logicalHeight) \
+    px\(mode.pixelWidth)x\(mode.pixelHeight) @\(mode.refreshHz)Hz
+    """
   }
 
   /// The same transaction discipline as `apply`, with the mirror call

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
@@ -192,8 +192,13 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
       throw DisplayConfigError(cgErrorCode: result.rawValue)
     }
 
-    // THE RETURN CODE IS NOT THE EVIDENCE — the achieved mode is.
-    let achieved = CGDisplayCopyDisplayMode(displayID)?.ioDisplayModeID
+    // THE RETURN CODE IS NOT THE EVIDENCE: the achieved mode is. Same bounded
+    // settle as the published path, for the same reason: the window server lands
+    // a mode change asynchronously, so one immediate read can still describe the
+    // outgoing mode and would report an honoured apply as unhonoured.
+    let achieved = settledRevealedModeID(requested: mode) {
+      CGDisplayCopyDisplayMode(displayID)?.ioDisplayModeID
+    }
     guard achieved == mode.ioModeID else {
       Logger(subsystem: "com.rydersel.Candela", category: "topology").error(
         """
@@ -255,22 +260,9 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
     }
 
     // THE RETURN CODE IS NOT THE EVIDENCE; the achieved mode is. Bounded settle
-    // rather than one read, as `applyRotation` does: the window server lands a
-    // mode change asynchronously, so a single read can still describe the
-    // outgoing mode. Half a second, because a change not landed by then is not
-    // landing. The first read is taken before any sleep, so an honoured commit
-    // pays nothing.
-    //
-    // Blocks the calling thread: the main actor for an interactive apply, a
-    // cooperative thread for the preview session and checkup runners. The
-    // alternative was reporting an unverified apply.
-    let deadline = Date().addingTimeInterval(0.5)
-    var achieved = achievedMode(displayID)
-    while ModeApplyVerification.verdict(requested: mode, achieved: achieved) == .unhonoured,
-      Date() < deadline
-    {
-      Thread.sleep(forTimeInterval: 0.05)
-      achieved = achievedMode(displayID)
+    // rather than one read, as `applyRotation` does.
+    let achieved = settled(read: { achievedMode(displayID) }) {
+      ModeApplyVerification.verdict(requested: mode, achieved: $0) == .honoured
     }
     guard ModeApplyVerification.verdict(requested: mode, achieved: achieved) == .honoured else {
       // Both geometries, here and in the error: a code alone says nothing about
@@ -288,6 +280,65 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
       throw DisplayConfigError(
         unhonouredCommit: .init(requested: mode, achieved: achieved))
     }
+  }
+
+  /// The window in which a committed mode change is still allowed to be landing.
+  /// Half a second, because a change not landed by then is not landing.
+  static let modeSettleWindow: TimeInterval = 0.5
+  static let modeSettlePoll: TimeInterval = 0.05
+
+  /// Re-reads the achieved state until it matches or the window closes, and
+  /// hands back the LAST reading either way, so the caller reports what the
+  /// display actually said rather than a stale first look.
+  ///
+  /// The window server lands a mode change asynchronously, so one immediate read
+  /// can still describe the outgoing mode. The read is taken before any sleep,
+  /// so an honoured apply pays nothing.
+  ///
+  /// Blocks the calling thread: the main actor for an interactive apply, a
+  /// cooperative thread for the preview session and checkup runners. The
+  /// alternative was reporting an unverified apply.
+  /// The revealed path's settle and its verdict together, split from the
+  /// CoreGraphics call so the pair tests without a display. The compare is
+  /// id-based and stays like with like across the loop: both sides are
+  /// `ioModeID`s in the one space CoreGraphics and CGS share, and the requested
+  /// id is fixed while only the read side moves. Geometry cannot stand in here,
+  /// because a revealed mode's CGS descriptor and the `CGDisplayMode` it lands as
+  /// do not have to spell the same size.
+  ///
+  /// Returns the LAST id read, so a caller that did not get what it asked for
+  /// can say what the display reports instead.
+  func settledRevealedModeID(
+    requested: DisplayMode,
+    window: TimeInterval = modeSettleWindow,
+    poll: TimeInterval = modeSettlePoll,
+    now: () -> Date = Date.init,
+    sleep: (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) },
+    read: () -> Int32?
+  ) -> Int32? {
+    settled(window: window, poll: poll, now: now, sleep: sleep, read: read) {
+      $0 == requested.ioModeID
+    }
+  }
+
+  /// The clock and the sleep are injected so a test spends no real time here;
+  /// nothing in the app passes anything but the defaults. Real time and not an
+  /// iteration count, because the read itself costs some of the window.
+  func settled<Reading>(
+    window: TimeInterval = modeSettleWindow,
+    poll: TimeInterval = modeSettlePoll,
+    now: () -> Date = Date.init,
+    sleep: (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) },
+    read: () -> Reading,
+    until landed: (Reading) -> Bool
+  ) -> Reading {
+    var observed = read()
+    let deadline = now().addingTimeInterval(window)
+    while !landed(observed), now() < deadline {
+      sleep(poll)
+      observed = read()
+    }
+    return observed
   }
 
   /// Not `currentMode(for:)`: that resolves against the deduplicated list and

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
@@ -257,17 +257,12 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
     // THE RETURN CODE IS NOT THE EVIDENCE, the achieved mode is. The cross-check
     // above proves the id still denotes the geometry asked for; it proves
     // nothing about what the commit then did with it.
+    // landing. The first read is taken before any sleep, so an honoured commit
+    // pays nothing.
     //
-    // Bounded settle rather than one immediate read, the shape `applyRotation`
-    // uses: the window server lands a mode change asynchronously, so a single
-    // read can still describe the outgoing mode and report a false miss. Half a
-    // second, because a change that has not landed by then is not landing.
-    //
-    // The first read is taken BEFORE any sleep and an honoured commit returns on
-    // it, so a caller on the main actor pays this block only on the failure
-    // path. 50 ms between polls for the same reason: ten reads is ample
-    // resolution for a settle measured in tens of milliseconds, and a tighter
-    // loop only spends more of a blocked main thread on a case already lost.
+    // Blocks the calling thread: the main actor for an interactive apply, a
+    // cooperative thread for the preview session and checkup runners. The
+    // alternative was reporting an unverified apply.
     let deadline = Date().addingTimeInterval(0.5)
     var achieved = achievedMode(displayID)
     while ModeApplyVerification.verdict(requested: mode, achieved: achieved) == .unhonoured,

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
@@ -254,9 +254,10 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
       throw DisplayConfigError(cgErrorCode: result.rawValue)
     }
 
-    // THE RETURN CODE IS NOT THE EVIDENCE, the achieved mode is. The cross-check
-    // above proves the id still denotes the geometry asked for; it proves
-    // nothing about what the commit then did with it.
+    // THE RETURN CODE IS NOT THE EVIDENCE; the achieved mode is. Bounded settle
+    // rather than one read, as `applyRotation` does: the window server lands a
+    // mode change asynchronously, so a single read can still describe the
+    // outgoing mode. Half a second, because a change not landed by then is not
     // landing. The first read is taken before any sleep, so an honoured commit
     // pays nothing.
     //
@@ -289,7 +290,6 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
     }
   }
 
-  /// The live mode as CoreGraphics reports it, deliberately NOT through
   /// Not `currentMode(for:)`: that resolves against the deduplicated list and
   /// answers nil for anything missing from it, which the settle loop would read
   /// as a mode that never landed. It also re-enumerates every CGS descriptor.

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
@@ -113,8 +113,41 @@ public struct ConfiguredDisplay: Sendable, Equatable, Identifiable {
 }
 
 public struct DisplayConfigError: Error, Sendable, Equatable {
+  /// What a COMMITTED transaction was asked for and what it left behind. Every
+  /// other `DisplayConfigError` means the display did not move; this one means it
+  /// did, so a caller holding a fallback must use it rather than report a refusal.
+  public struct UnhonouredCommit: Sendable, Equatable {
+    public let requested: DisplayMode
+    /// Nil when the display could not say what it is running, which is not
+    /// evidence the mode landed.
+    public let achieved: DisplayMode?
+
+    public init(requested: DisplayMode, achieved: DisplayMode?) {
+      self.requested = requested
+      self.achieved = achieved
+    }
+  }
+
+  /// Not a CoreGraphics code, and negative so it never reads as one. Not
+  /// `CGError.failure` either, which a transaction that never opened also throws.
+  public static let unhonouredCommitCode: Int32 = -1000
+
   public let cgErrorCode: Int32
-  public init(cgErrorCode: Int32) { self.cgErrorCode = cgErrorCode }
+  public let unhonouredCommit: UnhonouredCommit?
+
+  public init(cgErrorCode: Int32) {
+    self.cgErrorCode = cgErrorCode
+    unhonouredCommit = nil
+  }
+
+  public init(unhonouredCommit: UnhonouredCommit) {
+    cgErrorCode = Self.unhonouredCommitCode
+    self.unhonouredCommit = unhonouredCommit
+  }
+
+  /// Whether the display MOVED despite the throw. The one question that decides
+  /// whether a caller may say "nothing changed".
+  public var didCommit: Bool { unhonouredCommit != nil }
 }
 
 /// Opens a display-configuration transaction, or throws.
@@ -198,6 +231,13 @@ public protocol DisplayConfiguring: Sendable {
   /// The panel's own pixel count, from the mode flagged native. Needed to tell
   /// scaled modes from native ones.
   func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)?
+  /// Stages one mode change, commits it, then reads back the mode the display
+  /// Stages one mode change, commits it, then reads back what the display runs.
+  ///
+  /// Throws `DisplayConfigError` if the mode cannot be resolved, staging or the
+  /// commit fails, or the readback disagrees (`ModeApplyVerification`). **That
+  /// last throw follows a committed transaction**: the display is wherever
+  /// CoreGraphics put it, and only the caller's revert puts it back.
   func apply(_ mode: DisplayMode, to displayID: CGDirectDisplayID, scope: DisplayConfigScope) throws
 
   /// Stages one `CGConfigureDisplayMirrorOfDisplay` per change in a SINGLE
@@ -212,8 +252,8 @@ public protocol DisplayConfiguring: Sendable {
   /// topology does not show what was asked for (`MirrorVerification`). An empty
   /// `changes` array does nothing and opens no transaction.
   ///
-  /// **That last throw is the ONE that can follow a committed change**, and the
-  /// only place in this protocol where a throw does not mean "nothing moved".
+  /// **That last throw follows a committed change**, as `apply`'s readback does,
+  /// so neither one means "nothing moved".
   /// CoreGraphics accepted the batch and did something else; the machine is in
   /// whatever topology it chose, and nothing here puts it back. Reporting the
   /// divergence still beats the alternative that shipped, where a caller recorded

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
@@ -231,7 +231,6 @@ public protocol DisplayConfiguring: Sendable {
   /// The panel's own pixel count, from the mode flagged native. Needed to tell
   /// scaled modes from native ones.
   func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)?
-  /// Stages one mode change, commits it, then reads back the mode the display
   /// Stages one mode change, commits it, then reads back what the display runs.
   ///
   /// Throws `DisplayConfigError` if the mode cannot be resolved, staging or the

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/ModeApplyVerification.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/ModeApplyVerification.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// The published mode path's post-commit verdict. `CGCompleteDisplayConfiguration`
+/// has been measured returning `.success` over a request it did not honour, so
+/// the mode read back decides, not the return code. Pure, so it tests without a
+/// display. It answers what the desktop scans out, not how it reaches the glass:
+/// a mode bound to the wrong wire timing reads clean here.
+enum ModeApplyVerification {
+  enum Verdict: Equatable {
+    case honoured
+    case unhonoured
+  }
+
+  /// Geometry through `matchesGeometry`, never `ioModeID`. The id is positional,
+  /// and a display can be running a duplicate the enumeration collapsed (42 such
+  /// buckets on the Dell), so equal geometry under two different ids is the same
+  /// achieved state and an id compare would report a false miss.
+  ///
+  /// A nil `achieved` is unhonoured rather than a separate answer: a mode that
+  /// cannot be read is not a mode that landed, and every caller does the same
+  /// thing with either.
+  static func verdict(requested: DisplayMode, achieved: DisplayMode?) -> Verdict {
+    guard let achieved, achieved.matchesGeometry(of: requested) else { return .unhonoured }
+    return .honoured
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/ModeApplyVerification.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/ModeApplyVerification.swift
@@ -11,14 +11,12 @@ enum ModeApplyVerification {
     case unhonoured
   }
 
-  /// Geometry through `matchesGeometry`, never `ioModeID`. The id is positional,
-  /// and a display can be running a duplicate the enumeration collapsed (42 such
-  /// buckets on the Dell), so equal geometry under two different ids is the same
-  /// achieved state and an id compare would report a false miss.
-  ///
-  /// A nil `achieved` is unhonoured rather than a separate answer: a mode that
-  /// cannot be read is not a mode that landed, and every caller does the same
-  /// thing with either.
+  /// Geometry via `matchesGeometry`, never `ioModeID`: the id is positional and
+  /// the enumeration collapses duplicates (42 buckets on the Dell), so equal
+  /// geometry under two ids is the same achieved state. A nil `achieved` is
+  /// unhonoured: a mode that cannot be read is not one that landed. The
+  /// half-hertz tolerance absorbs CoreGraphics' float noise (59.997 for 60) and
+  /// so also calls NTSC 59.94 a 60; stored-mode matching makes the same trade.
   static func verdict(requested: DisplayMode, achieved: DisplayMode?) -> Verdict {
     guard let achieved, achieved.matchesGeometry(of: requested) else { return .unhonoured }
     return .honoured

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
@@ -24,10 +24,10 @@ public struct PreviewedMode: Sendable, Equatable {
 /// - No preview begins until the fallback mode has been read.
 /// - Confirm commits the mode that was previewed, not what the display reports
 ///   now; the two differ exactly when something went wrong.
-/// - A preview stays outstanding until a resolution succeeds. An apply that
-///   throws changed nothing, so the original fallback is still the one to keep,
-///   which is why every guard asks "is a preview applied?" and never "was an
-///   answer given?".
+/// - A preview stays outstanding until a resolution succeeds, which is why every
+///   guard asks "is a preview applied?" and never "was an answer given?". A
+///   throw never invalidates the fallback: a refusal left the display alone, and
+///   an unhonoured commit moved it without touching the pre-preview mode.
 public actor ModePreviewSession {
   /// One value so no path can pair one preview's display ID with another's
   /// fallback mode.
@@ -115,10 +115,16 @@ public actor ModePreviewSession {
     do {
       try configurator.apply(mode, to: displayID, scope: .preview)
     } catch let error as DisplayConfigError {
-      return .failure(error)
+      // A commit the display did not honour is not a refusal: the display is on a
+      // mode nobody picked, and failing here would leave it there with no
+      // countdown. So it is captured like a success; the fallback read before the
+      // apply is still the way back, and the countdown takes it.
+      guard error.didCommit else { return .failure(error) }
     } catch {
       return .failure(DisplayConfigError(cgErrorCode: -1))
     }
+    // The mode ASKED for, not what the display landed on: keep re-applies and
+    // re-verifies it, so an unhonoured commit cannot become permanent.
     outstanding = OutstandingPreview(
       displayID: displayID, previousMode: previous, previewedMode: mode
     )
@@ -177,9 +183,9 @@ public actor ModePreviewSession {
     answered.displayID == outstanding.displayID && answered.mode == outstanding.previewedMode
   }
 
-  /// Success is what clears the outstanding preview. A throw leaves session
-  /// state intact: the display did not move, so the record of how to move it
-  /// back is still true.
+  /// Only success clears the outstanding preview. A refusal moved nothing, and an
+  /// unhonoured commit moved the display to a third mode without touching the
+  /// record of the pre-preview mode, so session state is kept in both cases.
   ///
   /// A failed commit leaves the countdown armed on purpose, so a mode that
   /// could not be made permanent still falls back to one the user can see.

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
@@ -96,6 +96,9 @@ public actor ModePreviewSession {
         // End a live preview on another display first, or its fallback gets
         // retargeted here and that display is left in preview with no
         // countdown. Refuse if the revert fails rather than strand it.
+        //
+        // That error describes the OTHER display; `DisplayConfigError` carries no
+        // display ID, and widening it would touch every caller.
         if case let .failed(error) = revertOutstanding() { return .failure(error) }
         guard let read = configurator.currentMode(for: displayID) else {
           return .failure(DisplayConfigError(cgErrorCode: CGError.failure.rawValue))

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
@@ -6,15 +6,10 @@ import Foundation
 public struct PreviewedMode: Sendable, Equatable {
   public let displayID: CGDirectDisplayID
   public let mode: DisplayMode
-  /// Set when the apply that began this preview COMMITTED without landing on
-  /// `mode`: the display is on a third mode nobody picked. The keep question
-  /// still names `mode`, because that is what Keep re-applies; this is what a
-  /// surface needs to say what the glass is showing while the question is read.
-  ///
-  /// Defaulted, so an ANSWER can be built from a display and a mode alone.
-  /// `matches` compares those two and never this, or a UI that rendered the
-  /// preview before the divergence was known would have its answer refused as
-  /// stale over a caption.
+  /// Latest evidence of a commit that did not achieve its request. Once set,
+  /// this preview offers recovery only; choosing a mode starts a fresh preview.
+  /// Answers still match by display and mode, so an older caption cannot block
+  /// a revert or bypass recovery-only confirmation.
   public let unhonouredCommit: DisplayConfigError.UnhonouredCommit?
 
   public init(
@@ -37,8 +32,8 @@ public struct PreviewedMode: Sendable, Equatable {
 ///
 /// Invariants the safety argument rests on:
 /// - No preview begins until the fallback mode has been read.
-/// - Confirm commits the mode that was previewed, not what the display reports
-///   now; the two differ exactly when something went wrong.
+/// - Confirm never commits a mode after a known unhonoured commit. A fresh
+///   preview is required before that mode can be kept.
 /// - A preview stays outstanding until a resolution succeeds, which is why every
 ///   guard asks "is a preview applied?" and never "was an answer given?". A
 ///   throw never invalidates the fallback: a refusal left the display alone, and
@@ -51,11 +46,8 @@ public actor ModePreviewSession {
     /// Captured before the preview was applied. Survives failed resolutions.
     let previousMode: DisplayMode
     let previewedMode: DisplayMode
-    /// What the apply achieved, when it committed and did not honour the
-    /// request. Held here rather than derived later: the display can be
-    /// reconfigured again before anyone reads it, and this is the state at the
-    /// moment the question was asked.
-    let unhonouredCommit: DisplayConfigError.UnhonouredCommit?
+    /// Updated only after a committed failure; precommit refusals move nothing.
+    var unhonouredCommit: DisplayConfigError.UnhonouredCommit?
   }
 
   private let configurator: any DisplayConfiguring
@@ -148,15 +140,12 @@ public actor ModePreviewSession {
       // countdown. So it is captured like a success; the fallback read before the
       // apply is still the way back, and the countdown takes it.
       guard let commit = error.unhonouredCommit else { return .failure(error) }
-      // Carried out to the surfaces so the keep question can say what is on the
-      // glass. Silence here is what made the question unanswerable: the banner
-      // named a size the display was not showing and gave no way to tell.
       unhonoured = commit
     } catch {
       return .failure(DisplayConfigError(cgErrorCode: -1))
     }
-    // The mode ASKED for, not what the display landed on: keep re-applies and
-    // re-verifies it, so an unhonoured commit cannot become permanent.
+    // Retain the requested mode to match answers, even when recovery is the
+    // only available action.
     outstanding = OutstandingPreview(
       displayID: displayID, previousMode: previous, previewedMode: mode,
       unhonouredCommit: unhonoured
@@ -180,14 +169,19 @@ public actor ModePreviewSession {
       return lastOutcome ?? .reverted
     }
     guard matches(answered, outstanding) else { return .stale }
+    if let commit = outstanding.unhonouredCommit {
+      let failure = PreviewOutcome.failed(DisplayConfigError(unhonouredCommit: commit))
+      lastOutcome = failure
+      return failure
+    }
+    guard answered.unhonouredCommit == nil else { return .stale }
     return resolve(
       applying: outstanding.previewedMode, to: outstanding.displayID, success: .committed
     )
   }
 
-  /// Safe to call repeatedly for the same preview. A revert that threw left the
-  /// display where it was, so retrying once CoreGraphics recovers is the
-  /// recovery path the error UI drives.
+  /// Safe to retry for the same preview. Failed attempts preserve the original
+  /// fallback, even when the display committed a different mode.
   public func revert(_ answered: PreviewedMode) -> PreviewOutcome {
     guard let outstanding else { return lastOutcome ?? .reverted }
     guard matches(answered, outstanding) else { return .stale }
@@ -229,6 +223,9 @@ public actor ModePreviewSession {
     do {
       try configurator.apply(mode, to: displayID, scope: .session)
     } catch let error as DisplayConfigError {
+      if let commit = error.unhonouredCommit {
+        outstanding?.unhonouredCommit = commit
+      }
       lastOutcome = .failed(error)
       return .failed(error)
     } catch {

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/ModePreviewSession.swift
@@ -6,10 +6,25 @@ import Foundation
 public struct PreviewedMode: Sendable, Equatable {
   public let displayID: CGDirectDisplayID
   public let mode: DisplayMode
+  /// Set when the apply that began this preview COMMITTED without landing on
+  /// `mode`: the display is on a third mode nobody picked. The keep question
+  /// still names `mode`, because that is what Keep re-applies; this is what a
+  /// surface needs to say what the glass is showing while the question is read.
+  ///
+  /// Defaulted, so an ANSWER can be built from a display and a mode alone.
+  /// `matches` compares those two and never this, or a UI that rendered the
+  /// preview before the divergence was known would have its answer refused as
+  /// stale over a caption.
+  public let unhonouredCommit: DisplayConfigError.UnhonouredCommit?
 
-  public init(displayID: CGDirectDisplayID, mode: DisplayMode) {
+  public init(
+    displayID: CGDirectDisplayID,
+    mode: DisplayMode,
+    unhonouredCommit: DisplayConfigError.UnhonouredCommit? = nil
+  ) {
     self.displayID = displayID
     self.mode = mode
+    self.unhonouredCommit = unhonouredCommit
   }
 }
 
@@ -36,6 +51,11 @@ public actor ModePreviewSession {
     /// Captured before the preview was applied. Survives failed resolutions.
     let previousMode: DisplayMode
     let previewedMode: DisplayMode
+    /// What the apply achieved, when it committed and did not honour the
+    /// request. Held here rather than derived later: the display can be
+    /// reconfigured again before anyone reads it, and this is the state at the
+    /// moment the question was asked.
+    let unhonouredCommit: DisplayConfigError.UnhonouredCommit?
   }
 
   private let configurator: any DisplayConfiguring
@@ -60,7 +80,11 @@ public actor ModePreviewSession {
 
   /// What is applied and unresolved. A UI rebuilds its state from this.
   public var previewedMode: PreviewedMode? {
-    outstanding.map { PreviewedMode(displayID: $0.displayID, mode: $0.previewedMode) }
+    outstanding.map {
+      PreviewedMode(
+        displayID: $0.displayID, mode: $0.previewedMode, unhonouredCommit: $0.unhonouredCommit
+      )
+    }
   }
 
   /// Reported rather than inferred: a failed expiry disarms the countdown
@@ -115,6 +139,7 @@ public actor ModePreviewSession {
       previous = read
     }
 
+    var unhonoured: DisplayConfigError.UnhonouredCommit?
     do {
       try configurator.apply(mode, to: displayID, scope: .preview)
     } catch let error as DisplayConfigError {
@@ -122,14 +147,19 @@ public actor ModePreviewSession {
       // mode nobody picked, and failing here would leave it there with no
       // countdown. So it is captured like a success; the fallback read before the
       // apply is still the way back, and the countdown takes it.
-      guard error.didCommit else { return .failure(error) }
+      guard let commit = error.unhonouredCommit else { return .failure(error) }
+      // Carried out to the surfaces so the keep question can say what is on the
+      // glass. Silence here is what made the question unanswerable: the banner
+      // named a size the display was not showing and gave no way to tell.
+      unhonoured = commit
     } catch {
       return .failure(DisplayConfigError(cgErrorCode: -1))
     }
     // The mode ASKED for, not what the display landed on: keep re-applies and
     // re-verifies it, so an unhonoured commit cannot become permanent.
     outstanding = OutstandingPreview(
-      displayID: displayID, previousMode: previous, previewedMode: mode
+      displayID: displayID, previousMode: previous, previewedMode: mode,
+      unhonouredCommit: unhonoured
     )
     // Cleared here, not on entry: a begin() that fails establishes nothing, so
     // the last thing that really happened to the display stays the last outcome.

--- a/CandelaKit/Sources/CandelaKit/Displays/DisplayDiscovery.swift
+++ b/CandelaKit/Sources/CandelaKit/Displays/DisplayDiscovery.swift
@@ -36,15 +36,26 @@ public enum DisplayDiscovery {
       return Arm64DDC.getServiceMatches(displayIDs: Array(externalIDs))
         .filter { !$0.dummy && $0.service != nil }
         .map { match in
-          (ExternalDisplay(id: match.displayID,
-                           name: displayName(from: match.serviceDetails, displayID: match.displayID),
-                           persistenceKey: persistenceKey(from: match.serviceDetails)),
-           Arm64DDCService.create(service: match.service),
-           DisplayHardwareFacts.from(
-             service: match.serviceDetails,
-             matchScore: match.matchScore,
-             physicalSizeCm: Arm64DDC.physicalSizeCm(displayID: match.displayID)
-           ))
+          let key = persistenceKey(from: match.serviceDetails)
+          return (
+            ExternalDisplay(
+              id: match.displayID,
+              name: displayName(from: match.serviceDetails, displayID: match.displayID),
+              persistenceKey: key
+            ),
+            // The tag rather than the key: the service logs every read verdict,
+            // and a fallback key embeds the panel's serial number.
+            Arm64DDCService.create(
+              service: match.service,
+              displayID: match.displayID,
+              logTag: DisplayLogging.tag(for: key)
+            ),
+            DisplayHardwareFacts.from(
+              service: match.serviceDetails,
+              matchScore: match.matchScore,
+              physicalSizeCm: Arm64DDC.physicalSizeCm(displayID: match.displayID)
+            )
+          )
         }
     #else
       return [] // Intel adapter arrives in a later milestone; IntelDDC stays compiled.

--- a/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
@@ -14,23 +14,21 @@ public enum TapLifecycleAction: Sendable, Equatable {
 /// The edge is decided from the INTENDED sets, never the tap's `isRunning`: an
 /// emergency teardown leaves that flag true.
 public enum TapLifecyclePolicy {
-  /// `previous` is the last watched set the app committed to: nil when no tap
-  /// could be armed at all (no grant, or a start that failed), which is not the
-  /// same as an empty set. Empty means the app deliberately watches nothing and
-  /// can pick the tap back up the moment a key needs it; nil means something
-  /// outside this decision has to change first, so restarting from here would
-  /// retry a failed start on every reconfigure and every menu close.
-  ///
-  /// Two non-empty sets always reconfigure, equal or not: the config carries the
-  /// alternate-brightness-key flag as well, and that pref reaches the tap
-  /// through this same path.
+  /// `previous` nil: no tap could be armed (no grant, or a failed start). Not the
+  /// empty set, and retryable, since most start failures are transient.
+  /// `permanentlyUnavailable` is the one failure a retry cannot fix.
+  /// Equal non-empty sets still reconfigure: the config also carries the
+  /// alternate-brightness-key flag.
   public static func action(
     previous: Set<MediaKey>?,
     next: Set<MediaKey>,
-    grantHeld: Bool
+    grantHeld: Bool,
+    permanentlyUnavailable: Bool
   ) -> TapLifecycleAction {
     guard grantHeld else { return .nothing }
-    guard let previous else { return .nothing }
+    // Set only where no tap exists, so there is never one here to stop.
+    guard !permanentlyUnavailable else { return .nothing }
+    guard let previous else { return next.isEmpty ? .nothing : .start }
     if previous.isEmpty {
       return next.isEmpty ? .nothing : .start
     }

--- a/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
@@ -4,6 +4,10 @@ public enum TapLifecycleAction: Sendable, Equatable {
   case start
   case stop
   case reconfigure
+  /// Nothing is watched and no tap exists, so there is nothing to do to one. The
+  /// empty set is committed anyway: "watching nothing on purpose" and "no tap could
+  /// run" are different answers, and diagnostics reports them apart.
+  case recordEmpty
   case nothing
 }
 
@@ -28,7 +32,7 @@ public enum TapLifecyclePolicy {
     guard grantHeld else { return .nothing }
     // Set only where no tap exists, so there is never one here to stop.
     guard !permanentlyUnavailable else { return .nothing }
-    guard let previous else { return next.isEmpty ? .nothing : .start }
+    guard let previous else { return next.isEmpty ? .recordEmpty : .start }
     if previous.isEmpty {
       return next.isEmpty ? .nothing : .start
     }

--- a/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Input/TapLifecyclePolicy.swift
@@ -1,0 +1,39 @@
+/// What the app should do to the media-key event tap after the watched-key set
+/// is recomputed.
+public enum TapLifecycleAction: Sendable, Equatable {
+  case start
+  case stop
+  case reconfigure
+  case nothing
+}
+
+/// Decides whether the media-key tap should exist at all right now.
+///
+/// A tap watching nothing still costs a run-loop thread and two watchdog threads
+/// while every key passes through, so one exists only while something is watched.
+/// The edge is decided from the INTENDED sets, never the tap's `isRunning`: an
+/// emergency teardown leaves that flag true.
+public enum TapLifecyclePolicy {
+  /// `previous` is the last watched set the app committed to: nil when no tap
+  /// could be armed at all (no grant, or a start that failed), which is not the
+  /// same as an empty set. Empty means the app deliberately watches nothing and
+  /// can pick the tap back up the moment a key needs it; nil means something
+  /// outside this decision has to change first, so restarting from here would
+  /// retry a failed start on every reconfigure and every menu close.
+  ///
+  /// Two non-empty sets always reconfigure, equal or not: the config carries the
+  /// alternate-brightness-key flag as well, and that pref reaches the tap
+  /// through this same path.
+  public static func action(
+    previous: Set<MediaKey>?,
+    next: Set<MediaKey>,
+    grantHeld: Bool
+  ) -> TapLifecycleAction {
+    guard grantHeld else { return .nothing }
+    guard let previous else { return .nothing }
+    if previous.isEmpty {
+      return next.isEmpty ? .nothing : .start
+    }
+    return next.isEmpty ? .stop : .reconfigure
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
@@ -9,6 +9,9 @@ import Foundation
 public enum OledCareCadence {
   /// Restore-latency gate: any perceptible lag makes this unusable.
   public static let fast: Duration = .milliseconds(100)
+  /// The nomination geometry refresh rides this loop on a one second throttle:
+  /// slower stretches a moved window's shed, faster is dropped by the throttle.
+  public static let windowFollow: Duration = .seconds(1)
   /// The thresholds are minutes, so nothing needs a fast tick to reach them.
   public static let slow: Duration = .seconds(2)
   /// Nothing enrolled: the loop has no work, and `reconcileEnrollment` restarts
@@ -31,20 +34,36 @@ public enum OledCareCadence {
   /// it waits until skipped captures cannot explain the silence.
   public static let stallWarningSeconds: Double = 10 * OledCareCadence.samplingSeconds
 
-  /// Fast whenever a dim is UP BY ANY DELIVERY, or an achieved-state
-  /// verification is pending.
+  /// Fast whenever a dim INPUT SHOULD LIFT is up by any delivery, or an
+  /// achieved-state verification is pending.
   ///
   /// `anyOverlayUp` is the WANT, not the verified presence, on purpose: input
   /// lifts a dim the engine believes is up, and that belief needs fast ticks to
-  /// be corrected.
+  /// be corrected. Only dims `liftsOnInput` covers: detection dimming's mask is
+  /// `nominationDisplayed`, which buys the window-follow second, not 10 Hz.
   ///
   /// `anythingEnrolled` defaults to true so a caller that forgets it cannot idle
-  /// the loop by accident.
+  /// the loop by accident. A displayed nomination outranks it: a mask on screen
+  /// is work in flight whatever the caller says about enrollment.
   public static func interval(
     anyOverlayUp: Bool, anyLockDimEngaged: Bool, verificationPending: Bool,
-    anythingEnrolled: Bool = true
+    nominationDisplayed: Bool = false, anythingEnrolled: Bool = true
   ) -> Duration {
     if anyOverlayUp || anyLockDimEngaged || verificationPending { return fast }
+    if nominationDisplayed { return windowFollow }
     return anythingEnrolled ? slow : idle
+  }
+}
+
+extension OledDimState {
+  /// Whether the user's next input should end this dim. The cadence's fast term
+  /// and the driver's input monitor both key on it, so they cannot disagree.
+  /// `.active` is excluded though it can carry an overlay: detection dimming's
+  /// mask follows window geometry, not input, and counting it held the loop at 10 Hz.
+  public var liftsOnInput: Bool {
+    switch self {
+    case .idleDim, .blackout, .lockDim, .unfocusedDim: true
+    case .active, .suspended: false
+    }
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
@@ -26,21 +26,31 @@ public enum AccessibilityBackstopPolicy {
     /// The tap was re-armed by something else: a settings reset, or a pref that
     /// carries the re-arm without being about keys at all.
     case tapRearmed
+    /// The user was sent to the Accessibility list: the system prompt went up, or
+    /// one of the buttons that opens System Settings was pressed.
+    case sentToSystemSettings
   }
 
   /// Whether this edge reopens the hunt window, putting its clock back to zero.
   ///
-  /// Only a key-mode write does: a person turning a key family on with no grant is at
-  /// System Settings about to make it, however long the grant has been missing. The
-  /// tap's other re-arm routes re-derive the cadence from the live modes and leave the
-  /// clock where it is; reopening there would put an ungranted rig back on the
-  /// two-second interval for two minutes after a write that has nothing to do with
-  /// keys (a DDC availability switch, an audio-routing override).
+  /// Two of the three do, and they say the same thing about the person at the
+  /// keyboard: they are at System Settings about to make the grant, however long it
+  /// has been missing. Turning a key family on with no grant is that; so is being
+  /// handed the prompt or the list itself.
+  ///
+  /// A bare tap re-arm is not: those routes re-derive the cadence from the live
+  /// modes and leave the clock where it is. Reopening there would put an ungranted
+  /// rig back on the two-second interval for two minutes after a write that has
+  /// nothing to do with keys (a DDC availability switch, an audio-routing override).
   public static func reopensHunt(
     edge: Edge, granted: Bool, requiresAccessibility: Bool
   ) -> Bool {
-    guard edge == .keyModesWritten else { return false }
-    return !granted && requiresAccessibility
+    switch edge {
+    case .tapRearmed: return false
+    // The state halves still gate it: a held grant is not being hunted for, and an
+    // all-custom rig runs no timer for a re-stamp to move.
+    case .keyModesWritten, .sentToSystemSettings: return !granted && requiresAccessibility
+    }
   }
 
   /// `secondsSinceNotification` is nil when no notification has arrived this

--- a/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
@@ -18,6 +18,31 @@ public enum AccessibilityBackstopPolicy {
   /// lose the settle race, so the hunt resumes for this long after one.
   public static let notificationWindow: TimeInterval = 30
 
+  /// What asked for the backstop to be re-evaluated. Both cases carry the same state
+  /// and differ only in what they say about the person at the keyboard.
+  public enum Edge: Sendable, Equatable {
+    /// A key mode was written: someone chose whether a key family goes through us.
+    case keyModesWritten
+    /// The tap was re-armed by something else: a settings reset, or a pref that
+    /// carries the re-arm without being about keys at all.
+    case tapRearmed
+  }
+
+  /// Whether this edge reopens the hunt window, putting its clock back to zero.
+  ///
+  /// Only a key-mode write does: a person turning a key family on with no grant is at
+  /// System Settings about to make it, however long the grant has been missing. The
+  /// tap's other re-arm routes re-derive the cadence from the live modes and leave the
+  /// clock where it is; reopening there would put an ungranted rig back on the
+  /// two-second interval for two minutes after a write that has nothing to do with
+  /// keys (a DDC availability switch, an audio-routing override).
+  public static func reopensHunt(
+    edge: Edge, granted: Bool, requiresAccessibility: Bool
+  ) -> Bool {
+    guard edge == .keyModesWritten else { return false }
+    return !granted && requiresAccessibility
+  }
+
   /// `secondsSinceNotification` is nil when no notification has arrived this
   /// launch. A nil result means run no timer at all.
   public static func interval(

--- a/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/AccessibilityBackstopPolicy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// How often the Accessibility grant is polled behind the
+/// `com.apple.accessibility.api` notification. Held: watching for a revocation
+/// nothing else reports. Missing: hunting for a grant the user may be making now,
+/// worth two seconds for a while and very little an hour later.
+public enum AccessibilityBackstopPolicy {
+  /// Held: slow, but never zero. Latching on success is the defect this tracking
+  /// exists to prevent.
+  public static let heldInterval: TimeInterval = 10
+  /// Missing, with a grant plausibly moments away.
+  public static let huntingInterval: TimeInterval = 2
+  /// Missing long enough that nobody is standing at System Settings.
+  public static let restingInterval: TimeInterval = 30
+  /// Hunt length from the moment the grant went missing (launch, if it launched without one).
+  public static let huntWindow: TimeInterval = 120
+  /// A notification means TCC just changed something and the immediate read can
+  /// lose the settle race, so the hunt resumes for this long after one.
+  public static let notificationWindow: TimeInterval = 30
+
+  /// `secondsSinceNotification` is nil when no notification has arrived this
+  /// launch. A nil result means run no timer at all.
+  public static func interval(
+    granted: Bool,
+    requiresAccessibility: Bool,
+    secondsSinceMissingBegan: TimeInterval,
+    secondsSinceNotification: TimeInterval?
+  ) -> TimeInterval? {
+    // Before the skip: the prompt path trusts a held answer, so a stale `true`
+    // would leave a rig that turns a key family back on with dead keys and no prompt.
+    if granted { return heldInterval }
+    // Custom shortcuts are Carbon hotkeys: nothing prompts, reports or reads the
+    // grant on an all-custom rig.
+    guard requiresAccessibility else { return nil }
+    if secondsSinceMissingBegan < huntWindow { return huntingInterval }
+    if let secondsSinceNotification, secondsSinceNotification < notificationWindow {
+      return huntingInterval
+    }
+    return restingInterval
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCopy.swift
@@ -9,8 +9,9 @@ import Foundation
 ///
 /// The three that matter most, all of them defects this feature exists to
 /// prevent rather than hypotheticals:
-/// - readback has THREE answers, not two: the display answered, it is not
-///   answering, or it answered something that could not be read;
+/// - readback has FOUR answers, not two: the display answered, it is not
+///   answering, it answered something that could not be read, or it answered
+///   that it does not carry the code;
 /// - a brightness maximum that was READ from the display never reads like one
 ///   that was assumed;
 /// - volume unavailable because the DISPLAY denied it is a different sentence
@@ -95,7 +96,9 @@ public enum DiagnosticsCopy {
       return "\(app) has not sent anything to this display yet."
     }
     return switch evidence {
-    case .answered, .notAttempted:
+    // A refusal earns no caveat here: it names a register the display does not
+    // carry, which says nothing about the brightness command just accepted.
+    case .answered, .notAttempted, .refused:
       "Brightness is being sent to this display and accepted."
     case .allZeros:
       "Brightness is being sent to this display and accepted, but it never answers a read."
@@ -267,25 +270,39 @@ public enum DiagnosticsCopy {
   /// some hardware, it explains every other value on the page, and a user who
   /// has it needs the words to search for.
   ///
-  /// THREE outcomes past "not asked", and none of them may be folded together:
-  /// answering, never answering, and not replying are three different faults
-  /// with three different next steps.
+  /// FOUR outcomes past "no answer recorded", and none of them may be folded
+  /// together: answering, never answering, not replying and refusing the code are
+  /// four different findings with four different next steps. The refusal is the
+  /// one that is not a fault at all.
+  ///
+  /// The unasked arm says "has not recorded an answer" rather than "has not
+  /// read": one silence is held rather than published, so this sentence is
+  /// reachable on a display that was asked and said nothing back.
   public static func readEvidence(_ evidence: DDCReadEvidence, app: String) -> String {
     switch evidence {
-    case .notAttempted: "\(app) has not read from this display"
+    case .notAttempted: "\(app) has not recorded an answer from this display yet"
     case .answered: "This display answers reads"
     case .allZeros: "Write-only: this display takes commands but never answers a read"
     case .noReply: "This display did not reply to a read"
+    case .refused: "This display answered that it does not carry the value \(app) asked for"
     }
   }
 
   /// The SHORT verdict: the hub's chevron preview and the report's `readback:`
   /// field. `readEvidence(_:app:)` says the same thing at length; both come off
   /// the same worst-of-three evidence, so they cannot disagree.
+  ///
+  /// A refusal summarises as "Answers reads" on purpose, the one arm where this
+  /// is broader than the long sentence. It is a whole-DISPLAY summary and the
+  /// display replied; worst-of-three resolves to a refusal only when nothing
+  /// else was asked, so a display whose brightness command is off and whose
+  /// volume register is refused would otherwise be summarised by the one
+  /// register it does not carry. WHICH register that was stays on the page, in
+  /// `readEvidence(_:app:)`, and in the per-command read log.
   public static func readbackVerdict(_ evidence: DDCReadEvidence) -> String {
     switch evidence {
-    case .notAttempted: "Not asked yet"
-    case .answered: "Answers reads"
+    case .notAttempted: "No answer recorded yet"
+    case .answered, .refused: "Answers reads"
     case .allZeros: "Write-only"
     case .noReply: "Not answering"
     }
@@ -296,6 +313,10 @@ public enum DiagnosticsCopy {
   /// path or with the brightness command turned off, and the pass may not have
   /// run yet, so the flag is false without anything having asked. "The display
   /// did not report one" there is an absence claim about a probe that never ran.
+  ///
+  /// The unasked arm claims no more than the record holds, for the reason
+  /// `readEvidence` does: a held silence leaves the evidence at the floor, so
+  /// "has not asked" would be a claim about the wire this cannot make.
   ///
   /// A maximum that was READ says so outright, and never wears the "Assumed" the
   /// other two arms carry.
@@ -310,7 +331,7 @@ public enum DiagnosticsCopy {
       return "This display reported a maximum of \(maxValue)"
     }
     if evidence == .notAttempted {
-      return "Assumed 100: \(app) has not asked this display for its scale"
+      return "Assumed 100: \(app) has not recorded an answer about this display's scale"
     }
     return "Assumed 100: the display did not report one"
   }

--- a/CandelaKit/Sources/CandelaKit/Support/PowerSource.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/PowerSource.swift
@@ -1,0 +1,22 @@
+import Foundation
+import IOKit.ps
+
+/// Mains or battery, for anything that should cost less when unplugged.
+public enum PowerSource {
+  /// True only when an internal battery is the source in use. Everything this
+  /// cannot see (no battery, sources that will not enumerate) answers false, the
+  /// mains answer, so it degrades toward polling more often.
+  public static func isOnBattery() -> Bool {
+    guard let blob = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+      let sources = IOPSCopyPowerSourcesList(blob)?.takeRetainedValue() as? [CFTypeRef]
+    else { return false }
+    return sources.contains { source in
+      guard
+        let info = IOPSGetPowerSourceDescription(blob, source)?.takeUnretainedValue()
+          as? [String: Any],
+        info[kIOPSTypeKey] as? String == kIOPSInternalBatteryType
+      else { return false }
+      return info[kIOPSPowerSourceStateKey] as? String == kIOPSBatteryPowerValue
+    }
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/PrefPropagation.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/PrefPropagation.swift
@@ -107,6 +107,9 @@ public enum PrefEffect: Sendable, Hashable {
   /// virtual displays to the slot prefs. Carried by
   /// `virtualSlotConfigured` alone.
   case syncVirtualDisplays
+  /// `AppModel.notePollConsumerAppeared()`: rebuild the poll job so the first
+  /// fan-out does not wait out the idle interval in flight.
+  case restartBrightnessPoll
 }
 
 public enum PrefPropagation {
@@ -123,9 +126,14 @@ public enum PrefPropagation {
       // `hasVisibleSlider` derives from these two hide prefs.
       [.rebuildPanel, .updateStatusItem]
 
+    case .enableBrightnessSync:
+      // Sync is a poll consumer, so the job is rebuilt rather than left asleep on
+      // a long interval.
+      [.rebuildPanel, .restartBrightnessPoll]
+
     case .showContrast, .enableSliderSnap, .enableSliderPercent,
          .hideVolumeSlider, .friendlyName, .isDisabled, .hideOsd,
-         .enableBrightnessSync, .hideKeepAwake, .hideCombinedBrightness:
+         .hideKeepAwake, .hideCombinedBrightness:
       // `hideKeepAwake` is presentation alone: hiding the row while keep awake is ON
       // leaves the display awake, which the Menu Bar pane's caption says out loud.
       // `isDisabled` carries no `.rearmTap` deliberately: a display whose keyboard

--- a/CandelaKit/Sources/CandelaProbe/main.swift
+++ b/CandelaKit/Sources/CandelaProbe/main.swift
@@ -118,12 +118,13 @@ func ddcGet(code: UInt8, label: String) async {
   for entry in found {
     // A read failure is normal on a write-only panel, and WHICH failure is the
     // verdict: zeros over the sentinel is a panel answering nothing, silence is
-    // no answer at all.
+    // no answer at all, and a refusal is the panel naming a code it does not carry.
     let reading: String
     switch await entry.writer.readOutcome(command: code) {
     case let .frame(current, max): reading = "\(current)/\(max)"
     case .allZeros: reading = "read answered with zeros (write-only panel)"
     case .noReply: reading = "read got no reply (silent panel, or DDC is locked by HDR)"
+    case .refused: reading = "the display refused this code (it does not carry this register)"
     }
     print("\(entry.display.name): \(label) \(reading)")
   }

--- a/CandelaKit/Sources/CandelaProbe/main.swift
+++ b/CandelaKit/Sources/CandelaProbe/main.swift
@@ -112,10 +112,16 @@ func parseHexByte(_ text: String) -> UInt8? {
 func ddcGet(code: UInt8, label: String) async {
   requireDDCDisplays()
   for entry in found {
-    let result = await entry.writer.read(command: code)
-    // A read failure is normal on write-only panels (the MAG 341C ACKs every
-    // write and returns all-zeros for every read), not a tool fault.
-    print("\(entry.display.name): \(label) \(result.map { "\($0.current)/\($0.max)" } ?? "read failed (panel may be write-only, or DDC is locked by HDR)")")
+    // A read failure is normal on a write-only panel, and WHICH failure is the
+    // verdict: zeros over the sentinel is a panel answering nothing, silence is
+    // no answer at all.
+    let reading: String
+    switch await entry.writer.readOutcome(command: code) {
+    case let .frame(current, max): reading = "\(current)/\(max)"
+    case .allZeros: reading = "read answered with zeros (write-only panel)"
+    case .noReply: reading = "read got no reply (silent panel, or DDC is locked by HDR)"
+    }
+    print("\(entry.display.name): \(label) \(reading)")
   }
 }
 

--- a/CandelaKit/Sources/CandelaProbe/main.swift
+++ b/CandelaKit/Sources/CandelaProbe/main.swift
@@ -59,6 +59,10 @@ usage: candela-probe [--display <id>] <subcommand>
   vd online <id>                          is that display in THIS process's online list
   conform [--apply]                       assert the private-API platform assumptions; run after every macOS update
   regress [--apply] [--json <path>] [--record <dir>] [--commit <sha>] [--tools <dir>] [--debug-app <path>]  assert the app-behaviour invariants against the deployed app
+
+DDC pacing is per process: this tool keeps its own bus floor per display and
+knows nothing about the app's. One DDC writer at a time covers the probe, so
+quit or idle anything else driving the same panel before a DDC subcommand.
 """
 
 /// The DDC subcommands need a DDC-capable external display. The private-API
@@ -482,8 +486,9 @@ case "modeapply":
   let before = configurator.currentMode(for: target)
   print("before: \(before.map { "\($0.logicalWidth)x\($0.logicalHeight) fb \($0.pixelWidth)x\($0.pixelHeight) id \($0.ioModeID) \(String(format: "%g", $0.refreshHz)) Hz" } ?? "unknown")")
   print("applying: \(mode.logicalWidth)x\(mode.logicalHeight) fb \(mode.pixelWidth)x\(mode.pixelHeight) id \(mode.ioModeID) provenance \(mode.provenance) \(String(format: "%g", mode.refreshHz)) Hz")
-  do {
-    try configurator.apply(mode, to: target, scope: applyScope)
+  // Run for an unhonoured commit too: that apply MOVED the display, so what it
+  // shows and how it gets back matter more there.
+  func reportAchievedThenHold() {
     let after = configurator.currentMode(for: target)
     print("after:  \(after.map { "\($0.logicalWidth)x\($0.logicalHeight) fb \($0.pixelWidth)x\($0.pixelHeight) id \($0.ioModeID) \(String(format: "%g", $0.refreshHz)) Hz" } ?? "unknown")")
     print("scope: \(applyScope); holding \(holdSeconds)s...")
@@ -493,6 +498,20 @@ case "modeapply":
         ? "exiting: session scope keeps the mode; put the display back."
         : "exiting: preview scope reverts now."
     )
+  }
+  do {
+    try configurator.apply(mode, to: target, scope: applyScope)
+    reportAchievedThenHold()
+  } catch let error as DisplayConfigError where error.didCommit {
+    // Not a refusal: the commit went through and the display took something
+    // else. The error's own achieved mode as well as the `after:` line, which
+    // goes through the deduplicated list and can answer "unknown".
+    let landed = error.unhonouredCommit?.achieved
+    print("""
+    apply UNHONOURED: the commit went through and the display did not take it; it reports \(landed.map { "\($0.logicalWidth)x\($0.logicalHeight) fb \($0.pixelWidth)x\($0.pixelHeight) \(String(format: "%g", $0.refreshHz)) Hz" } ?? "nothing readable")
+    """)
+    reportAchievedThenHold()
+    exit(4)
   } catch {
     print("apply FAILED: \(error)")
     exit(4)

--- a/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
@@ -57,4 +57,51 @@ struct AccessibilityBackstopPolicyTests {
     #expect(interval(requires: false, missingFor: 3600) == nil)
     #expect(interval(requires: false, sinceNotification: 0) == nil)
   }
+
+  /// The cadence an hour into a missing grant that the tap wants, for each edge.
+  ///
+  /// The edge goes THROUGH the policy, exactly as `AccessibilityPermission`'s two
+  /// doors do: nothing here decides for it, so hard-coding the predicate either way
+  /// moves one of the two answers below. What is modelled is only what the permission
+  /// object does with the verdict, which is to put the hunt clock back to zero.
+  private func cadenceAfterEdge(
+    _ edge: AccessibilityBackstopPolicy.Edge,
+    granted: Bool = false,
+    requires: Bool = true
+  ) -> TimeInterval? {
+    let reopens = AccessibilityBackstopPolicy.reopensHunt(
+      edge: edge, granted: granted, requiresAccessibility: requires
+    )
+    return interval(granted: granted, requires: requires, missingFor: reopens ? 0 : 3600)
+  }
+
+  /// A pref that re-arms the tap says nothing about whether anyone is at System
+  /// Settings, and most of them are not about keys at all, so the clock stays put.
+  @Test func anUnrelatedTapRearmLeavesTheRestingCadence() {
+    #expect(cadenceAfterEdge(.tapRearmed) == 30)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .tapRearmed, granted: false, requiresAccessibility: true
+    ) == false)
+  }
+
+  /// The one edge that does mean someone may be about to grant it.
+  @Test func aKeyModeWriteReopensTheHunt() {
+    #expect(cadenceAfterEdge(.keyModesWritten) == 2)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .keyModesWritten, granted: false, requiresAccessibility: true
+    ))
+  }
+
+  /// The state halves, on the edge that can carry them: a held grant is not being
+  /// hunted for, and an all-custom rig runs no timer for a re-stamp to move.
+  @Test func aKeyModeWriteReopensNothingWithoutBothStateHalves() {
+    #expect(cadenceAfterEdge(.keyModesWritten, granted: true) == 10)
+    #expect(cadenceAfterEdge(.keyModesWritten, requires: false) == nil)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .keyModesWritten, granted: true, requiresAccessibility: true
+    ) == false)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .keyModesWritten, granted: false, requiresAccessibility: false
+    ) == false)
+  }
 }

--- a/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import CandelaKit
+
+@Suite("Accessibility backstop cadence")
+struct AccessibilityBackstopPolicyTests {
+  private func interval(
+    granted: Bool = false,
+    requires: Bool = true,
+    missingFor: TimeInterval = 0,
+    sinceNotification: TimeInterval? = nil
+  ) -> TimeInterval? {
+    AccessibilityBackstopPolicy.interval(
+      granted: granted,
+      requiresAccessibility: requires,
+      secondsSinceMissingBegan: missingFor,
+      secondsSinceNotification: sinceNotification
+    )
+  }
+
+  @Test func aHeldGrantIsPolledForeverAtTenSeconds() {
+    #expect(interval(granted: true) == 10)
+    #expect(interval(granted: true, missingFor: 100_000) == 10)
+  }
+
+  /// The tracked answer feeds the prompt path, which declines to prompt while it
+  /// says the grant is held, so the held poll survives the skip.
+  @Test func aHeldGrantIsPolledEvenWhenNothingNeedsIt() {
+    #expect(interval(granted: true, requires: false) == 10)
+  }
+
+  @Test func aMissingGrantHuntsForTheFirstTwoMinutes() {
+    #expect(interval(missingFor: 0) == 2)
+    #expect(interval(missingFor: 60) == 2)
+    #expect(interval(missingFor: 119.9) == 2)
+  }
+
+  @Test func theHuntBacksOffOnceTheWindowHasPassed() {
+    #expect(interval(missingFor: 120) == 30)
+    #expect(interval(missingFor: 3600) == 30)
+  }
+
+  @Test func aNotificationReopensTheHuntFromAnyAge() {
+    #expect(interval(missingFor: 3600, sinceNotification: 0) == 2)
+    #expect(interval(missingFor: 3600, sinceNotification: 29.9) == 2)
+  }
+
+  @Test func theNotificationWindowExpiresBackToTheRestingCadence() {
+    #expect(interval(missingFor: 3600, sinceNotification: 30) == 30)
+    #expect(interval(missingFor: 3600, sinceNotification: 600) == 30)
+  }
+
+  /// An all-custom or all-disabled rig runs Carbon hotkeys only, so no timer.
+  @Test func nothingIsPolledWhenNoKeyFamilyNeedsTheGrant() {
+    #expect(interval(requires: false) == nil)
+    #expect(interval(requires: false, missingFor: 3600) == nil)
+    #expect(interval(requires: false, sinceNotification: 0) == nil)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AccessibilityBackstopPolicyTests.swift
@@ -92,6 +92,29 @@ struct AccessibilityBackstopPolicyTests {
     ))
   }
 
+  /// The prompt and the two buttons that open the Accessibility list: the user is
+  /// at System Settings by construction, so the backstop polls fast for their
+  /// return however long the grant has been gone.
+  @Test func beingSentToSystemSettingsReopensTheHunt() {
+    #expect(cadenceAfterEdge(.sentToSystemSettings) == 2)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .sentToSystemSettings, granted: false, requiresAccessibility: true
+    ))
+  }
+
+  /// Same two halves as the key-mode write. The all-custom case is the live one:
+  /// the onboarding flow can offer the list before any key family wants the grant.
+  @Test func beingSentToSystemSettingsReopensNothingWithoutBothStateHalves() {
+    #expect(cadenceAfterEdge(.sentToSystemSettings, granted: true) == 10)
+    #expect(cadenceAfterEdge(.sentToSystemSettings, requires: false) == nil)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .sentToSystemSettings, granted: true, requiresAccessibility: true
+    ) == false)
+    #expect(AccessibilityBackstopPolicy.reopensHunt(
+      edge: .sentToSystemSettings, granted: false, requiresAccessibility: false
+    ) == false)
+  }
+
   /// The state halves, on the edge that can carry them: a held grant is not being
   /// hunted for, and an all-custom rig runs no timer for a re-stamp to move.
   @Test func aKeyModeWriteReopensNothingWithoutBothStateHalves() {

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessControllerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessControllerTests.swift
@@ -68,8 +68,15 @@ actor FakeDDC: DDCWriting {
   nonisolated func landedWriteCount() -> Int { landed.withLock { $0 } }
 
   func read(command: UInt8) async -> (current: UInt16, max: UInt16)? {
-    readResult
+    reads += 1
+    return readResult
   }
+
+  /// Counts the reads that reached the wire, which is the only way to tell a
+  /// controller that asked and got nothing from one that never asked.
+  private(set) var reads = 0
+
+  func recordedReadCount() -> Int { reads }
 
   func recordedWrites() async -> [(command: UInt8, value: UInt16)] { writes }
 

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollCadenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollCadenceTests.swift
@@ -1,0 +1,95 @@
+import os
+import Testing
+@testable import CandelaKit
+
+// MARK: - Cadence policy
+
+/// One row of the truth table. Every row is spelled out rather than re-derived: a
+/// test that recomputes the policy agrees with a wrong one just as readily.
+private struct Cell: Sendable, Hashable {
+  let moving: Bool
+  let surface: Bool
+  let sync: Bool
+  let native: Bool
+  let battery: Bool
+  let want: BrightnessPollCadence
+}
+
+private let cadenceCells: [Cell] = [
+  Cell(moving: false, surface: false, sync: false, native: false, battery: false, want: .slowIdle),
+  Cell(moving: false, surface: false, sync: false, native: false, battery: true,  want: .batterySlowIdle),
+  Cell(moving: false, surface: false, sync: false, native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: false, sync: false, native: true,  battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: false, battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: false, battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: false, native: true,  battery: true,  want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: false, battery: false, want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: false, battery: true,  want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: false, sync: true,  native: true,  battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: false, battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: false, battery: true,  want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: true,  battery: false, want: .idle),
+  Cell(moving: false, surface: true,  sync: true,  native: true,  battery: true,  want: .idle),
+  Cell(moving: true,  surface: false, sync: false, native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: false, native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: false, sync: false, native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: false, native: true,  battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: false, native: true,  battery: true,  want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: false, sync: true,  native: true,  battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: false, battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: false, battery: true,  want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: true,  battery: false, want: .fast),
+  Cell(moving: true,  surface: true,  sync: true,  native: true,  battery: true,  want: .fast),
+]
+
+@Suite("Poll cadence policy")
+struct BrightnessPollCadencePolicyTests {
+  @Test func theTableCoversEveryCell() {
+    #expect(cadenceCells.count == 32)
+    // 32 rows is only every cell if no two describe the same inputs: a duplicated
+    // row and a missing one look identical from the count alone.
+    let inputs = Set(cadenceCells.map { [$0.moving, $0.surface, $0.sync, $0.native, $0.battery] })
+    #expect(inputs.count == 32)
+  }
+
+  @Test(arguments: cadenceCells)
+  fileprivate func cadence(_ cell: Cell) {
+    let got = BrightnessPollCadence.choose(
+      isMoving: cell.moving,
+      isSyncEnabled: cell.sync,
+      isSurfaceVisible: cell.surface,
+      isExternalNativeActive: cell.native,
+      isOnBattery: cell.battery
+    )
+    #expect(got == cell.want)
+  }
+
+  /// The power-source read is the one input with a cost, so it is asked for only
+  /// in the branch that uses it.
+  @Test func theBatteryIsNotReadUnlessTheSlowBranchIsReached() {
+    let asked = OSAllocatedUnfairLock(initialState: 0)
+    func onBattery() -> Bool {
+      asked.withLock { $0 += 1 }
+      return false
+    }
+    _ = BrightnessPollCadence.choose(
+      isMoving: true, isSyncEnabled: false, isSurfaceVisible: false,
+      isExternalNativeActive: false, isOnBattery: onBattery())
+    _ = BrightnessPollCadence.choose(
+      isMoving: false, isSyncEnabled: false, isSurfaceVisible: true,
+      isExternalNativeActive: false, isOnBattery: onBattery())
+    #expect(asked.withLock { $0 } == 0)
+    _ = BrightnessPollCadence.choose(
+      isMoving: false, isSyncEnabled: false, isSurfaceVisible: false,
+      isExternalNativeActive: false, isOnBattery: onBattery())
+    #expect(asked.withLock { $0 } == 1)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -105,11 +105,11 @@ private func makePoller(
 @Test func readMatchingExpectedIsDiscardedAsEcho() async {
   let probe = Probe(expected: 0.5, generation: 3, hardware: 0.5)
   let poller = makePoller(probe)
-  let task = Task { await poller.run() }
-  _ = await waitUntil { probe.reads.count >= 3 }
-  task.cancel()
-  #expect(probe.reads.count >= 3)
+  var intervals: [Duration] = []
+  for _ in 0..<3 { intervals.append(await poller.pollOnce()) }
+  #expect(probe.reads.count == 3)
   #expect(probe.adoptions.isEmpty)
+  #expect(intervals == Array(repeating: .milliseconds(30), count: 3))
 }
 
 @Test func readWithinToleranceIsDiscardedAsEcho() async {
@@ -198,15 +198,12 @@ private func makePoller(
 
 @Test func divergenceSwitchesToFastCadence() async {
   let probe = Probe(expected: 0.5, generation: 1, hardware: 0.9)
-  // The idle interval dwarfs waitUntil's window on purpose: `run()` ticks before it
-  // sleeps, so a fast poller produces five reads in ~40 ms while an idle one cannot
-  // produce read two inside 3 s. The gate below is the cadence assertion; an elapsed-time
-  // bound crossed 1.198 s under runner starvation while still on the fast cadence.
   let poller = makePoller(probe, fast: .milliseconds(10), idle: .seconds(30))
-  let task = Task { await poller.run() }
-  let got = await waitUntil { probe.reads.count >= 5 }
-  task.cancel()
-  #expect(got)
+  var intervals: [Duration] = []
+  for _ in 0..<5 { intervals.append(await poller.pollOnce()) }
+  #expect(probe.reads.count == 5)
+  #expect(probe.adoptions.count == 5)
+  #expect(intervals == Array(repeating: .milliseconds(10), count: 5))
 }
 
 @Test func echoStaysOnIdleCadence() async {

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -168,11 +168,11 @@ private func makePoller(
 @Test func readMatchingExpectedIsDiscardedAsEcho() async {
   let probe = Probe(expected: 0.5, generation: 3, hardware: 0.5)
   let poller = makePoller(probe)
-  let task = Task { await poller.run() }
-  _ = await waitUntil { probe.reads.count >= 3 }
-  task.cancel()
-  #expect(probe.reads.count >= 3)
+  var intervals: [Duration] = []
+  for _ in 0..<3 { intervals.append(await poller.pollOnce()) }
+  #expect(probe.reads.count == 3)
   #expect(probe.adoptions.isEmpty)
+  #expect(intervals == Array(repeating: .milliseconds(30), count: 3))
 }
 
 @Test func readWithinToleranceIsDiscardedAsEcho() async {
@@ -261,15 +261,12 @@ private func makePoller(
 
 @Test func divergenceSwitchesToFastCadence() async {
   let probe = Probe(expected: 0.5, generation: 1, hardware: 0.9)
-  // The idle interval dwarfs waitUntil's window on purpose: `run()` ticks before it
-  // sleeps, so a fast poller produces five reads in ~40 ms while an idle one cannot
-  // produce read two inside 3 s. The gate below is the cadence assertion; an elapsed-time
-  // bound crossed 1.198 s under runner starvation while still on the fast cadence.
   let poller = makePoller(probe, fast: .milliseconds(10), idle: .seconds(30))
-  let task = Task { await poller.run() }
-  let got = await waitUntil { probe.reads.count >= 5 }
-  task.cancel()
-  #expect(got)
+  var intervals: [Duration] = []
+  for _ in 0..<5 { intervals.append(await poller.pollOnce()) }
+  #expect(probe.reads.count == 5)
+  #expect(probe.adoptions.count == 5)
+  #expect(intervals == Array(repeating: .milliseconds(10), count: 5))
 }
 
 @Test func echoStaysOnIdleCadence() async {

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -28,12 +28,27 @@ private final class Probe: Sendable {
     var converging = false
     var epochCurrent = true
     var hardware: Double? = 0.5
+    var syncEnabled = false
+    var surfaceVisible = false
+    var onBattery = false
+    /// Each counts wakeups, which reads cannot (a tick can skip its read). Two
+    /// counters so a sleep sliced to re-check only ONE signal still shows up.
+    var syncAsks = 0
+    var surfaceAsks = 0
   }
 
   private let state = OSAllocatedUnfairLock(initialState: State())
-  let displayID: CGDirectDisplayID = 7
+  let displayID: CGDirectDisplayID
+  /// A built-in probe is how a rig with nothing to consume the value is modelled:
+  /// it is polled like anything else but casts no vote on the cadence.
+  let isExternal: Bool
 
-  init(expected: Double?, generation: UInt64 = 0, hardware: Double? = 0.5) {
+  init(
+    expected: Double?, generation: UInt64 = 0, hardware: Double? = 0.5,
+    isExternal: Bool = true, displayID: CGDirectDisplayID = 7
+  ) {
+    self.isExternal = isExternal
+    self.displayID = displayID
     state.withLock {
       $0.expectedValue = expected
       $0.generation = generation
@@ -43,10 +58,15 @@ private final class Probe: Sendable {
 
   var reads: [ReadRecord] { state.withLock { $0.reads } }
   var adoptions: [Adoption] { state.withLock { $0.adoptions } }
+  var syncAsks: Int { state.withLock { $0.syncAsks } }
+  var surfaceAsks: Int { state.withLock { $0.surfaceAsks } }
 
   func setNativeActive(_ value: Bool) { state.withLock { $0.nativeActive = value } }
   func setConverging(_ value: Bool) { state.withLock { $0.converging = value } }
   func setEpochCurrent(_ value: Bool) { state.withLock { $0.epochCurrent = value } }
+  func setSyncEnabled(_ value: Bool) { state.withLock { $0.syncEnabled = value } }
+  func setSurfaceVisible(_ value: Bool) { state.withLock { $0.surfaceVisible = value } }
+  func setOnBattery(_ value: Bool) { state.withLock { $0.onBattery = value } }
 
   func read(_ id: CGDirectDisplayID) -> Double? {
     state.withLock { state in
@@ -59,6 +79,18 @@ private final class Probe: Sendable {
     { [state] in state.withLock { $0.epochCurrent } }
   }
 
+  var isSyncEnabled: @Sendable () -> Bool {
+    { [state] in state.withLock { $0.syncAsks += 1; return $0.syncEnabled } }
+  }
+
+  var isSurfaceVisible: @Sendable () -> Bool {
+    { [state] in state.withLock { $0.surfaceAsks += 1; return $0.surfaceVisible } }
+  }
+
+  var isOnBattery: @Sendable () -> Bool {
+    { [state] in state.withLock { $0.onBattery } }
+  }
+
   var target: BrightnessPoller.Target {
     BrightnessPoller.Target(
       displayID: displayID,
@@ -67,7 +99,8 @@ private final class Probe: Sendable {
       adopt: { [state] value, generation in
         state.withLock { $0.adoptions.append(Adoption(value: value, generation: generation)) }
       },
-      isConverging: { [state] in state.withLock { $0.converging } }
+      isConverging: { [state] in state.withLock { $0.converging } },
+      isExternal: isExternal
     )
   }
 }
@@ -88,15 +121,45 @@ private func makePoller(
   _ probe: Probe,
   fast: Duration = .milliseconds(10),
   idle: Duration = .milliseconds(30),
+  slowIdle: Duration = .milliseconds(60),
+  batteryIdle: Duration = .milliseconds(90),
   tolerance: Double = 0.008
 ) -> BrightnessPoller {
   BrightnessPoller(
     targets: [probe.target],
     read: { probe.read($0) },
     isEpochCurrent: probe.isEpochCurrent,
+    isSyncEnabled: probe.isSyncEnabled,
+    isSurfaceVisible: probe.isSurfaceVisible,
+    isOnBattery: probe.isOnBattery,
     fastInterval: fast,
     idleInterval: idle,
+    slowIdleInterval: slowIdle,
+    batteryIdleInterval: batteryIdle,
     tolerance: tolerance
+  )
+}
+
+/// Several targets on one job, so a rig can hold an external AND a built-in. The
+/// read routes by display id, which is why a probe can carry its own.
+private func makePoller(
+  _ probes: [Probe],
+  fast: Duration = .milliseconds(10),
+  idle: Duration = .milliseconds(30),
+  slowIdle: Duration = .milliseconds(60),
+  batteryIdle: Duration = .milliseconds(90)
+) -> BrightnessPoller {
+  BrightnessPoller(
+    targets: probes.map(\.target),
+    read: { id in probes.first { $0.displayID == id }.flatMap { $0.read(id) } },
+    isEpochCurrent: probes[0].isEpochCurrent,
+    isSyncEnabled: probes[0].isSyncEnabled,
+    isSurfaceVisible: probes[0].isSurfaceVisible,
+    isOnBattery: probes[0].isOnBattery,
+    fastInterval: fast,
+    idleInterval: idle,
+    slowIdleInterval: slowIdle,
+    batteryIdleInterval: batteryIdle
   )
 }
 
@@ -222,6 +285,149 @@ private func makePoller(
   // Idle cadence over this window is 2 reads and fast would be ~50, so only the upper
   // bound can show the wrong cadence, and starvation moves the count the safe way.
   #expect(probe.reads.count <= 4)
+}
+
+// MARK: - Idle cadence
+
+@Test func nothingConsumingTheValueLengthensTheInterval() async {
+  // Built-in only, echoing: nothing is moving, no surface is up, sync is off and
+  // no EXTERNAL is native, which is the whole of the slow condition.
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .milliseconds(200))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { !probe.reads.isEmpty }
+  try? await Task.sleep(for: .milliseconds(250))
+  task.cancel()
+  #expect(started)
+  // The idle interval here is the FAST one, so a poller that ignored the slow
+  // cadence would be at ~50 reads. The control below proves this window can carry
+  // them.
+  #expect(probe.reads.count <= 4)
+}
+
+@Test func aSurfaceAppearingShortensTheNextIntervalWithNoRestart() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .milliseconds(200))
+  let task = Task { await poller.run() }
+  _ = await waitUntil { !probe.reads.isEmpty }
+  // Flipped mid-run, on the SAME poll job: the cadence is re-read every tick, so
+  // nothing restarts it.
+  probe.setSurfaceVisible(true)
+  let sped = await waitUntil { probe.reads.count >= 20 }
+  task.cancel()
+  #expect(sped)
+}
+
+@Test func syncOnKeepsTheShortIntervalWithNoExternalNative() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  probe.setSyncEnabled(true)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .seconds(30))
+  let task = Task { await poller.run() }
+  let sped = await waitUntil { probe.reads.count >= 20 }
+  task.cancel()
+  #expect(sped)
+}
+
+@Test func batteryLengthensTheSlowIntervalFurther() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  probe.setOnBattery(true)
+  let poller = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(5),
+    slowIdle: .milliseconds(20), batteryIdle: .milliseconds(400))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { !probe.reads.isEmpty }
+  try? await Task.sleep(for: .milliseconds(300))
+  task.cancel()
+  #expect(started)
+  // On mains this window is ~15 reads.
+  #expect(probe.reads.count <= 2)
+}
+
+/// The whole saving, stated as wakeups rather than reads: a tick can skip its read
+/// (a non-native target), so only the per-loop cadence read counts the timer.
+@Test func aSlowIntervalWakesOncePerIntervalNotOncePerSecond() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let poller = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(20), slowIdle: .milliseconds(300))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { probe.syncAsks >= 1 }
+  try? await Task.sleep(for: .milliseconds(250))
+  task.cancel()
+  #expect(started)
+  // A sleep sliced at the idle interval would show about 12 in whichever signal it
+  // re-checked, so both are asserted.
+  #expect(probe.syncAsks <= 2)
+  #expect(probe.surfaceAsks <= 2)
+}
+
+/// The app's route back from a long interval is rebuilding the job, which buys
+/// nothing unless a fresh run reads BEFORE it sleeps.
+@Test func aFreshJobReadsBeforeItSleeps() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let first = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(50), slowIdle: .seconds(30))
+  let firstTask = Task { await first.run() }
+  _ = await waitUntil { !probe.reads.isEmpty }
+  firstTask.cancel() // asleep for 30 s, exactly the state a surface can open into
+  let before = probe.reads.count
+  probe.setSurfaceVisible(true)
+  let replacement = makePoller(
+    probe, fast: .milliseconds(5), idle: .milliseconds(50), slowIdle: .seconds(30))
+  let start = ContinuousClock.now
+  let secondTask = Task { await replacement.run() }
+  let read = await waitUntil(.seconds(2)) { probe.reads.count > before }
+  let elapsed = ContinuousClock.now - start
+  secondTask.cancel()
+  #expect(read)
+  #expect(elapsed < .milliseconds(500))
+}
+
+/// A display on the DDC path is not a consumer of the poll: it is never read, so
+/// it must not hold the short interval either.
+@Test func aNonNativeExternalDoesNotHoldTheShortInterval() async {
+  let external = Probe(expected: 0.5, generation: 1, hardware: 0.5, displayID: 8)
+  external.setNativeActive(false)
+  let builtIn = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false, displayID: 9)
+  let poller = makePoller(
+    [builtIn, external], fast: .milliseconds(5), idle: .milliseconds(5),
+    slowIdle: .milliseconds(200))
+  let task = Task { await poller.run() }
+  let started = await waitUntil { !builtIn.reads.isEmpty }
+  try? await Task.sleep(for: .milliseconds(250))
+  task.cancel()
+  #expect(started)
+  #expect(external.reads.isEmpty)
+  #expect(builtIn.reads.count <= 4)
+}
+
+/// The control for the test above: the same rig with the external ON the native
+/// path must hold the short interval, or the one above passes for the wrong reason.
+@Test func aNativeExternalDoesHoldTheShortInterval() async {
+  let external = Probe(expected: 0.5, generation: 1, hardware: 0.5, displayID: 8)
+  let builtIn = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false, displayID: 9)
+  let poller = makePoller(
+    [builtIn, external], fast: .milliseconds(5), idle: .milliseconds(5),
+    slowIdle: .seconds(30))
+  let task = Task { await poller.run() }
+  let sped = await waitUntil { builtIn.reads.count >= 20 }
+  task.cancel()
+  #expect(sped)
+}
+
+/// The poll job must survive every idle state: an external entering HDR reaches
+/// the native path through no call of ours, and the running poller is what
+/// notices.
+@Test func theSlowCadenceStillNoticesADisplayTurningNative() async {
+  let probe = Probe(expected: 0.5, generation: 1, hardware: 0.9)
+  probe.setNativeActive(false)
+  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .milliseconds(50))
+  let task = Task { await poller.run() }
+  try? await Task.sleep(for: .milliseconds(120))
+  #expect(probe.reads.isEmpty)
+  probe.setNativeActive(true)
+  let adopted = await waitUntil { !probe.adoptions.isEmpty }
+  task.cancel()
+  #expect(adopted)
 }
 
 // MARK: - Lifecycle

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -369,17 +369,22 @@ private func makePoller(
   let firstTask = Task { await first.run() }
   _ = await waitUntil { !probe.reads.isEmpty }
   firstTask.cancel() // asleep for 30 s, exactly the state a surface can open into
+  // Awaited, not merely cancelled: a read the old job had already begun would
+  // otherwise land after the count below and pass for the new job's first read.
+  await firstTask.value
   let before = probe.reads.count
   probe.setSurfaceVisible(true)
   let replacement = makePoller(
     probe, fast: .milliseconds(5), idle: .milliseconds(50), slowIdle: .seconds(30))
   let start = ContinuousClock.now
   let secondTask = Task { await replacement.run() }
-  let read = await waitUntil(.seconds(2)) { probe.reads.count > before }
+  let read = await waitUntil(.seconds(5)) { probe.reads.count > before }
   let elapsed = ContinuousClock.now - start
   secondTask.cancel()
   #expect(read)
-  #expect(elapsed < .milliseconds(500))
+  // Milliseconds expected; the bound survives a loaded machine and stays an order
+  // of magnitude under the 30 s a job that slept first would wait.
+  #expect(elapsed < .seconds(2))
 }
 
 /// A display on the DDC path is not a consumer of the poll: it is never read, so

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
@@ -3,10 +3,9 @@ import Testing
 @testable import CandelaKit
 
 /// A panel that says nothing TWICE RUNNING is asked once per plug, and every
-/// route that can make it answer again clears the verdict that stopped the
-/// asking. One bad pass is not a verdict: bus contention, the probe holding the
-/// wire and another panel entering HDR all produce one, on displays that answer
-/// perfectly on the next pass.
+/// route that can make it answer again clears the skip. The clears reach the
+/// skip only: the app runs the read pass before it fans a reconfiguration out,
+/// so a clear there wiped the verdict that pass had just earned.
 
 @MainActor
 private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> BrightnessController {
@@ -32,8 +31,75 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   var latch = DDCReadSkipLatch()
   latch.record(.noReply)
   #expect(!latch.skipsRead)
+  latch.record(.noReply)
+  #expect(latch.skipsRead)
+}
+
+/// The two zeros passes a write-only panel is asked before it is left alone.
+@Test func twoZerosPassesLatchTheSkip() {
+  var latch = DDCReadSkipLatch()
+  latch.record(.allZeros)
+  #expect(!latch.skipsRead)
   latch.record(.allZeros)
   #expect(latch.skipsRead)
+}
+
+/// Zeros and silence are different findings: one of each is a contended wire,
+/// and taking it as a pair flipped the MAG to "Not answering" on one bad pass.
+@Test func aZerosPassAndASilentPassAreNotAPair() {
+  var mixed = DDCReadSkipLatch()
+  mixed.record(.allZeros)
+  #expect(mixed.record(.noReply) == false)
+  #expect(!mixed.skipsRead)
+
+  var reversed = DDCReadSkipLatch()
+  reversed.record(.noReply)
+  #expect(reversed.record(.allZeros) == true) // zeros is the panel's own word
+  #expect(!reversed.skipsRead)
+}
+
+/// And the run the broken pair was hiding: the silence still latches and
+/// publishes, one pass later than it used to, once a second silence agrees.
+@Test func aZerosPassThenTwoSilentPassesPublishesOnTheThird() {
+  var latch = DDCReadSkipLatch()
+  #expect(latch.record(.allZeros) == true)
+  #expect(latch.record(.noReply) == false)
+  #expect(!latch.skipsRead)
+  #expect(latch.record(.noReply) == true)
+  #expect(latch.skipsRead)
+}
+
+/// The publish half, which the read sites read straight off `record`.
+@Test func aLoneSilencePublishesNothingAndTheSecondOnePublishes() {
+  var latch = DDCReadSkipLatch()
+  #expect(latch.record(.noReply) == false)
+  #expect(latch.record(.noReply) == true)
+}
+
+/// A zeros reply is the panel's own word about itself, so it never waits for a
+/// second pass the way a silence does, and neither does a frame.
+@Test func anAnswerPublishesOnItsFirstPass() {
+  var zeros = DDCReadSkipLatch()
+  #expect(zeros.record(.allZeros) == true)
+  var frames = DDCReadSkipLatch()
+  #expect(frames.record(.answered) == true)
+}
+
+/// A pass that never reached the wire proved nothing, so it publishes nothing.
+@Test func aPassThatAttemptedNothingPublishesNothing() {
+  var latch = DDCReadSkipLatch()
+  #expect(latch.record(.notAttempted) == false)
+}
+
+/// The clear is about the ASKING. A cleared latch has to earn a silent verdict
+/// over again, which is what stops one stale silence from publishing alone.
+@Test func aClearedLatchMakesASilenceWaitForItsPairAgain() {
+  var latch = DDCReadSkipLatch()
+  latch.record(.noReply)
+  latch.record(.noReply)
+  latch.clear()
+  #expect(latch.record(.noReply) == false)
+  #expect(latch.record(.noReply) == true)
 }
 
 /// Consecutive, not cumulative: a panel that answered between two bad passes has
@@ -81,13 +147,64 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   let fake = FakeDDC(readResult: nil)
   let controller = makeLegacyPathController(writer: fake)
   await controller.refreshFromHardware()
-  // The verdict is published from the FIRST pass: diagnostics reports what the
-  // wire proved, and only the asking waits for a second silent pass.
-  #expect(controller.readEvidence == .noReply)
+  // One silence is what a held wire looks like, so the row keeps saying nothing
+  // has been proved yet.
+  #expect(controller.readEvidence == .notAttempted)
   await controller.refreshFromHardware()
+  // The second one in a row is: it trips the latch, and the pass that trips it is
+  // the pass that publishes.
+  #expect(controller.readEvidence == .noReply)
   await controller.refreshFromHardware()
   #expect(controller.readEvidence == .noReply)
   #expect(await fake.recordedReadCount() == 2)
+}
+
+/// The Dell's measured behaviour: silence once on a plug-in pass and once right
+/// after a mode change, with a clean frame on the next pass each time.
+@MainActor
+@Test func oneSilenceLeavesAnAnsweringPanelsVerdictStanding() async {
+  let fake = FakeDDC(readResult: (current: 50, max: 100))
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+
+  await fake.setReadResult(nil)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+
+  await fake.setReadResult((current: 60, max: 100))
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  #expect(await fake.recordedReadCount() == 3)
+}
+
+/// A frame resets both halves: the verdict it publishes and the silent count
+/// behind the skip, so the next bad pass is a first one again.
+@MainActor
+@Test func aFrameResetsTheVerdictAndTheCount() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake, panelIdentity: "panel-a")
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+
+  // The latch is set, so nothing would be asked without this. The clear is the
+  // asking half only: the verdict is still the one the reads earned.
+  await controller.handleReconfigure()
+  #expect(controller.readEvidence == .noReply)
+
+  await fake.setReadResult((current: 50, max: 100))
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+
+  // The discriminator for the count: without the frame's reset this pass would be
+  // the second silence of a pair and would publish on its own.
+  await fake.setReadResult(nil)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+  #expect(await fake.recordedReadCount() == 5)
 }
 
 @MainActor
@@ -109,7 +226,7 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   let fake = FakeDDC(readResult: nil)
   let controller = makeLegacyPathController(writer: fake)
   await controller.refreshFromHardware()
-  #expect(controller.readEvidence == .noReply)
+  #expect(controller.readEvidence == .notAttempted)
 
   await fake.setReadResult((current: 50, max: 100))
   await controller.refreshFromHardware()
@@ -131,14 +248,18 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   await controller.refreshFromHardware()
   await controller.refreshFromHardware()
   controller.noteWake()
-  #expect(controller.readEvidence == .notAttempted)
+  // The skip is gone; the verdict is not. Nothing has asked the panel since it
+  // was earned, so there is nothing to replace it with.
+  #expect(controller.readEvidence == .noReply)
   await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 3)
+  // And the cleared count means that pass was a first silence again, so it did
+  // not re-publish on its own.
+  #expect(controller.readEvidence == .noReply)
 }
 
-/// The replug route. `rebind` compares the panel IDENTITY, which a new cable or
-/// a new port on the same monitor does not change, so a reconfiguration is the
-/// only thing that gives that panel another hearing.
+/// The replug route: `rebind` compares panel IDENTITY, which a new cable or port
+/// does not change, so only a reconfiguration gives that panel another hearing.
 @MainActor
 @Test func aReconfigurationAsksASilentPanelAgain() async {
   let fake = FakeDDC(readResult: nil)
@@ -149,9 +270,27 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 2)
   await controller.handleReconfigure()
-  #expect(controller.readEvidence == .notAttempted)
+  // The app reads BEFORE it reconfigures each display, so a verdict dropped here
+  // is the one the pass just earned.
+  #expect(controller.readEvidence == .noReply)
   await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 3)
+}
+
+/// A reconfiguration in the app's real order: the read pass runs first, then the
+/// per-display fan-out. The verdict that pass earned has to survive it.
+@MainActor
+@Test func aReconfigurationKeepsTheVerdictTheReadPassJustEarned() async {
+  let fake = FakeDDC(readResult: (current: 0, max: 0))
+  let controller = makeLegacyPathController(writer: fake, panelIdentity: "panel-a")
+  await controller.refreshFromHardware()
+  await controller.handleReconfigure()
+  #expect(controller.readEvidence == .allZeros)
+
+  await fake.setReadResult((current: 50, max: 100))
+  await controller.refreshFromHardware()
+  await controller.handleReconfigure()
+  #expect(controller.readEvidence == .answered)
 }
 
 @MainActor
@@ -161,16 +300,16 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   await controller.refreshFromHardware()
   await controller.refreshFromHardware()
   controller.rebind(writer: fake, panelIdentity: "panel-b")
+  // Both halves, unlike every other clear: a verdict earned by the panel that was
+  // here is not a fact about the one that replaced it.
   #expect(controller.readEvidence == .notAttempted)
   await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 3)
+  #expect(controller.readEvidence == .notAttempted)
 }
 
-/// A verdict earned while HDR held the register is a fact about the window, not
-/// about the panel, so it must not outlive it. It must also not be WIPED while
-/// the window is still open: no read follows under the native path, so a clear
-/// there would replace a real write-only verdict with silence in the diagnostics
-/// report and nothing would put it back until HDR ends.
+/// A skip earned while HDR held the register is a fact about the window, not the
+/// panel, so it must not outlive it. The verdict does: nothing has asked since.
 @MainActor
 @Test func anHDRWindowClosingAsksASilentPanelAgain() async {
   let fake = FakeDDC(readResult: nil)
@@ -200,7 +339,7 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   await hdr.stubEnabled(false)
   _ = await hdr.measuredHDREnabled(displayID: 1)
   await controller.noteHDRStateMayHaveChanged()
-  #expect(controller.readEvidence == .notAttempted)
+  #expect(controller.readEvidence == .noReply)
   await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 3)
 }
@@ -228,10 +367,38 @@ private func makeValueController(
   let fake = FakeDDC(readResult: nil)
   let controller = makeValueController(writer: fake)
   await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .notAttempted)
+  await controller.refreshFromHardware()
   #expect(controller.readEvidence == .noReply)
   await controller.refreshFromHardware()
-  await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 2)
+}
+
+/// The same rule as the brightness read, at the register that costs the most to
+/// ask: a lone silence leaves standing whatever the panel last proved.
+@MainActor
+@Test func oneSilenceLeavesTheValueRegistersVerdictStanding() async {
+  let fake = FakeDDC(readResult: (current: 50, max: 100))
+  let controller = makeValueController(writer: fake)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+
+  await fake.setReadResult(nil)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+  #expect(await fake.recordedReadCount() == 3)
+}
+
+/// A zeros reply is the panel's word about itself, so it publishes on its first
+/// pass the way a frame does, without waiting for a pair.
+@MainActor
+@Test func aValueRegisterAnsweringZerosPublishesAtOnce() async {
+  let fake = FakeDDC(readResult: (current: 0, max: 0))
+  let controller = makeValueController(writer: fake)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .allZeros)
 }
 
 @MainActor
@@ -250,6 +417,7 @@ private func makeValueController(
   let fake = FakeDDC(readResult: nil)
   let controller = makeValueController(writer: fake)
   await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .notAttempted)
   await fake.setReadResult((current: 50, max: 100))
   await controller.refreshFromHardware()
   #expect(controller.readEvidence == .answered)
@@ -263,14 +431,16 @@ private func makeValueController(
   await controller.refreshFromHardware()
   await controller.refreshFromHardware()
   controller.rebind(writer: fake, panelIdentity: "panel-b")
+  // Both halves, unlike every other clear: a verdict earned by the panel that was
+  // here is not a fact about the one that replaced it.
   #expect(controller.readEvidence == .notAttempted)
   await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 3)
+  #expect(controller.readEvidence == .notAttempted)
 }
 
-/// Wake, reconfiguration and the HDR-off edge all reach the value controllers
-/// through the display's brightness controller: the three share one wire, and
-/// only the brightness controller can see the HDR window that locked it.
+/// The value controllers are reached through the brightness controller, the only
+/// one of the three that can see the HDR window that locked their shared wire.
 @MainActor
 @Test func theWiresWakeAndReconfigurationReachTheValueControllers() async {
   let fake = FakeDDC(readResult: nil)
@@ -294,7 +464,8 @@ private func makeValueController(
   #expect(await fake.recordedReadCount() == 2)
 
   brightness.noteWake()
-  #expect(volume.readEvidence == .notAttempted)
+  // The skip travels down the wire; the verdict stays where the reads left it.
+  #expect(volume.readEvidence == .noReply)
   await volume.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 3)
 
@@ -302,6 +473,31 @@ private func makeValueController(
   await volume.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 4)
   await brightness.handleReconfigure()
+  #expect(volume.readEvidence == .noReply)
   await volume.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 5)
+}
+
+/// The same order at the sibling registers: read pass first, reconfiguration
+/// fan-out second, and the diagnostics row still reads the answer afterwards.
+@MainActor
+@Test func aReconfigurationKeepsTheValueRegistersFreshVerdict() async {
+  let fake = FakeDDC(readResult: (current: 40, max: 100))
+  let volume = makeValueController(writer: fake)
+  let defaults = InMemoryDefaults()
+  defaults.set(true, forKey: "disableCombinedBrightness")
+  let brightness = BrightnessController(
+    writer: fake,
+    backends: BrightnessBackends(
+      applierNative: NativeBrightnessApplier(displayID: 1) { _, _ in false },
+      hdr: nil, shade: nil, gamma: nil
+    ),
+    prefs: DisplayPrefs(defaults: defaults, persistenceKey: "wire-siblings-verdict"),
+    displayID: 1,
+    wireSiblings: [volume]
+  )
+
+  await volume.refreshFromHardware()
+  await brightness.handleReconfigure()
+  #expect(volume.readEvidence == .answered)
 }

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
@@ -501,3 +501,133 @@ private func makeValueController(
   await brightness.handleReconfigure()
   #expect(volume.readEvidence == .answered)
 }
+
+// MARK: - The settling pass
+
+/// A read pass a topology change triggered runs over a wire still renegotiating.
+/// The Dell is measured silent on every such pass and answers a frame on the next
+/// quiet one, so a silence there is evidence about the moment, not the panel.
+
+@MainActor
+@Test func aSettlingSilenceIsDiscardedWholeAndNeverLatches() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake)
+  for _ in 0 ..< 4 { await controller.refreshFromHardware(settling: true) }
+  // Not published, and not counted either: the panel is still asked, which is
+  // what makes the discard a discard and not a second skip.
+  #expect(controller.readEvidence == .notAttempted)
+  #expect(await fake.recordedReadCount() == 4)
+}
+
+/// The invariant a reconfiguration used to defeat: one busy-bus miss never brands
+/// a panel. A contended menu-close pass followed by the measured-silent settling
+/// pass published "Not answering" on a panel that answers.
+@MainActor
+@Test func aContendedPassAndASettlingPassAreNotAPair() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware(settling: true)
+  #expect(controller.readEvidence == .notAttempted)
+
+  await fake.setReadResult((current: 50, max: 100))
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+}
+
+/// The discriminator for the test above: two COUNTING silences still publish, so
+/// the discard narrows what latches rather than disabling the latch.
+@MainActor
+@Test func twoCountingSilencesStillPublishAcrossASettlingOne() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware(settling: true)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+}
+
+/// Zeros are the panel's own word about itself and the wire carried them, so a
+/// settling pass publishes them exactly as any other pass does.
+@MainActor
+@Test func aSettlingPassStillPublishesZeros() async {
+  let fake = FakeDDC(readResult: (current: 0, max: 0))
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware(settling: true)
+  #expect(controller.readEvidence == .allZeros)
+}
+
+@MainActor
+@Test func aSettlingPassStillAdoptsAFrame() async {
+  let fake = FakeDDC(readResult: (current: 50, max: 100))
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware(settling: true)
+  #expect(controller.readEvidence == .answered)
+}
+
+/// The same rule at the value registers, where a pass costs `pollingTries`
+/// ladders rather than one.
+@MainActor
+@Test func aSettlingSilenceAtTheValueRegisterIsDiscardedToo() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeValueController(writer: fake)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware(settling: true)
+  #expect(controller.readEvidence == .notAttempted)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+}
+
+// MARK: - The read's staleness fence
+
+/// A writer that runs the test's own code WHILE a read is in flight. Landing a
+/// write between a read being issued and its continuation is the whole scenario,
+/// and nothing else can reach that instant.
+///
+/// `@unchecked Sendable`: the counter and the hook are touched only from calls
+/// the controller makes one at a time, and the test reads them after the await.
+private final class InterleavingDDC: DDCWriting, @unchecked Sendable {
+  private let result: (current: UInt16, max: UInt16)?
+  var duringFirstRead: (@MainActor () -> Void)?
+  private(set) var reads = 0
+
+  init(result: (current: UInt16, max: UInt16)?) { self.result = result }
+
+  func write(command _: UInt8, value _: UInt16) async -> Bool { true }
+
+  func read(command _: UInt8) async -> (current: UInt16, max: UInt16)? {
+    reads += 1
+    if let hook = duringFirstRead {
+      duringFirstRead = nil
+      await MainActor.run { hook() }
+    }
+    return result
+  }
+}
+
+/// The panel's surface fan-out and a key press both submit while a read is on a
+/// wedged bus. The read is then describing the register BEFORE that write, so
+/// adopting it would undo the user's input, in the published value and in the
+/// store.
+@MainActor
+@Test func aWriteIssuedDuringAReadDropsTheRead() async {
+  let fake = InterleavingDDC(result: (current: 20, max: 100))
+  let controller = makeLegacyPathController(writer: fake)
+  controller.setBrightness(0.8)
+  fake.duringFirstRead = { controller.setBrightness(0.6) }
+  await controller.refreshFromHardware()
+  // 0.2 is what the read carried. The write that landed mid-read is newer.
+  #expect(controller.brightness == 0.6)
+  // The panel still answered, and that is a fact about the wire either way.
+  #expect(controller.readEvidence == .answered)
+}
+
+/// The control: with nothing landing mid-read, the same read is adopted.
+@MainActor
+@Test func aReadWithNoWriteBehindItIsAdopted() async {
+  let fake = InterleavingDDC(result: (current: 20, max: 100))
+  let controller = makeLegacyPathController(writer: fake)
+  controller.setBrightness(0.8)
+  await controller.refreshFromHardware()
+  #expect(controller.brightness == 0.2)
+}

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
@@ -1,0 +1,127 @@
+import CoreGraphics
+import Testing
+@testable import CandelaKit
+
+/// A silent panel is asked once per plug, and every route that can make it
+/// answer again clears the verdict that stopped the asking.
+
+@MainActor
+private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> BrightnessController {
+  let defaults = InMemoryDefaults()
+  defaults.set(true, forKey: "disableCombinedBrightness")
+  return BrightnessController(
+    writer: writer,
+    backends: BrightnessBackends(
+      applierNative: NativeBrightnessApplier(displayID: 1) { _, _ in false },
+      hdr: hdr,
+      shade: nil,
+      gamma: nil
+    ),
+    prefs: DisplayPrefs(defaults: defaults, persistenceKey: "hdr-read-skip"),
+    displayID: 1,
+    wireSiblings: []
+  )
+}
+
+/// The control for every count below: a panel that answers is asked on every
+/// pass, so a read counter that stays at 1 is the skip and not a broken fake.
+@MainActor
+@Test func aPanelThatAnswersIsAskedOnEveryPass() async {
+  let fake = FakeDDC(readResult: (current: 50, max: 100))
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  #expect(await fake.recordedReadCount() == 2)
+}
+
+@MainActor
+@Test func aSilentPanelIsAskedOnce() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+  #expect(await fake.recordedReadCount() == 1)
+}
+
+@MainActor
+@Test func aPanelAnsweringZerosIsAskedOnce() async {
+  let fake = FakeDDC(readResult: (current: 0, max: 0))
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .allZeros)
+  #expect(await fake.recordedReadCount() == 1)
+}
+
+@MainActor
+@Test func wakeAsksASilentPanelAgain() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  controller.noteWake()
+  #expect(controller.readEvidence == .notAttempted)
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 2)
+}
+
+/// The replug route. `rebind` compares the panel IDENTITY, which a new cable or
+/// a new port on the same monitor does not change, so a reconfiguration is the
+/// only thing that gives that panel another hearing.
+@MainActor
+@Test func aReconfigurationAsksASilentPanelAgain() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake, panelIdentity: "panel-a")
+  await controller.refreshFromHardware()
+  controller.rebind(writer: fake, panelIdentity: "panel-a")
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 1)
+  await controller.handleReconfigure()
+  #expect(controller.readEvidence == .notAttempted)
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 2)
+}
+
+@MainActor
+@Test func anotherPanelOnTheWireIsAskedForItself() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake, panelIdentity: "panel-a")
+  await controller.refreshFromHardware()
+  controller.rebind(writer: fake, panelIdentity: "panel-b")
+  #expect(controller.readEvidence == .notAttempted)
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 2)
+}
+
+/// A verdict earned while HDR held the register is a fact about the window, not
+/// about the panel, so it must not outlive it.
+@MainActor
+@Test func anHDRWindowClosingAsksASilentPanelAgain() async {
+  let fake = FakeDDC(readResult: nil)
+  let hdr = FakeHDR(supports: true, enabled: false)
+  let controller = makeHDRController(writer: fake, hdr: hdr)
+  await controller.initialHDRRefresh?.value
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+
+  // HDR engaged outside the app, discovered on the next observation: the fake's
+  // own cache catches up first, the way the real backend's ~2 s cache does.
+  await hdr.stubEnabled(true)
+  _ = await hdr.measuredHDREnabled(displayID: 1)
+  await controller.noteHDRStateMayHaveChanged()
+  #expect(controller.isHDREngaged)
+  // Entering is a window opening: nothing earned through it exists yet, and the
+  // native path is what skips the read here.
+  #expect(controller.readEvidence == .noReply)
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 1)
+
+  await hdr.stubEnabled(false)
+  _ = await hdr.measuredHDREnabled(displayID: 1)
+  await controller.noteHDRStateMayHaveChanged()
+  #expect(controller.readEvidence == .notAttempted)
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 2)
+}

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
@@ -2,8 +2,11 @@ import CoreGraphics
 import Testing
 @testable import CandelaKit
 
-/// A silent panel is asked once per plug, and every route that can make it
-/// answer again clears the verdict that stopped the asking.
+/// A panel that says nothing TWICE RUNNING is asked once per plug, and every
+/// route that can make it answer again clears the verdict that stopped the
+/// asking. One bad pass is not a verdict: bus contention, the probe holding the
+/// wire and another panel entering HDR all produce one, on displays that answer
+/// perfectly on the next pass.
 
 @MainActor
 private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> BrightnessController {
@@ -23,37 +26,102 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   )
 }
 
+// MARK: - The latch itself
+
+@Test func oneSilentPassDoesNotLatchTheSkip() {
+  var latch = DDCReadSkipLatch()
+  latch.record(.noReply)
+  #expect(!latch.skipsRead)
+  latch.record(.allZeros)
+  #expect(latch.skipsRead)
+}
+
+/// Consecutive, not cumulative: a panel that answered between two bad passes has
+/// proved the wire works, and the count starts again.
+@Test func anAnswerBetweenTwoSilentPassesResetsTheCount() {
+  var latch = DDCReadSkipLatch()
+  latch.record(.noReply)
+  latch.record(.answered)
+  latch.record(.noReply)
+  #expect(!latch.skipsRead)
+}
+
+/// A pass that never reached the wire has learned nothing either way, so it
+/// neither counts towards the latch nor clears it.
+@Test func aPassThatAttemptedNothingLeavesTheCountAlone() {
+  var latch = DDCReadSkipLatch()
+  latch.record(.noReply)
+  latch.record(.notAttempted)
+  #expect(!latch.skipsRead)
+  latch.record(.noReply)
+  #expect(latch.skipsRead)
+  latch.record(.notAttempted)
+  #expect(latch.skipsRead)
+  latch.clear()
+  #expect(!latch.skipsRead)
+}
+
+// MARK: - The brightness read
+
 /// The control for every count below: a panel that answers is asked on every
-/// pass, so a read counter that stays at 1 is the skip and not a broken fake.
+/// pass, so a read counter that stops rising is the skip and not a broken fake.
 @MainActor
 @Test func aPanelThatAnswersIsAskedOnEveryPass() async {
   let fake = FakeDDC(readResult: (current: 50, max: 100))
   let controller = makeLegacyPathController(writer: fake)
   await controller.refreshFromHardware()
   await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
   #expect(controller.readEvidence == .answered)
+  #expect(await fake.recordedReadCount() == 3)
+}
+
+@MainActor
+@Test func aSilentPanelIsAskedTwiceAndThenNotAgain() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  // The verdict is published from the FIRST pass: diagnostics reports what the
+  // wire proved, and only the asking waits for a second silent pass.
+  #expect(controller.readEvidence == .noReply)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
   #expect(await fake.recordedReadCount() == 2)
 }
 
 @MainActor
-@Test func aSilentPanelIsAskedOnce() async {
-  let fake = FakeDDC(readResult: nil)
-  let controller = makeLegacyPathController(writer: fake)
-  await controller.refreshFromHardware()
-  await controller.refreshFromHardware()
-  await controller.refreshFromHardware()
-  #expect(controller.readEvidence == .noReply)
-  #expect(await fake.recordedReadCount() == 1)
-}
-
-@MainActor
-@Test func aPanelAnsweringZerosIsAskedOnce() async {
+@Test func aPanelAnsweringZerosIsAskedTwiceAndThenNotAgain() async {
   let fake = FakeDDC(readResult: (current: 0, max: 0))
   let controller = makeLegacyPathController(writer: fake)
   await controller.refreshFromHardware()
   await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
   #expect(controller.readEvidence == .allZeros)
-  #expect(await fake.recordedReadCount() == 1)
+  #expect(await fake.recordedReadCount() == 2)
+}
+
+/// The defect the two-pass rule exists for. One transient silence on a panel
+/// that answers used to publish "does not answer reads" for the rest of the
+/// plug.
+@MainActor
+@Test func oneSilentPassSelfCorrectsOnTheNextOne() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeLegacyPathController(writer: fake)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+
+  await fake.setReadResult((current: 50, max: 100))
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  #expect(await fake.recordedReadCount() == 2)
+
+  // And the answer put the count back to zero, so the next bad pass is a first
+  // one again rather than the second of a pair.
+  await fake.setReadResult(nil)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 4)
 }
 
 @MainActor
@@ -61,10 +129,11 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   let fake = FakeDDC(readResult: nil)
   let controller = makeLegacyPathController(writer: fake)
   await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
   controller.noteWake()
   #expect(controller.readEvidence == .notAttempted)
   await controller.refreshFromHardware()
-  #expect(await fake.recordedReadCount() == 2)
+  #expect(await fake.recordedReadCount() == 3)
 }
 
 /// The replug route. `rebind` compares the panel IDENTITY, which a new cable or
@@ -75,13 +144,14 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   let fake = FakeDDC(readResult: nil)
   let controller = makeLegacyPathController(writer: fake, panelIdentity: "panel-a")
   await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
   controller.rebind(writer: fake, panelIdentity: "panel-a")
   await controller.refreshFromHardware()
-  #expect(await fake.recordedReadCount() == 1)
+  #expect(await fake.recordedReadCount() == 2)
   await controller.handleReconfigure()
   #expect(controller.readEvidence == .notAttempted)
   await controller.refreshFromHardware()
-  #expect(await fake.recordedReadCount() == 2)
+  #expect(await fake.recordedReadCount() == 3)
 }
 
 @MainActor
@@ -89,20 +159,25 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   let fake = FakeDDC(readResult: nil)
   let controller = makeLegacyPathController(writer: fake, panelIdentity: "panel-a")
   await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
   controller.rebind(writer: fake, panelIdentity: "panel-b")
   #expect(controller.readEvidence == .notAttempted)
   await controller.refreshFromHardware()
-  #expect(await fake.recordedReadCount() == 2)
+  #expect(await fake.recordedReadCount() == 3)
 }
 
 /// A verdict earned while HDR held the register is a fact about the window, not
-/// about the panel, so it must not outlive it.
+/// about the panel, so it must not outlive it. It must also not be WIPED while
+/// the window is still open: no read follows under the native path, so a clear
+/// there would replace a real write-only verdict with silence in the diagnostics
+/// report and nothing would put it back until HDR ends.
 @MainActor
 @Test func anHDRWindowClosingAsksASilentPanelAgain() async {
   let fake = FakeDDC(readResult: nil)
   let hdr = FakeHDR(supports: true, enabled: false)
   let controller = makeHDRController(writer: fake, hdr: hdr)
   await controller.initialHDRRefresh?.value
+  await controller.refreshFromHardware()
   await controller.refreshFromHardware()
   #expect(controller.readEvidence == .noReply)
 
@@ -116,12 +191,117 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
   // native path is what skips the read here.
   #expect(controller.readEvidence == .noReply)
   await controller.refreshFromHardware()
-  #expect(await fake.recordedReadCount() == 1)
+  #expect(await fake.recordedReadCount() == 2)
+
+  // A reconfiguration inside the window keeps the verdict, for the reason above.
+  await controller.handleReconfigure()
+  #expect(controller.readEvidence == .noReply)
 
   await hdr.stubEnabled(false)
   _ = await hdr.measuredHDREnabled(displayID: 1)
   await controller.noteHDRStateMayHaveChanged()
   #expect(controller.readEvidence == .notAttempted)
   await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 3)
+}
+
+// MARK: - The volume and contrast reads
+
+@MainActor
+private func makeValueController(
+  writer: any DDCWriting, panelIdentity: String? = nil
+) -> DDCValueController {
+  let defaults = InMemoryDefaults()
+  let prefs = DisplayPrefs(defaults: defaults, persistenceKey: "value-read-skip")
+  prefs.startupAction = .read
+  // One transaction per pass, so the counts below are passes and nothing else.
+  prefs.pollingMode = .minimal
+  return DDCValueController(
+    writer: writer, command: .volume, prefs: prefs, panelIdentity: panelIdentity
+  )
+}
+
+/// The cost this skip is about: five transactions a pass by default and twenty
+/// on heavy, against the brightness read's one.
+@MainActor
+@Test func aSilentValueRegisterIsAskedTwiceAndThenNotAgain() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeValueController(writer: fake)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .noReply)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
   #expect(await fake.recordedReadCount() == 2)
+}
+
+@MainActor
+@Test func aValueRegisterThatAnswersIsAskedOnEveryPass() async {
+  let fake = FakeDDC(readResult: (current: 50, max: 100))
+  let controller = makeValueController(writer: fake)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  #expect(await fake.recordedReadCount() == 3)
+}
+
+@MainActor
+@Test func oneSilentValuePassSelfCorrectsOnTheNextOne() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeValueController(writer: fake)
+  await controller.refreshFromHardware()
+  await fake.setReadResult((current: 50, max: 100))
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  #expect(await fake.recordedReadCount() == 2)
+}
+
+@MainActor
+@Test func rebindingAValueControllerOntoAnotherPanelAsksItAgain() async {
+  let fake = FakeDDC(readResult: nil)
+  let controller = makeValueController(writer: fake, panelIdentity: "panel-a")
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  controller.rebind(writer: fake, panelIdentity: "panel-b")
+  #expect(controller.readEvidence == .notAttempted)
+  await controller.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 3)
+}
+
+/// Wake, reconfiguration and the HDR-off edge all reach the value controllers
+/// through the display's brightness controller: the three share one wire, and
+/// only the brightness controller can see the HDR window that locked it.
+@MainActor
+@Test func theWiresWakeAndReconfigurationReachTheValueControllers() async {
+  let fake = FakeDDC(readResult: nil)
+  let volume = makeValueController(writer: fake)
+  let defaults = InMemoryDefaults()
+  defaults.set(true, forKey: "disableCombinedBrightness")
+  let brightness = BrightnessController(
+    writer: fake,
+    backends: BrightnessBackends(
+      applierNative: NativeBrightnessApplier(displayID: 1) { _, _ in false },
+      hdr: nil, shade: nil, gamma: nil
+    ),
+    prefs: DisplayPrefs(defaults: defaults, persistenceKey: "wire-siblings"),
+    displayID: 1,
+    wireSiblings: [volume]
+  )
+
+  await volume.refreshFromHardware()
+  await volume.refreshFromHardware()
+  await volume.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 2)
+
+  brightness.noteWake()
+  #expect(volume.readEvidence == .notAttempted)
+  await volume.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 3)
+
+  await volume.refreshFromHardware()
+  await volume.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 4)
+  await brightness.handleReconfigure()
+  await volume.refreshFromHardware()
+  #expect(await fake.recordedReadCount() == 5)
 }

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
@@ -77,12 +77,35 @@ private func makeHDRController(writer: any DDCWriting, hdr: FakeHDR) -> Brightne
 }
 
 /// A zeros reply is the panel's own word about itself, so it never waits for a
-/// second pass the way a silence does, and neither does a frame.
+/// second pass the way a silence does, and neither does a frame or a refusal.
 @Test func anAnswerPublishesOnItsFirstPass() {
   var zeros = DDCReadSkipLatch()
   #expect(zeros.record(.allZeros) == true)
   var frames = DDCReadSkipLatch()
   #expect(frames.record(.answered) == true)
+  var refusals = DDCReadSkipLatch()
+  #expect(refusals.record(.refused) == true)
+}
+
+/// A refused register is the panel's settled word, so re-asking it every pass
+/// spends the wire on a question already answered: it counts toward the skip on
+/// the same two-pass rule as the other findings. The Dell's VCP 0x62 is this
+/// case, and the value controller pays `pollingTries` transactions per pass for it.
+@Test func twoRefusedPassesLatchTheSkip() {
+  var latch = DDCReadSkipLatch()
+  latch.record(.refused)
+  #expect(!latch.skipsRead)
+  latch.record(.refused)
+  #expect(latch.skipsRead)
+}
+
+/// And a refusal is its own run, like zeros: one refusal beside one silence is a
+/// contended wire rather than a settled verdict.
+@Test func aRefusedPassAndASilentPassAreNotAPair() {
+  var latch = DDCReadSkipLatch()
+  latch.record(.refused)
+  #expect(latch.record(.noReply) == false)
+  #expect(!latch.skipsRead)
 }
 
 /// A pass that never reached the wire proved nothing, so it publishes nothing.
@@ -630,4 +653,20 @@ private final class InterleavingDDC: DDCWriting, @unchecked Sendable {
   controller.setBrightness(0.8)
   await controller.refreshFromHardware()
   #expect(controller.brightness == 0.2)
+}
+
+/// What the fence drops is the VALUE. The panel's own maximum is a fact about
+/// the hardware rather than about anyone's intent, so a key press landing
+/// mid-read must not take it down with the reading: dropped, every later write
+/// scales against the assumed 100 until some other pass happens to answer, and
+/// the provenance flag says "assumed" about a number the panel reported.
+@MainActor
+@Test func aWriteIssuedDuringAReadStillKeepsThePanelsScale() async {
+  let fake = InterleavingDDC(result: (current: 60, max: 120))
+  let controller = makeLegacyPathController(writer: fake)
+  fake.duringFirstRead = { controller.setBrightness(0.6) }
+  await controller.refreshFromHardware()
+  #expect(controller.brightness == 0.6, "the write is the newer intent")
+  #expect(controller.maxDDCValue == 120)
+  #expect(controller.didReadMaxDDC)
 }

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessReadSkipTests.swift
@@ -670,3 +670,193 @@ private final class InterleavingDDC: DDCWriting, @unchecked Sendable {
   #expect(controller.maxDDCValue == 120)
   #expect(controller.didReadMaxDDC)
 }
+
+// MARK: - Remapped read registers
+
+private actor RemappedRegisterDDC: DDCWriting {
+  private(set) var commandsRead: [UInt8] = []
+  private var outcomes: [UInt8: DDCReadOutcome] = [:]
+  private var duringNextRead: (@MainActor @Sendable () async -> Void)?
+
+  func setOutcome(_ outcome: DDCReadOutcome, for code: UInt8) { outcomes[code] = outcome }
+  func onNextRead(_ hook: @escaping @MainActor @Sendable () async -> Void) {
+    duringNextRead = hook
+  }
+  func write(command _: UInt8, value _: UInt16) async -> Bool { true }
+  func read(command: UInt8) async -> (current: UInt16, max: UInt16)? {
+    await readOutcome(command: command).value
+  }
+  func readOutcome(command: UInt8) async -> DDCReadOutcome {
+    commandsRead.append(command)
+    let outcome = outcomes[command] ?? .refused
+    let hook = duringNextRead
+    duringNextRead = nil
+    await hook?()
+    return outcome
+  }
+}
+
+@MainActor
+private func remap(_ prefs: DisplayPrefs, command: DDCCommand, codes: [UInt8]) {
+  var tuning = prefs.tuning(for: command)
+  tuning.remapCodes = codes
+  prefs.setTuning(tuning, for: command)
+}
+
+@MainActor
+private func makeRemapBrightnessController(
+  writer: any DDCWriting, prefs: DisplayPrefs
+) -> BrightnessController {
+  BrightnessController(
+    writer: writer,
+    backends: BrightnessBackends(
+      applierNative: NativeBrightnessApplier(displayID: 1) { _, _ in false },
+      hdr: nil, shade: nil, gamma: nil
+    ),
+    prefs: prefs, displayID: 1, panelIdentity: "remap-panel", wireSiblings: []
+  )
+}
+
+@MainActor
+@Test func brightnessRemapRetriesAfterThePreviousRegisterWasRefused() async {
+  let defaults = InMemoryDefaults()
+  defaults.set(true, forKey: "disableCombinedBrightness")
+  let prefs = DisplayPrefs(defaults: defaults, persistenceKey: "brightness-remap")
+  let wire = RemappedRegisterDDC()
+  let controller = makeRemapBrightnessController(writer: wire, prefs: prefs)
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .refused)
+  #expect(await wire.commandsRead == [0x10, 0x10])
+
+  // Settings commits reapply dimming; the next menu refresh reuses the panel.
+  remap(prefs, command: .brightness, codes: [0x12])
+  await wire.setOutcome(.frame(current: 40, max: 80), for: 0x12)
+  controller.reapplyAfterPrefChange()
+  await controller.waitForPendingWrites()
+  controller.rebind(writer: wire, panelIdentity: "remap-panel")
+  await controller.refreshFromHardware()
+  #expect(await wire.commandsRead == [0x10, 0x10, 0x12])
+  #expect(controller.readEvidence == .answered)
+  #expect(controller.didReadMaxDDC)
+  #expect(controller.maxDDCValue == 80)
+  #expect(controller.brightness == 0.5)
+
+  // Returning to the default register also starts a fresh run and scale.
+  remap(prefs, command: .brightness, codes: [])
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .refused)
+  #expect(!controller.didReadMaxDDC)
+  #expect(controller.maxDDCValue == 100)
+  await controller.refreshFromHardware()
+  #expect(await wire.commandsRead == [0x10, 0x10, 0x12, 0x10, 0x10])
+
+  // A trailing write code and an unrelated preference do not change the read.
+  remap(prefs, command: .brightness, codes: [0x10, 0x13])
+  prefs.pollingMode = .heavy
+  controller.reapplyAfterPrefChange()
+  await controller.waitForPendingWrites()
+  await controller.refreshFromHardware()
+  #expect(await wire.commandsRead == [0x10, 0x10, 0x12, 0x10, 0x10])
+}
+
+@MainActor
+@Test(arguments: [DDCCommand.volume, DDCCommand.contrast])
+func valueRemapRetriesAfterThePreviousRegisterWasRefused(command: DDCCommand) async {
+  let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "value-remap")
+  prefs.startupAction = .read
+  prefs.pollingMode = .minimal
+  remap(prefs, command: command, codes: [0x11])
+  let wire = RemappedRegisterDDC()
+  let controller = DDCValueController(
+    writer: wire, command: command, prefs: prefs, panelIdentity: "remap-panel"
+  )
+  await controller.refreshFromHardware()
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .refused)
+
+  remap(prefs, command: command, codes: [0x12])
+  await wire.setOutcome(.frame(current: 40, max: 80), for: 0x12)
+  controller.rebind(writer: wire, panelIdentity: "remap-panel")
+  await controller.refreshFromHardware()
+  #expect(await wire.commandsRead.contains(0x12))
+  #expect(controller.readEvidence == .answered)
+  #expect(controller.readMax == 80)
+  #expect(controller.value == 0.5)
+
+  remap(prefs, command: command, codes: [0x11])
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .refused)
+  #expect(controller.readMax == nil)
+  await controller.refreshFromHardware()
+  #expect(await wire.commandsRead.filter { $0 == 0x11 }.count == 4)
+  remap(prefs, command: command, codes: [0x11, 0x13])
+  prefs.pollingMode = .heavy
+  await controller.refreshFromHardware()
+  #expect(await wire.commandsRead.filter { $0 == 0x11 }.count == 4)
+
+  remap(prefs, command: command, codes: [])
+  await wire.setOutcome(.frame(current: 30, max: 60), for: command.code)
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .answered)
+  #expect(controller.readMax == 60)
+  #expect(controller.value == 0.5)
+}
+
+@MainActor
+@Test(arguments: [false, true])
+func brightnessRemapDropsAnOldRegistersInFlightAnswer(returnToOriginalCode: Bool) async {
+  let defaults = InMemoryDefaults()
+  defaults.set(true, forKey: "disableCombinedBrightness")
+  let prefs = DisplayPrefs(defaults: defaults, persistenceKey: "brightness-remap-flight")
+  let wire = RemappedRegisterDDC()
+  let controller = makeRemapBrightnessController(writer: wire, prefs: prefs)
+  await wire.setOutcome(.frame(current: 60, max: 120), for: 0x10)
+  await wire.onNextRead {
+    remap(prefs, command: .brightness, codes: [0x12])
+    await controller.refreshFromHardware()
+    if returnToOriginalCode {
+      remap(prefs, command: .brightness, codes: [])
+      await wire.setOutcome(.refused, for: 0x10)
+    }
+    await controller.refreshFromHardware()
+    await controller.refreshFromHardware()
+  }
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .refused)
+  #expect(controller.maxDDCValue == 100)
+  #expect(!controller.didReadMaxDDC)
+  await controller.refreshFromHardware()
+  #expect(await wire.commandsRead == (returnToOriginalCode
+    ? [0x10, 0x12, 0x10, 0x10] : [0x10, 0x12, 0x12]))
+}
+
+@MainActor
+@Test(arguments: [DDCCommand.volume, DDCCommand.contrast], [false, true])
+func valueRemapDropsAnOldRegistersInFlightAnswer(
+  command: DDCCommand, returnToOriginalCode: Bool
+) async {
+  let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "value-remap-flight")
+  prefs.startupAction = .read
+  prefs.pollingMode = .minimal
+  let wire = RemappedRegisterDDC()
+  let controller = DDCValueController(writer: wire, command: command, prefs: prefs)
+  await wire.setOutcome(.frame(current: 60, max: 120), for: command.code)
+  await wire.onNextRead {
+    remap(prefs, command: command, codes: [0x11])
+    await controller.refreshFromHardware()
+    if returnToOriginalCode {
+      remap(prefs, command: command, codes: [])
+      await wire.setOutcome(.refused, for: command.code)
+    }
+    await controller.refreshFromHardware()
+    await controller.refreshFromHardware()
+  }
+  await controller.refreshFromHardware()
+  #expect(controller.readEvidence == .refused)
+  #expect(controller.readMax == nil)
+  let readsBeforeRefresh = await wire.commandsRead
+  await controller.refreshFromHardware()
+  let valueReads = await wire.commandsRead.filter { $0 != VCP.audioMuteScreenBlank }
+  #expect(valueReads == readsBeforeRefresh.filter { $0 != VCP.audioMuteScreenBlank })
+}

--- a/CandelaKit/Tests/CandelaKitTests/CheckupLiveRunnersTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CheckupLiveRunnersTests.swift
@@ -87,6 +87,9 @@ struct CheckupLiveRunnersTests {
     var modeList: [DisplayMode]
     var current: DisplayMode?
     var refuse: Set<Int32> = []
+    /// Mode id to the mode the display is left on: a commit that went through
+    /// and was not honoured, which is not the same event as a refusal.
+    var unhonour: [Int32: DisplayMode] = [:]
 
     func displays() -> [ConfiguredDisplay] { [] }
     func modes(for displayID: CGDirectDisplayID) -> [DisplayMode] { modeList }
@@ -95,6 +98,9 @@ struct CheckupLiveRunnersTests {
       modeList.first(where: \.isNative).map { ($0.pixelWidth, $0.pixelHeight) }
     }
     func apply(_ mode: DisplayMode, to displayID: CGDirectDisplayID, scope: DisplayConfigScope) throws {
+      if let landed = unhonour[mode.ioModeID] {
+        throw DisplayConfigError(unhonouredCommit: .init(requested: mode, achieved: landed))
+      }
       if refuse.contains(mode.ioModeID) {
         throw DisplayConfigError(cgErrorCode: CGError.invalidOperation.rawValue)
       }
@@ -123,6 +129,41 @@ struct CheckupLiveRunnersTests {
     let refusing = FakeConfigurator(modeList: [native], current: native, refuse: [1])
     let refused = await CheckupLiveModeRunner(configurator: refusing, displayID: 1).runNativeMode()
     #expect(refused.first?.verdict.kind == "refused")
+    #expect(refused.first?.verdict.text.contains("apply refused") == true)
+  }
+
+  /// An unhonoured commit is not a refusal (nothing said no), and the achieved
+  /// geometry is the finding, so no error code replaces it.
+  @Test func anUnhonouredCommitNamesWhatTheDisplayShowsRatherThanARefusal() async {
+    let native = mode(1, w: 3840, h: 2160, hz: 60, native: true)
+    let landed = mode(2, w: 1920, h: 1080, hz: 60)
+    let diverging = FakeConfigurator(
+      modeList: [native], current: landed, unhonour: [1: landed])
+    let claims = await CheckupLiveModeRunner(configurator: diverging, displayID: 1).runNativeMode()
+    // The KIND carries as much as the sentence: the report prints it as the
+    // row's label, so a refused kind reads "refused" whatever the text says.
+    #expect(claims.first?.verdict.kind == "notObserved")
+    let text = claims.first?.verdict.text ?? ""
+    #expect(!text.contains("refused"))
+    #expect(text.contains("applied 3840 by 2160 at 60 Hz"))
+    #expect(text.contains("macOS reports 1920 by 1080 at 60 Hz"))
+  }
+
+  /// The rate-only sweep is where an unhonoured commit is invisible on screen,
+  /// so its claim keeps the rate it asked for AND the one it got.
+  @Test func theRefreshSweepKeepsBothRatesWhenACommitIsNotHonoured() async {
+    let m60 = mode(1, w: 3840, h: 2160, hz: 60, native: true)
+    let m120 = mode(2, w: 3840, h: 2160, hz: 120)
+    let diverging = FakeConfigurator(
+      modeList: [m60, m120], current: m60, unhonour: [2: m60])
+    let claims = await CheckupLiveModeRunner(configurator: diverging, displayID: 1)
+      .runRefreshSweep()
+    let claim = claims.first { $0.verdict.text.hasPrefix("120 Hz") }
+    #expect(claim?.verdict.kind == "notObserved")
+    let text = claim?.verdict.text ?? ""
+    #expect(!text.contains("refused"))
+    #expect(text.contains("applied 3840 by 2160 at 120 Hz"))
+    #expect(text.contains("macOS reports 3840 by 2160 at 60 Hz"))
   }
 
   @Test func everyApplyIsPreviewScopedSoACrashDoesNotParkThePanel() async {

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
@@ -82,8 +82,12 @@ struct BrightnessReadEvidenceCallSiteTests {
     #expect(controller.readEvidence == .allZeros)
   }
 
-  @Test func asilentBusIsPublishedAsNoReply() async {
+  /// Two passes, unlike the zeros answer above: silence publishes only once it
+  /// has happened twice running. `BrightnessReadSkipTests` pins the rule.
+  @Test func asilentBusIsPublishedAsNoReplyOnTheSecondPass() async {
     let (controller, _) = Self.make(writer: FakeDDC(readResult: nil))
+    await controller.refreshFromHardware()
+    #expect(controller.readEvidence == .notAttempted)
     await controller.refreshFromHardware()
     #expect(controller.readEvidence == .noReply)
   }

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
@@ -109,6 +109,11 @@ struct BrightnessReadEvidenceCallSiteTests {
 
   /// The other half, and the one a monotonic fold got wrong: a pass that does ask
   /// supersedes, or the app says "answers with zeros" about a panel that just answered.
+  ///
+  /// What makes a pass ask has changed: a panel that answered nothing is asked
+  /// once per plug, so the wake here is not decoration, it is the thing that
+  /// earns the second question. `BrightnessReadSkipTests` pins the skip and
+  /// every route out of it.
   @Test func apassThatAsksAgainSupersedesTheOldVerdict() async {
     let fake = FakeDDC(readResult: (current: 0, max: 0))
     let (controller, _) = Self.make(writer: fake)
@@ -116,6 +121,7 @@ struct BrightnessReadEvidenceCallSiteTests {
     #expect(controller.readEvidence == .allZeros)
 
     await fake.setReadResult((current: 40, max: 80))
+    controller.noteWake()
     await controller.refreshFromHardware()
     #expect(controller.readEvidence == .answered)
   }

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
@@ -114,10 +114,11 @@ struct BrightnessReadEvidenceCallSiteTests {
   /// The other half, and the one a monotonic fold got wrong: a pass that does ask
   /// supersedes, or the app says "answers with zeros" about a panel that just answered.
   ///
-  /// What makes a pass ask has changed: a panel that answered nothing is asked
-  /// once per plug, so the wake here is not decoration, it is the thing that
-  /// earns the second question. `BrightnessReadSkipTests` pins the skip and
-  /// every route out of it.
+  /// Nothing has to earn the second question here: the skip latches on the
+  /// SECOND non-answer of a kind, so one zeros pass leaves the next one asking.
+  /// A wake was called here for a while, which read as the thing that unlocked
+  /// the re-ask and is not. `BrightnessReadSkipTests` pins the latch and every
+  /// route out of it, the wake included.
   @Test func apassThatAsksAgainSupersedesTheOldVerdict() async {
     let fake = FakeDDC(readResult: (current: 0, max: 0))
     let (controller, _) = Self.make(writer: fake)
@@ -125,7 +126,6 @@ struct BrightnessReadEvidenceCallSiteTests {
     #expect(controller.readEvidence == .allZeros)
 
     await fake.setReadResult((current: 40, max: 80))
-    controller.noteWake()
     await controller.refreshFromHardware()
     #expect(controller.readEvidence == .answered)
   }

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
@@ -304,6 +304,47 @@ struct RefusedRegisterEvidenceTests {
     #expect(await writer.reads(of: VCP.audioSpeakerVolume) == 1)
   }
 
+  /// The other half of that exit: ending the pass must not ERASE what an earlier
+  /// try heard. Zeros outrank a refusal in the transport's fold and in the
+  /// evidence ordering above, being the more specific finding about the register:
+  /// a panel that put zeros on the bus said something about every code. Assigning
+  /// the refusal over them left this suite green and contradicted both.
+  @Test func arefusalDoesNotEraseAZerosAnswerFromEarlierInThePass() async {
+    let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "refused-after-zeros")
+    prefs.startupAction = .read
+    let writer = RefusingDDC([.allZeros, .refused])
+    let volume = DDCValueController(writer: writer, command: .volume, prefs: prefs)
+
+    await volume.refreshFromHardware()
+    #expect(volume.readEvidence == .allZeros)
+    #expect(await writer.reads(of: VCP.audioSpeakerVolume) == 2, "control: both tries ran")
+  }
+
+  /// The direction the pass fold runs. A refusal supersedes a silence heard
+  /// earlier in the same pass, which is the transport's own ordering: the panel
+  /// answering "not this register" is a more specific observation than a busy
+  /// wire. `DDCReadEvidence.worse` ranks it the other way, for the fold ACROSS
+  /// controllers, where a refused register must never speak for a display; using
+  /// that ordering inside the pass published `.noReply` off one contended try
+  /// and closed the latch on a finding the panel never gave.
+  @Test func arefusalSupersedesASilenceHeardEarlierInThePass() async {
+    let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "refused-after-silence")
+    prefs.startupAction = .read
+    let writer = RefusingDDC([.noReply, .refused])
+    let volume = DDCValueController(writer: writer, command: .volume, prefs: prefs)
+
+    await volume.refreshFromHardware()
+    #expect(volume.readEvidence == .refused, "it publishes on its first pass, as a refusal does")
+    await volume.refreshFromHardware()
+    #expect(volume.readEvidence == .refused)
+
+    // And the latch closed on the refusal, not on a silence run the contended
+    // try invented: two passes of the same finding stop the register being asked.
+    let afterTwoPasses = await writer.reads(of: VCP.audioSpeakerVolume)
+    await volume.refreshFromHardware()
+    #expect(await writer.reads(of: VCP.audioSpeakerVolume) == afterTwoPasses)
+  }
+
   /// And it latches on the same two-pass rule as the other findings, so the
   /// register is not re-asked for the life of the plug. Without this the Dell
   /// spends `pollingTries` transactions on VCP 0x62 on every pass, forever.

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadEvidenceTests.swift
@@ -31,10 +31,36 @@ struct DDCReadEvidenceTests {
     #expect(DDCReadEvidence.worst([.allZeros, .notAttempted, .notAttempted]) == .allZeros)
   }
 
-  /// "No reply" and "answered with zeros" are different facts about a panel, and only
-  /// the second is the write-only signature.
-  @Test func noReplyAndAllZerosAreNotTheSameFact() {
-    #expect(DDCReadEvidence.noReply != DDCReadEvidence.allZeros)
+  /// The Dell: brightness and contrast answer, and the volume register is refused
+  /// because the panel carries no VCP 0x62. The display answers reads and the fold
+  /// has to say so; ranking a refusal as a non-answer published "Not answering"
+  /// about a panel that had just answered twice.
+  @Test func arefusedRegisterLeavesAnAnsweringDisplayAnswering() {
+    #expect(DDCReadEvidence.worst([.refused, .answered, .answered]) == .answered)
+    #expect(DDCReadEvidence.worse(.refused, .answered) == .answered)
+    #expect(DDCReadEvidence.worse(.answered, .refused) == .answered)
+  }
+
+  /// It is still a finding, though: above the floor, so a display that refused
+  /// something does not read as one nothing has been asked of, and below both
+  /// silences, which is what keeps it out of the "not answering" verdict.
+  @Test func arefusalOutranksTheFloorAndNeitherSilence() {
+    #expect(DDCReadEvidence.worse(.refused, .notAttempted) == .refused)
+    #expect(DDCReadEvidence.worse(.notAttempted, .refused) == .refused)
+    #expect(DDCReadEvidence.worse(.refused, .noReply) == .noReply)
+    #expect(DDCReadEvidence.worse(.refused, .allZeros) == .allZeros)
+  }
+
+  /// "No reply", "answered with zeros" and "refused the code" are three different
+  /// facts about a panel: only the second is the write-only signature, and only
+  /// the third is the panel replying. Asserted through the copy, because three
+  /// enum cases in a `Set` are distinct whatever the code does, and a check that
+  /// cannot fail is not a check. Collapse an arm of `readEvidence` and this goes
+  /// red.
+  @Test func theThreeValuelessFindingsAreNotTheSameFact() {
+    let sentences = [DDCReadEvidence.noReply, .allZeros, .refused]
+      .map { DiagnosticsCopy.readEvidence($0, app: "Candela") }
+    #expect(Set(sentences).count == 3)
   }
 }
 
@@ -212,5 +238,124 @@ struct MaxDDCProvenanceTests {
     await controller.refreshFromHardware()
     #expect(controller.didReadMaxDDC == true)
     #expect(controller.maxDDCValue == 80)
+  }
+}
+
+/// A panel that answers the read with its own result code: the Dell does this
+/// for VCP 0x62, which it does not carry. Counted per command, because the pin
+/// is that the refused register stops being asked while its siblings do not.
+///
+/// `outcomes` scripts the tries within one pass, the last entry repeating, so a
+/// refusal can be followed by the contended silence the pass fold used to lose
+/// it to. Default: every try refuses.
+///
+/// `@unchecked Sendable` is not needed: an actor confines the state, and the
+/// controller awaits every call.
+private actor RefusingDDC: DDCWriting {
+  private var readsByCommand: [UInt8: Int] = [:]
+  private var outcomes: [DDCReadOutcome]
+
+  init(_ outcomes: [DDCReadOutcome] = [.refused]) { self.outcomes = outcomes }
+
+  func write(command _: UInt8, value _: UInt16) async -> Bool { true }
+
+  func read(command: UInt8) async -> (current: UInt16, max: UInt16)? {
+    await readOutcome(command: command).value
+  }
+
+  func readOutcome(command: UInt8) async -> DDCReadOutcome {
+    readsByCommand[command, default: 0] += 1
+    return outcomes.count > 1 ? outcomes.removeFirst() : (outcomes.first ?? .refused)
+  }
+
+  func reads(of command: UInt8) -> Int { readsByCommand[command, default: 0] }
+}
+
+/// The configuration the round this fix came from is about: the Dell under "Ask
+/// the display", whose volume register answers a refusal on every try.
+@Suite("Read evidence for a refused register")
+@MainActor
+struct RefusedRegisterEvidenceTests {
+  /// It publishes on the FIRST pass, unlike a silence: the panel's own result
+  /// code is not a busy wire, so nothing is gained by waiting for a second.
+  @Test func arefusedVolumeRegisterPublishesOnItsFirstPass() async {
+    let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "refused-volume")
+    prefs.startupAction = .read
+    let volume = DDCValueController(writer: RefusingDDC(), command: .volume, prefs: prefs)
+
+    await volume.refreshFromHardware()
+    #expect(volume.readEvidence == .refused)
+  }
+
+  /// A refusal ends the pass on the try that carried it, so one contended try
+  /// behind it cannot speak for the pass. Worst-wins ranks a silence above a
+  /// refusal, so without the early exit this pass folded to `.noReply` and two of
+  /// them published "Not answering" about a display that replied every time. The
+  /// exit is also what stops a refused register costing `pollingTries`
+  /// transactions a pass.
+  @Test func arefusalEndsThePassOnTheTryThatCarriedIt() async {
+    let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "refused-pass")
+    prefs.startupAction = .read
+    let writer = RefusingDDC([.refused, .noReply])
+    let volume = DDCValueController(writer: writer, command: .volume, prefs: prefs)
+
+    await volume.refreshFromHardware()
+    #expect(volume.readEvidence == .refused)
+    #expect(await writer.reads(of: VCP.audioSpeakerVolume) == 1)
+  }
+
+  /// And it latches on the same two-pass rule as the other findings, so the
+  /// register is not re-asked for the life of the plug. Without this the Dell
+  /// spends `pollingTries` transactions on VCP 0x62 on every pass, forever.
+  @Test func arefusedVolumeRegisterStopsBeingAskedAfterTwoPasses() async {
+    let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "refused-latch")
+    prefs.startupAction = .read
+    let writer = RefusingDDC()
+    let volume = DDCValueController(writer: writer, command: .volume, prefs: prefs)
+
+    await volume.refreshFromHardware()
+    await volume.refreshFromHardware()
+    let afterLatching = await writer.reads(of: VCP.audioSpeakerVolume)
+    #expect(afterLatching > 0, "control: the register was asked at all")
+
+    await volume.refreshFromHardware()
+    #expect(await writer.reads(of: VCP.audioSpeakerVolume) == afterLatching)
+    #expect(volume.readEvidence == .refused)
+  }
+
+  /// The brightness controller publishes the same verdict off its one read per
+  /// pass, so the two call sites cannot drift.
+  @Test func abrightnessRefusalPublishesTheSameVerdict() async {
+    let controller = makeLegacyPathController(writer: RefusingDDC())
+
+    await controller.refreshFromHardware()
+    #expect(controller.readEvidence == .refused)
+    // A refusal carries no maximum, so the scale stays assumed and says so.
+    #expect(controller.didReadMaxDDC == false)
+    #expect(controller.maxDDCValue == 100)
+  }
+
+  /// The headline, at the surface the round-4 finding is about: the Dell answers
+  /// brightness and contrast and refuses volume, and the display-level fold the
+  /// hub, the Diagnostics row and the report all read has to call that display
+  /// answering.
+  @Test func adisplayThatRefusesOneRegisterStillReadsAsAnswering() async {
+    let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "refused-fold")
+    prefs.startupAction = .read
+    let volume = DDCValueController(writer: RefusingDDC(), command: .volume, prefs: prefs)
+    let contrast = DDCValueController(
+      writer: FakeDDC(readResult: (current: 50, max: 100)), command: .contrast, prefs: prefs
+    )
+    let brightness = makeLegacyPathController(writer: FakeDDC(readResult: (current: 30, max: 100)))
+
+    await volume.refreshFromHardware()
+    await contrast.refreshFromHardware()
+    await brightness.refreshFromHardware()
+
+    let folded = DDCReadEvidence.worst([
+      brightness.readEvidence, volume.readEvidence, contrast.readEvidence,
+    ])
+    #expect(folded == .answered)
+    #expect(DiagnosticsCopy.readbackVerdict(folded) == "Answers reads")
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -73,10 +73,7 @@ private func replyFrame(command: UInt8, current: UInt16, max: UInt16) -> [UInt8]
 
 // MARK: - The retry ladder, driven by a scripted panel
 
-/// One scripted reply per read call: `nil` is a read call that fails, `[]` is a
-/// read call that reports success and writes nothing, bytes are what the panel
-/// puts in the buffer. The last entry keeps answering once the script runs out,
-/// so a test says what it is about and no more.
+/// One scripted reply per read call: `nil` fails, `[]` reports success and
 /// writes nothing, bytes are what the panel puts in the buffer. The last entry
 /// repeats once the script runs out.
 ///
@@ -87,9 +84,7 @@ private final class ScriptedPanel: @unchecked Sendable {
   private var writeResults: [Int32]
   private(set) var writes = 0
   private(set) var reads = 0
-  /// Packets and sleeps in the order the transaction spent them, as `write`,
-  /// `read` and `sleep:<microseconds>`. The pacing tests below are about that
-  /// order and nothing else, so the sleeps have to be visible.
+  /// Packets and sleeps in the order spent, as `write`, `read` and
   /// `sleep:<microseconds>`; the pacing tests are about that order.
   private(set) var trace: [String] = []
 
@@ -128,8 +123,6 @@ private final class ScriptedPanel: @unchecked Sendable {
   }
 }
 
-/// Time the tests move by hand, so the three gap cases are pinned without
-/// spending any. Starts away from zero so that rewinding it stays in range.
 /// Time the tests move by hand. Starts away from zero so rewinding stays in range.
 ///
 /// `@unchecked Sendable`: every mutation happens on the test's own thread, from

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -59,15 +59,14 @@ private func refusalFrame(command: UInt8, code: UInt8 = 0x01) -> [UInt8] {
   #expect(Arm64DDC.replyVerdict(garbled) == .silent)
 }
 
-/// The control for the four cases above: the verdict function distinguishes at
-/// all, rather than answering `.silent` to everything.
+/// The control for the cases above: the verdict function distinguishes at all,
+/// rather than answering `.silent` to everything.
 @Test func theVerdictsAreDistinct() {
   let untouched = Arm64DDC.replyVerdict([UInt8](repeating: Arm64DDC.replySentinel, count: 11))
   let zeros = Arm64DDC.replyVerdict([UInt8](repeating: 0, count: 11))
   let frame = Arm64DDC.replyVerdict(replyFrame(command: 0x10, current: 1, max: 2))
-  #expect(untouched != zeros)
-  #expect(zeros != frame)
-  #expect(frame != untouched)
+  let refusal = Arm64DDC.replyVerdict(refusalFrame(command: 0x10), command: 0x10)
+  #expect(Set([untouched, zeros, frame, refusal]).count == 4)
 }
 
 /// A frame that answers a DIFFERENT code than the one asked is not an answer,
@@ -248,29 +247,31 @@ private func runRead(
 @Test func aRefusedRegisterEndsTheLadderOnTheAttemptThatCarriedIt() {
   let panel = ScriptedPanel([refusalFrame(command: 0x10)])
   var reply = [UInt8](repeating: 0, count: 11)
-  #expect(runRead(panel, reply: &reply) == .silent)
+  #expect(runRead(panel, reply: &reply) == .refused)
   #expect(panel.reads == 1)
   #expect(panel.writes == 1)
 }
 
-/// The evidence is unchanged by the early exit: a refusal is not a readable
-/// register, so it reads as silence and the skip latch counts it as before.
-@Test func aRefusalStillReadsAsSilenceRatherThanAnAnswer() {
-  #expect(Arm64DDC.replyVerdict(refusalFrame(command: 0x10), command: 0x10) == .silent)
-  #expect(Arm64DDC.attemptVerdict(refusalFrame(command: 0x10), command: 0x10).isRefusal)
+/// And it is its OWN outcome, not a shade of silence: the panel replied, so a
+/// display whose volume register is refused must not be reported as one that
+/// stopped answering.
+@Test func aRefusalIsItsOwnOutcomeRatherThanSilence() {
+  #expect(Arm64DDC.replyVerdict(refusalFrame(command: 0x10), command: 0x10) == .refused)
+  #expect(DDCReadOutcome.refused.evidence == .refused)
+  #expect(DDCReadOutcome.refused.value == nil)
 }
 
-/// The ordering `isRefusal` rests on: `attemptVerdict` checks the checksum
+/// The ordering the refusal verdict rests on: `replyVerdict` checks the checksum
 /// FIRST, so a result code carried in bytes that failed their own integrity
-/// check is not the panel answering. `isRefusal` deliberately does not check the
-/// checksum itself, so nothing but that ordering keeps a corrupted frame from
-/// ending the ladder.
+/// check is not the panel answering. `DDCReplyFrame.isRefusal` deliberately does
+/// not check the checksum itself, so nothing but that ordering keeps a corrupted
+/// frame from ending the ladder.
 @Test func aRefusalWithABrokenChecksumIsNotAnAnswerAndKeepsRetrying() {
   var corrupted = refusalFrame(command: 0x10)
   corrupted[corrupted.count - 1] &+= 1
   // The frame still SAYS refusal; only the checksum says not to believe it.
   #expect(DDCReplyFrame.isRefusal(corrupted, of: 0x10))
-  #expect(!Arm64DDC.attemptVerdict(corrupted, command: 0x10).isRefusal)
+  #expect(Arm64DDC.replyVerdict(corrupted, command: 0x10) == .silent)
 
   let panel = ScriptedPanel([corrupted])
   var reply = [UInt8](repeating: 0, count: 11)
@@ -305,6 +306,16 @@ private func runRead(
   ])
   var reply = [UInt8](repeating: 0, count: 11)
   #expect(runRead(panel, reply: &reply) == .answeredZeros)
+  #expect(panel.reads == 2)
+}
+
+/// The other direction: a refusal behind a dropped read call is the transaction's
+/// answer, because the panel did eventually speak and a lost call proves nothing
+/// about the register.
+@Test func aRefusalOutlivesAnEarlierFailedCall() {
+  let panel = ScriptedPanel([nil, refusalFrame(command: 0x10)])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .refused)
   #expect(panel.reads == 2)
 }
 
@@ -504,6 +515,12 @@ private func pacerOnAQuietBus(_ clock: FakeClock) -> DDCBusPacer {
   #expect(Arm64DDC.fold(.silent, .answeredZeros) == .answeredZeros)
   #expect(Arm64DDC.fold(.silent, .silent) == .silent)
   #expect(Arm64DDC.fold(.answeredZeros, .ok) == .ok)
+  // A refusal beats a silence and loses to zeros, in both argument orders.
+  #expect(Arm64DDC.fold(.silent, .refused) == .refused)
+  #expect(Arm64DDC.fold(.refused, .silent) == .refused)
+  #expect(Arm64DDC.fold(.answeredZeros, .refused) == .answeredZeros)
+  #expect(Arm64DDC.fold(.refused, .answeredZeros) == .answeredZeros)
+  #expect(Arm64DDC.fold(.refused, .ok) == .ok)
 }
 
 // MARK: - What a read outcome publishes
@@ -521,11 +538,14 @@ private func pacerOnAQuietBus(_ clock: FakeClock) -> DDCBusPacer {
   #expect(DDCReadOutcome.frame(current: 0, max: 0).evidence == .allZeros)
 }
 
-@Test func zerosOnTheBusAndSilenceStaySeparate() {
+@Test func zerosOnTheBusAndSilenceAndARefusalStaySeparate() {
   #expect(DDCReadOutcome.allZeros.evidence == .allZeros)
   #expect(DDCReadOutcome.allZeros.value == nil)
   #expect(DDCReadOutcome.noReply.evidence == .noReply)
   #expect(DDCReadOutcome.noReply.value == nil)
+  #expect(DDCReadOutcome.refused.evidence == .refused)
+  #expect(DDCReadOutcome.refused.value == nil)
+  #expect(Set([DDCReadOutcome.allZeros.evidence, .noReply, .refused]).count == 3)
 }
 
 // MARK: - The default a writer with no transport of its own inherits

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -130,6 +130,10 @@ private final class ScriptedPanel: @unchecked Sendable {
 
 /// Time the tests move by hand, so the three gap cases are pinned without
 /// spending any. Starts away from zero so that rewinding it stays in range.
+/// Time the tests move by hand. Starts away from zero so rewinding stays in range.
+///
+/// `@unchecked Sendable`: every mutation happens on the test's own thread, from
+/// closures `runTransaction` calls synchronously.
 private final class FakeClock: @unchecked Sendable {
   private var nanos: UInt64 = 1_000_000_000
 
@@ -368,6 +372,38 @@ private func pacerOnAQuietBus(_ clock: FakeClock) -> DDCBusPacer {
   #expect(pacer.deficit(floor: 10000) == 10000)
 }
 
+/// The pacer outlives the service: `DisplayDiscovery.discover()` rebuilds it on
+/// every refresh while the retired one can still drain a queued write.
+@Test func twoServicesForOneDisplayShareTheFloor() {
+  let clock = FakeClock()
+  let first = DDCBusPacerRegistry.shared.pacer(for: 0xFACE_0001, now: clock.reader)
+  clock.advance(microseconds: 60000)
+  #expect(first.deficit(floor: 10000) == 0)
+  first.recordBusUse()
+
+  // The rebuild. The clock argument is ignored for a key already registered,
+  // which is the point: a new service does not get to restart the floor.
+  let second = DDCBusPacerRegistry.shared.pacer(for: 0xFACE_0001, now: clock.reader)
+  #expect(second === first)
+  #expect(second.deficit(floor: 10000) == 10000)
+}
+
+/// And the other direction, which is what a per-display key is for: a write to
+/// one panel never delays a write to another.
+@Test func twoDisplaysDoNotPaceEachOther() {
+  let clock = FakeClock()
+  let one = DDCBusPacerRegistry.shared.pacer(for: 0xFACE_0002, now: clock.reader)
+  let other = DDCBusPacerRegistry.shared.pacer(for: 0xFACE_0003, now: clock.reader)
+  #expect(one !== other)
+  clock.advance(microseconds: 60000)
+  one.recordBusUse()
+  #expect(one.deficit(floor: 10000) == 10000)
+  #expect(other.deficit(floor: 10000) == 0)
+}
+
+/// The fold's own contract. The ladder returns on a valid frame rather than
+/// folding it, so the `.ok` arms exist to keep the function total, not for a path
+/// anything takes today.
 @Test func theFoldKeepsTheMoreSpecificFinding() {
   #expect(Arm64DDC.fold(.answeredZeros, .silent) == .answeredZeros)
   #expect(Arm64DDC.fold(.silent, .answeredZeros) == .answeredZeros)

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -77,34 +77,65 @@ private func replyFrame(command: UInt8, current: UInt16, max: UInt16) -> [UInt8]
 /// read call that reports success and writes nothing, bytes are what the panel
 /// puts in the buffer. The last entry keeps answering once the script runs out,
 /// so a test says what it is about and no more.
+/// writes nothing, bytes are what the panel puts in the buffer. The last entry
+/// repeats once the script runs out.
 ///
-/// `@unchecked Sendable`: `runTransaction` calls both closures synchronously on
-/// the calling thread and has returned before the test reads the counters, so
-/// there is no concurrent access to confine.
+/// `@unchecked Sendable`: `runTransaction` calls both closures synchronously and
+/// has returned before the test reads the counters.
 private final class ScriptedPanel: @unchecked Sendable {
   private var replies: [[UInt8]?]
+  private var writeResults: [Int32]
   private(set) var writes = 0
   private(set) var reads = 0
+  /// Packets and sleeps in the order the transaction spent them, as `write`,
+  /// `read` and `sleep:<microseconds>`. The pacing tests below are about that
+  /// order and nothing else, so the sleeps have to be visible.
+  /// `sleep:<microseconds>`; the pacing tests are about that order.
+  private(set) var trace: [String] = []
 
-  init(_ replies: [[UInt8]?]) { self.replies = replies }
+  /// When set, a slept microsecond is a microsecond of fake time. I2C calls cost
+  /// nothing on this clock, so every gap is a sleep.
+  var clock: FakeClock?
+
+  init(_ replies: [[UInt8]?], writeResults: [Int32] = [0], clock: FakeClock? = nil) {
+    self.replies = replies
+    self.writeResults = writeResults
+    self.clock = clock
+  }
 
   var transport: Arm64DDC.I2CTransport {
     Arm64DDC.I2CTransport(
       write: { _, _, _ in
         self.writes += 1
-        return 0
+        self.trace.append("write")
+        return self.writeResults.count > 1 ? self.writeResults.removeFirst() : (self.writeResults.first ?? 0)
       },
       read: { _, buffer, count in
         self.reads += 1
+        self.trace.append("read")
         let reply = self.replies.count > 1 ? self.replies.removeFirst() : (self.replies.first ?? nil)
         guard let reply, !reply.isEmpty else { return reply == nil ? -1 : 0 }
         reply.withUnsafeBytes { bytes in
           buffer.copyMemory(from: bytes.baseAddress!, byteCount: min(bytes.count, Int(count)))
         }
         return 0
+      },
+      sleep: {
+        self.trace.append("sleep:\($0)")
+        self.clock?.advance(microseconds: UInt64($0))
       }
     )
   }
+}
+
+/// Time the tests move by hand, so the three gap cases are pinned without
+/// spending any. Starts away from zero so that rewinding it stays in range.
+private final class FakeClock: @unchecked Sendable {
+  private var nanos: UInt64 = 1_000_000_000
+
+  var reader: @Sendable () -> UInt64 { { self.nanos } }
+  func advance(microseconds: UInt64) { self.nanos += microseconds * 1000 }
+  func rewind(microseconds: UInt64) { self.nanos -= microseconds * 1000 }
 }
 
 private func runRead(
@@ -114,7 +145,7 @@ private func runRead(
   return Arm64DDC.runTransaction(
     service: nil, send: &send, reply: &reply, replyCommand: command,
     writeSleepTime: 0, numOfWriteCycles: nil, readSleepTime: 0,
-    numOfRetryAttemps: 4, retrySleepTime: 0, transport: panel.transport
+    numOfRetryAttemps: 4, retrySleepTime: 0, pacer: nil, transport: panel.transport
   )
 }
 
@@ -187,11 +218,154 @@ private func runRead(
   let outcome = Arm64DDC.runTransaction(
     service: nil, send: &send, reply: &reply, replyCommand: nil,
     writeSleepTime: 0, numOfWriteCycles: nil, readSleepTime: 0,
-    numOfRetryAttemps: 4, retrySleepTime: 0, transport: panel.transport
+    numOfRetryAttemps: 4, retrySleepTime: 0, pacer: nil, transport: panel.transport
   )
   #expect(outcome == .ok)
   #expect(panel.writes == 1)
   #expect(panel.reads == 0)
+}
+
+// MARK: - The bus floor, measured rather than assumed
+
+/// Every transaction below runs through this: a scripted panel, a pacer on the
+/// same fake clock the sleeps advance, and a 10 ms floor.
+private func runPaced(
+  _ panel: ScriptedPanel, pacer: DDCBusPacer?, send: [UInt8], replyLength: Int = 0,
+  writeCycles: UInt8? = nil, retries: UInt8 = 4
+) -> Arm64DDC.TransactionOutcome {
+  var send = send
+  var reply = [UInt8](repeating: 0, count: replyLength)
+  return Arm64DDC.runTransaction(
+    service: nil, send: &send, reply: &reply, replyCommand: send.count == 1 ? send[0] : nil,
+    writeSleepTime: 10000, numOfWriteCycles: writeCycles, readSleepTime: 50000,
+    numOfRetryAttemps: retries, retrySleepTime: 20000, pacer: pacer,
+    transport: panel.transport
+  )
+}
+
+private let setBrightness: [UInt8] = [0x10, 0x00, 0x32]
+
+/// A pacer whose display has been quiet for longer than the floor. Construction
+/// seeds the bus as JUST USED, so an idle-bus test has to let that seed age.
+private func pacerOnAQuietBus(_ clock: FakeClock) -> DDCBusPacer {
+  let pacer = DDCBusPacer(now: clock.reader)
+  clock.advance(microseconds: 60000)
+  return pacer
+}
+
+/// The 10 ms used to be spent before every packet, even the first to reach a bus
+/// quiet for minutes, on a transaction measured at about 14 ms.
+@Test func aWriteOnAQuietBusGoesOutWithoutWaiting() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([], clock: clock)
+  #expect(runPaced(panel, pacer: pacerOnAQuietBus(clock), send: setBrightness) == .ok)
+  #expect(panel.trace == ["write"])
+}
+
+/// And the gap that exists today survives: a burst still puts 10 ms between
+/// packets, because the floor is measured from the last call rather than
+/// skipped.
+@Test func backToBackWritesKeepTheirTenMillisecondGap() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([], clock: clock)
+  let pacer = pacerOnAQuietBus(clock)
+  _ = runPaced(panel, pacer: pacer, send: setBrightness)
+  _ = runPaced(panel, pacer: pacer, send: setBrightness)
+  #expect(panel.trace == ["write", "sleep:10000", "write"])
+}
+
+/// Only the remainder is owed. A bus quiet for 6 of the 10 ms waits 4, not 10
+/// and not nothing.
+@Test func aPartlyIdleBusWaitsOnlyTheRemainder() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([], clock: clock)
+  let pacer = pacerOnAQuietBus(clock)
+  _ = runPaced(panel, pacer: pacer, send: setBrightness)
+  clock.advance(microseconds: 6000)
+  _ = runPaced(panel, pacer: pacer, send: setBrightness)
+  #expect(panel.trace == ["write", "sleep:4000", "write"])
+}
+
+/// A read leaves the bus busy at its REPLY read, so the write behind it is paced
+/// from there and keeps its 10 ms; the read's own 50 ms settle is untouched.
+@Test func aWriteRightAfterAReadKeepsItsGapAndTheSettleIsUntouched() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([replyFrame(command: 0x10, current: 50, max: 100)], clock: clock)
+  let pacer = pacerOnAQuietBus(clock)
+  #expect(runPaced(panel, pacer: pacer, send: [0x10], replyLength: 11) == .ok)
+  _ = runPaced(panel, pacer: pacer, send: setBrightness)
+  #expect(panel.trace == ["write", "sleep:50000", "read", "sleep:10000", "write"])
+}
+
+/// A read is paced like anything else, so the request behind a fresh write waits
+/// its floor. Run twice to show the settle is the same 50 ms either way.
+@Test func aReadIsPacedFromTheBusToo() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([replyFrame(command: 0x10, current: 50, max: 100)], clock: clock)
+  let pacer = pacerOnAQuietBus(clock)
+  _ = runPaced(panel, pacer: pacer, send: setBrightness)
+  _ = runPaced(panel, pacer: pacer, send: [0x10], replyLength: 11)
+  #expect(panel.trace == ["write", "sleep:10000", "write", "sleep:50000", "read"])
+}
+
+/// Retries are untouched: the retry sleep and the next attempt's own sleep both
+/// stand. Only the FIRST packet of a transaction is paced from the bus.
+@Test func aRetryKeepsBothOfItsSleeps() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([], writeResults: [-1], clock: clock)
+  let outcome = runPaced(
+    panel, pacer: pacerOnAQuietBus(clock), send: setBrightness, retries: 1
+  )
+  #expect(outcome == .silent)
+  #expect(panel.writes == 2)
+  #expect(panel.trace == ["write", "sleep:20000", "sleep:10000", "write", "sleep:20000"])
+}
+
+/// Same rule inside one attempt: a second write cycle is not the first packet,
+/// so it keeps the full sleep and the two packets stay 10 ms apart.
+@Test func aSecondWriteCycleKeepsItsFullSleep() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([], clock: clock)
+  _ = runPaced(
+    panel, pacer: pacerOnAQuietBus(clock), send: setBrightness, writeCycles: 2
+  )
+  #expect(panel.trace == ["write", "sleep:10000", "write"])
+}
+
+/// A refresh retires the service, so the replacement starts by assuming the bus
+/// was busy; otherwise its first packet could follow the retired service's traffic
+/// by microseconds, silently on the write-only MAG.
+@Test func aFreshServiceStartsOwingTheFullFloor() {
+  let clock = FakeClock()
+  let panel = ScriptedPanel([], clock: clock)
+  _ = runPaced(panel, pacer: DDCBusPacer(now: clock.reader), send: setBrightness)
+  #expect(panel.trace == ["sleep:10000", "write"])
+}
+
+/// No pacer, no memory of the bus, so the floor is paid in full. The control for
+/// the tests above.
+@Test func aTransactionWithNoPacerPaysTheFloorInFull() {
+  let panel = ScriptedPanel([])
+  _ = runPaced(panel, pacer: nil, send: setBrightness)
+  #expect(panel.trace == ["sleep:10000", "write"])
+}
+
+/// The arithmetic on its own, including the two ends a ladder test cannot
+/// reach: a pacer at the moment it is built, and a clock that went backwards.
+@Test func theFloorIsWhatTheBusStillOwes() {
+  let clock = FakeClock()
+  let pacer = DDCBusPacer(now: clock.reader)
+  // Built, not used: the bus is assumed busy, so the whole floor is owed.
+  #expect(pacer.deficit(floor: 10000) == 10000)
+  pacer.recordBusUse()
+  #expect(pacer.deficit(floor: 10000) == 10000)
+  clock.advance(microseconds: 4000)
+  #expect(pacer.deficit(floor: 10000) == 6000)
+  clock.advance(microseconds: 60000)
+  #expect(pacer.deficit(floor: 10000) == 0)
+  pacer.recordBusUse()
+  clock.rewind(microseconds: 5000)
+  #expect(pacer.deficit(floor: 10000) == 10000)
 }
 
 @Test func theFoldKeepsTheMoreSpecificFinding() {

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -1,0 +1,238 @@
+import Testing
+@testable import CandelaKit
+
+// MARK: - The sentinel rule
+
+/// The checksum a real panel puts in the last byte, so a fixture frame is a
+/// frame rather than eleven bytes that happen to fail validation.
+private func sealed(_ frame: [UInt8]) -> [UInt8] {
+  var sealed = frame
+  sealed[sealed.count - 1] = Arm64DDC.checksum(
+    chk: 0x50, data: &sealed, start: 0, end: sealed.count - 2
+  )
+  return sealed
+}
+
+/// `[source][length][reply op][result][command][type][max hi][max lo][cur hi][cur lo][chk]`
+private func replyFrame(command: UInt8, current: UInt16, max: UInt16) -> [UInt8] {
+  sealed([
+    0x6E, 0x88, 0x02, 0x00, command, 0x00,
+    UInt8(max >> 8), UInt8(max & 0xFF),
+    UInt8(current >> 8), UInt8(current & 0xFF),
+    0x00,
+  ])
+}
+
+/// With a zero fill, a buffer nobody wrote to and a panel that answered zeros
+/// are the same bytes.
+@Test func theReplySentinelIsNotZero() {
+  #expect(Arm64DDC.replySentinel != 0)
+}
+
+@Test func anUntouchedBufferIsSilenceRatherThanZeros() {
+  let untouched = [UInt8](
+    repeating: Arm64DDC.replySentinel, count: DDCReplyFrame.expectedLength
+  )
+  #expect(Arm64DDC.replyVerdict(untouched) == .silent)
+}
+
+@Test func aBufferChangedToZerosIsThePanelAnswering() {
+  #expect(Arm64DDC.replyVerdict([UInt8](repeating: 0, count: 11)) == .answeredZeros)
+}
+
+@Test func aCleanFrameIsAnAnswer() {
+  #expect(Arm64DDC.replyVerdict(replyFrame(command: 0x10, current: 50, max: 100)) == .ok)
+}
+
+/// Partially written, so neither all zeros nor the untouched sentinel: the panel
+/// said something and it was not an answer.
+@Test func aFrameThatFailsItsChecksumIsSilence() {
+  var garbled = replyFrame(command: 0x10, current: 50, max: 100)
+  garbled[7] &+= 1
+  #expect(Arm64DDC.replyVerdict(garbled) == .silent)
+}
+
+/// The control for the four cases above: the verdict function distinguishes at
+/// all, rather than answering `.silent` to everything.
+@Test func theVerdictsAreDistinct() {
+  let untouched = Arm64DDC.replyVerdict([UInt8](repeating: Arm64DDC.replySentinel, count: 11))
+  let zeros = Arm64DDC.replyVerdict([UInt8](repeating: 0, count: 11))
+  let frame = Arm64DDC.replyVerdict(replyFrame(command: 0x10, current: 1, max: 2))
+  #expect(untouched != zeros)
+  #expect(zeros != frame)
+  #expect(frame != untouched)
+}
+
+/// A frame that answers a DIFFERENT code than the one asked is not an answer,
+/// and it must not end the ladder either (see the retry tests below).
+@Test func aFrameAnsweringAnotherCodeIsNotAnAnswer() {
+  let frame = replyFrame(command: 0x12, current: 50, max: 100)
+  #expect(Arm64DDC.replyVerdict(frame, command: 0x10) == .silent)
+  #expect(Arm64DDC.replyVerdict(frame, command: 0x12) == .ok)
+}
+
+// MARK: - The retry ladder, driven by a scripted panel
+
+/// One scripted reply per read call: `nil` is a read call that fails, `[]` is a
+/// read call that reports success and writes nothing, bytes are what the panel
+/// puts in the buffer. The last entry keeps answering once the script runs out,
+/// so a test says what it is about and no more.
+///
+/// `@unchecked Sendable`: `runTransaction` calls both closures synchronously on
+/// the calling thread and has returned before the test reads the counters, so
+/// there is no concurrent access to confine.
+private final class ScriptedPanel: @unchecked Sendable {
+  private var replies: [[UInt8]?]
+  private(set) var writes = 0
+  private(set) var reads = 0
+
+  init(_ replies: [[UInt8]?]) { self.replies = replies }
+
+  var transport: Arm64DDC.I2CTransport {
+    Arm64DDC.I2CTransport(
+      write: { _, _, _ in
+        self.writes += 1
+        return 0
+      },
+      read: { _, buffer, count in
+        self.reads += 1
+        let reply = self.replies.count > 1 ? self.replies.removeFirst() : (self.replies.first ?? nil)
+        guard let reply, !reply.isEmpty else { return reply == nil ? -1 : 0 }
+        reply.withUnsafeBytes { bytes in
+          buffer.copyMemory(from: bytes.baseAddress!, byteCount: min(bytes.count, Int(count)))
+        }
+        return 0
+      }
+    )
+  }
+}
+
+private func runRead(
+  _ panel: ScriptedPanel, command: UInt8 = 0x10, reply: inout [UInt8]
+) -> Arm64DDC.TransactionOutcome {
+  var send: [UInt8] = [command]
+  return Arm64DDC.runTransaction(
+    service: nil, send: &send, reply: &reply, replyCommand: command,
+    writeSleepTime: 0, numOfWriteCycles: nil, readSleepTime: 0,
+    numOfRetryAttemps: 4, retrySleepTime: 0, transport: panel.transport
+  )
+}
+
+/// The write lands, the reply read fails, and the transaction used to return on
+/// attempt one carrying the write's success.
+@Test func aFailedReplyReadSpendsTheWholeLadder() {
+  let panel = ScriptedPanel([nil])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .silent)
+  #expect(panel.writes == 5)
+  #expect(panel.reads == 5)
+}
+
+/// A read call that succeeds and writes nothing must not read as a panel
+/// answering zeros. Delete the sentinel fill and this test says `answeredZeros`.
+@Test func aReadThatWritesNothingIsSilenceRatherThanZeros() {
+  let panel = ScriptedPanel([[]])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .silent)
+}
+
+/// The panel that lies: a checksum-clean frame answering a DIFFERENT code is
+/// retried like any other failed read, and the good frame behind it wins.
+@Test func aFrameAnsweringAnotherCodeIsRetriedAndTheGoodOneWins() {
+  let asked = replyFrame(command: 0x10, current: 50, max: 100)
+  let panel = ScriptedPanel([replyFrame(command: 0x12, current: 99, max: 99), asked])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .ok)
+  #expect(reply == asked)
+  #expect(panel.reads == 2)
+}
+
+/// The control for the test above: with nothing better behind it, the lying
+/// panel is silence rather than an answer, and it costs the whole ladder.
+@Test func aFrameAnsweringAnotherCodeAloneIsSilence() {
+  let panel = ScriptedPanel([replyFrame(command: 0x12, current: 99, max: 99)])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .silent)
+  #expect(panel.reads == 5)
+}
+
+/// Zeros on the bus are the more specific finding and outlive a later attempt
+/// that got nothing usable.
+@Test func zerosSurviveALaterRejectedFrame() {
+  let panel = ScriptedPanel([
+    [UInt8](repeating: 0, count: 11),
+    replyFrame(command: 0x12, current: 9, max: 9),
+  ])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .answeredZeros)
+}
+
+/// And a valid frame still supersedes them: a panel that answers is not reported
+/// write-only because one attempt caught it mid-sentence.
+@Test func aValidFrameSupersedesEarlierZeros() {
+  let panel = ScriptedPanel([
+    [UInt8](repeating: 0, count: 11),
+    replyFrame(command: 0x10, current: 30, max: 100),
+  ])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .ok)
+}
+
+/// The write path, which none of this changes: an acknowledged write with no
+/// reply expected ends the transaction on the first attempt.
+@Test func anAcknowledgedWriteReturnsOnTheFirstAttempt() {
+  let panel = ScriptedPanel([])
+  var send: [UInt8] = [0x10, 0x00, 0x32]
+  var reply: [UInt8] = []
+  let outcome = Arm64DDC.runTransaction(
+    service: nil, send: &send, reply: &reply, replyCommand: nil,
+    writeSleepTime: 0, numOfWriteCycles: nil, readSleepTime: 0,
+    numOfRetryAttemps: 4, retrySleepTime: 0, transport: panel.transport
+  )
+  #expect(outcome == .ok)
+  #expect(panel.writes == 1)
+  #expect(panel.reads == 0)
+}
+
+@Test func theFoldKeepsTheMoreSpecificFinding() {
+  #expect(Arm64DDC.fold(.answeredZeros, .silent) == .answeredZeros)
+  #expect(Arm64DDC.fold(.silent, .answeredZeros) == .answeredZeros)
+  #expect(Arm64DDC.fold(.silent, .silent) == .silent)
+  #expect(Arm64DDC.fold(.answeredZeros, .ok) == .ok)
+}
+
+// MARK: - What a read outcome publishes
+
+@Test func aFrameWithARealMaximumIsAnAnsweredPanel() {
+  let outcome = DDCReadOutcome.frame(current: 50, max: 100)
+  #expect(outcome.evidence == .answered)
+  #expect(outcome.value?.current == 50)
+  #expect(outcome.value?.max == 100)
+}
+
+/// A frame carrying a zero maximum is the same admission as a buffer of zeros,
+/// and both sites read that mapping from here rather than deriving it twice.
+@Test func aFrameWithAZeroMaximumIsTheWriteOnlySignature() {
+  #expect(DDCReadOutcome.frame(current: 0, max: 0).evidence == .allZeros)
+}
+
+@Test func zerosOnTheBusAndSilenceStaySeparate() {
+  #expect(DDCReadOutcome.allZeros.evidence == .allZeros)
+  #expect(DDCReadOutcome.allZeros.value == nil)
+  #expect(DDCReadOutcome.noReply.evidence == .noReply)
+  #expect(DDCReadOutcome.noReply.value == nil)
+}
+
+// MARK: - The default a writer with no transport of its own inherits
+
+@Test func aWriterThatOnlyReturnsAValueCannotClaimZerosOnTheBus() async {
+  #expect(await FakeDDC(readResult: nil).readOutcome(command: VCP.brightness) == .noReply)
+  #expect(
+    await FakeDDC(readResult: (current: 0, max: 0)).readOutcome(command: VCP.brightness)
+      == .frame(current: 0, max: 0)
+  )
+  #expect(
+    await FakeDDC(readResult: (current: 50, max: 100)).readOutcome(command: VCP.brightness)
+      == .frame(current: 50, max: 100)
+  )
+}

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -154,13 +154,40 @@ private func runRead(
 }
 
 /// The write lands, the reply read fails, and the transaction used to return on
-/// attempt one carrying the write's success.
-@Test func aFailedReplyReadSpendsTheWholeLadder() {
+/// attempt one carrying the write's success. It is still a failed read, and it
+/// still retries: once, not four times. A read CALL that failed never reached a
+/// panel, so the remaining attempts re-ask a wire that is not carrying reads, at
+/// about 80 ms each, on every pass, for the life of the install.
+@Test func aFailedReplyReadIsRetriedOnceAndNoMore() {
   let panel = ScriptedPanel([nil])
   var reply = [UInt8](repeating: 0, count: 11)
   #expect(runRead(panel, reply: &reply) == .silent)
-  #expect(panel.writes == 5)
-  #expect(panel.reads == 5)
+  #expect(panel.writes == 2)
+  #expect(panel.reads == 2)
+}
+
+/// The other half of that rule: the retry is real, so a call that fails once and
+/// then lands still answers.
+@Test func aFailedReplyReadStillGetsItsOneRetry() {
+  let asked = replyFrame(command: 0x10, current: 40, max: 80)
+  let panel = ScriptedPanel([nil, asked])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .ok)
+  #expect(reply == asked)
+  #expect(panel.reads == 2)
+}
+
+/// The cap counts failed read CALLS, not attempts. A frame that arrives and
+/// fails validation keeps the full ladder (the panel did answer, and a garbled
+/// answer is what retries exist for), so a ladder that mixes the two spends its
+/// two failed calls wherever they fall.
+@Test func aFailedCallAmongBadFramesStillLeavesOneMoreCall() {
+  let lying = replyFrame(command: 0x12, current: 99, max: 99)
+  let panel = ScriptedPanel([lying, nil, lying, nil, lying])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .silent)
+  // Attempts 1 to 4: bad frame, failed call, bad frame, failed call and stop.
+  #expect(panel.reads == 4)
 }
 
 /// A read call that succeeds and writes nothing must not read as a panel

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -23,6 +23,13 @@ private func replyFrame(command: UInt8, current: UInt16, max: UInt16) -> [UInt8]
   ])
 }
 
+/// The same frame carrying a result code instead of a value: the display
+/// parsed the Get VCP and refused the code. `0x01` is the MCCS "unsupported VCP
+/// code", the one the Dell answers for a register it does not carry.
+private func refusalFrame(command: UInt8, code: UInt8 = 0x01) -> [UInt8] {
+  sealed([0x6E, 0x88, 0x02, code, command, 0x00, 0, 0, 0, 0, 0x00])
+}
+
 /// With a zero fill, a buffer nobody wrote to and a panel that answered zeros
 /// are the same bytes.
 @Test func theReplySentinelIsNotZero() {
@@ -204,6 +211,74 @@ private func runRead(
   ])
   var reply = [UInt8](repeating: 0, count: 11)
   #expect(runRead(panel, reply: &reply) == .ok)
+}
+
+// MARK: - A refusal is an answer, and it ends the ladder
+
+/// A refused register costs ONE transaction, as it did before the reply frame
+/// was validated at all. Retrying re-asks a question the panel answered, and the
+/// value controller spends this ladder `pollingTries` times per pass.
+@Test func aRefusedRegisterEndsTheLadderOnTheAttemptThatCarriedIt() {
+  let panel = ScriptedPanel([refusalFrame(command: 0x10)])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .silent)
+  #expect(panel.reads == 1)
+  #expect(panel.writes == 1)
+}
+
+/// The evidence is unchanged by the early exit: a refusal is not a readable
+/// register, so it reads as silence and the skip latch counts it as before.
+@Test func aRefusalStillReadsAsSilenceRatherThanAnAnswer() {
+  #expect(Arm64DDC.replyVerdict(refusalFrame(command: 0x10), command: 0x10) == .silent)
+  #expect(Arm64DDC.attemptVerdict(refusalFrame(command: 0x10), command: 0x10).isRefusal)
+}
+
+/// The ordering `isRefusal` rests on: `attemptVerdict` checks the checksum
+/// FIRST, so a result code carried in bytes that failed their own integrity
+/// check is not the panel answering. `isRefusal` deliberately does not check the
+/// checksum itself, so nothing but that ordering keeps a corrupted frame from
+/// ending the ladder.
+@Test func aRefusalWithABrokenChecksumIsNotAnAnswerAndKeepsRetrying() {
+  var corrupted = refusalFrame(command: 0x10)
+  corrupted[corrupted.count - 1] &+= 1
+  // The frame still SAYS refusal; only the checksum says not to believe it.
+  #expect(DDCReplyFrame.isRefusal(corrupted, of: 0x10))
+  #expect(!Arm64DDC.attemptVerdict(corrupted, command: 0x10).isRefusal)
+
+  let panel = ScriptedPanel([corrupted])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .silent)
+  #expect(panel.reads == 5)
+}
+
+/// The control for the early exit, and the rule it rests on: only a result-code
+/// refusal is an answer. A malformed, mis-addressed or stale frame proves
+/// nothing about the register and keeps every retry it had.
+@Test func onlyARefusalEndsTheLadderAndEveryOtherRejectionRetries() {
+  // Re-sealed after the edit: a broken checksum would end these transactions
+  // for a reason that has nothing to do with which rejection they carry.
+  var wrongSource = refusalFrame(command: 0x10)
+  wrongSource[0] = 0x6F
+  var notAReply = refusalFrame(command: 0x10)
+  notAReply[2] = 0xE3
+  for frame in [sealed(wrongSource), sealed(notAReply), refusalFrame(command: 0x12)] {
+    let panel = ScriptedPanel([frame])
+    var reply = [UInt8](repeating: 0, count: 11)
+    #expect(runRead(panel, reply: &reply) == .silent)
+    #expect(panel.reads == 5)
+  }
+}
+
+/// A refusal on attempt two does not erase what attempt one proved: zeros are
+/// the more specific finding and the fold keeps them.
+@Test func aRefusalDoesNotEraseEarlierZeros() {
+  let panel = ScriptedPanel([
+    [UInt8](repeating: 0, count: 11),
+    refusalFrame(command: 0x10),
+  ])
+  var reply = [UInt8](repeating: 0, count: 11)
+  #expect(runRead(panel, reply: &reply) == .answeredZeros)
+  #expect(panel.reads == 2)
 }
 
 /// The write path, which none of this changes: an acknowledged write with no

--- a/CandelaKit/Tests/CandelaKitTests/DDCReplyFrameTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReplyFrameTests.swift
@@ -51,6 +51,51 @@ struct DDCReplyFrameTests {
         == .echoedDifferentCommand(expected: 0x10, got: 0x12))
   }
 
+  // MARK: - Which rejections are the panel's own answer
+
+  /// The one rejection that ends the retry ladder, enumerated against every
+  /// other one: a result code is a display that parsed the request and said no,
+  /// and the rest are frames that never carried an answer at all.
+  @Test func onlyAResultCodeRefusalIsTheDisplaysOwnAnswer() {
+    var refused = goodFrame()
+    refused[3] = 0x01
+    #expect(DDCReplyFrame.isRefusal(refused, of: 0x10))
+
+    // A usable answer is not a refusal either: the ladder returns on it for its
+    // own reason.
+    #expect(!DDCReplyFrame.isRefusal(goodFrame(), of: 0x10))
+    #expect(!DDCReplyFrame.isRefusal([UInt8](repeating: 0, count: 11), of: 0x10))
+    #expect(!DDCReplyFrame.isRefusal([0x6E, 0x88], of: 0x10))
+    var notAReply = goodFrame()
+    notAReply[2] = 0xE3
+    #expect(!DDCReplyFrame.isRefusal(notAReply, of: 0x10))
+    #expect(!DDCReplyFrame.isRefusal(goodFrame(command: 0x12), of: 0x10))
+  }
+
+  /// Every non-zero result code, not only the 0x01 the spec names: the field's
+  /// meaning is "the display processed this and reports an error", and a panel
+  /// answering 0x02 has answered.
+  @Test func anyNonZeroResultCodeIsARefusal() {
+    for code: UInt8 in [0x01, 0x02, 0xFF] {
+      var frame = goodFrame()
+      frame[3] = code
+      #expect(DDCReplyFrame.isRefusal(frame, of: 0x10))
+    }
+  }
+
+  /// A result code on a frame naming ANOTHER code is a stale or mis-addressed
+  /// reply, not an answer about this one, so it keeps its retries. `rejection`
+  /// reports the result code before it reaches the echo, which is why this is
+  /// checked separately rather than read off that enum.
+  @Test func aResultCodeEchoingAnotherCommandIsNotAnAnswerAboutThisOne() {
+    var frame = goodFrame(command: 0x12)
+    frame[3] = 0x01
+    #expect(DDCReplyFrame.rejection(for: frame, command: 0x10) == .displayReportedError(0x01))
+    #expect(!DDCReplyFrame.isRefusal(frame, of: 0x10))
+    // The panel that really was asked about 0x12 gets the early exit.
+    #expect(DDCReplyFrame.isRefusal(frame, of: 0x12))
+  }
+
   // MARK: - Big-endian decode
 
   /// The IntelDDC bug, pinned: `UInt16(high << 8)` shifts in UInt8 and yields

--- a/CandelaKit/Tests/CandelaKitTests/DDCValueControllerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCValueControllerTests.swift
@@ -692,6 +692,22 @@ struct DDCValueControllerTests {
     #expect(harness.prefs.muted)
   }
 
+  /// The same rule for this controller's `readMax`: the staleness fence drops
+  /// the VALUE a user write superseded, never the panel's reported scale, which
+  /// is not about intent at all. Dropped, later writes scale against the assumed
+  /// 100 until some other pass happens to answer.
+  @Test func aValueWriteDuringTheReadStillKeepsThePanelsScale() async {
+    let scripted = ScriptedDDC(reads: [(current: 30, max: 80)], hookAfterRead: 1)
+    let harness = Harness(command: .contrast, savedValue: 0.6, writer: scripted) { prefs in
+      prefs.startupAction = .read
+    }
+    let controller = harness.controller
+    await scripted.setHook { await MainActor.run { controller.setValue(0.9) } }
+    await harness.controller.refreshFromHardware()
+    #expect(harness.controller.value == 0.9, "the write is the newer intent")
+    #expect(harness.controller.readMax == 80)
+  }
+
   @Test func minimalPollingReadsExactlyOnce() async {
     // A bug that reads once regardless of tries — or five times under
     // .minimal — fails one of this pair.

--- a/CandelaKit/Tests/CandelaKitTests/DDCValueControllerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCValueControllerTests.swift
@@ -88,6 +88,36 @@ struct DDCValueControllerTests {
     func recordedWrites() -> [(command: UInt8, value: UInt16)] { writes }
   }
 
+  /// A panel whose registers answer differently: neither fake above can, and the
+  /// skip pin needs the value register silent while the mute register replies.
+  ///
+  /// `@unchecked Sendable` is not needed: an actor confines the state, and the
+  /// controller awaits every call.
+  private actor PerCommandDDC: DDCWriting {
+    private var answers: [UInt8: (current: UInt16, max: UInt16)]
+    private var readsByCommand: [UInt8: Int] = [:]
+    private var writes: [(command: UInt8, value: UInt16)] = []
+
+    init(_ answers: [UInt8: (current: UInt16, max: UInt16)]) { self.answers = answers }
+
+    func write(command: UInt8, value: UInt16) async -> Bool {
+      writes.append((command, value))
+      return true
+    }
+
+    func read(command: UInt8) async -> (current: UInt16, max: UInt16)? {
+      readsByCommand[command, default: 0] += 1
+      return answers[command]
+    }
+
+    func setAnswer(_ answer: (current: UInt16, max: UInt16)?, for command: UInt8) {
+      answers[command] = answer
+    }
+
+    func reads(of command: UInt8) -> Int { readsByCommand[command, default: 0] }
+    func recordedWrites() -> [(command: UInt8, value: UInt16)] { writes }
+  }
+
   // MARK: - Seeding
 
   @Test func volumeSeedsTheForkDefaultOfTwelvePointFivePercent() {
@@ -994,6 +1024,40 @@ struct DDCValueControllerTests {
 
     await harness.controller.refreshFromHardware()
     #expect(harness.controller.readEvidence == .noReply)
+  }
+
+  /// The read skip belongs to the VALUE register. VCP 0x8D is a different
+  /// register with its own answer, so a latched 0x62 must not stop the mute
+  /// readback: it is the only thing that tells this controller what state the
+  /// panel's own mute command is in, and a pass that skips it leaves the flag
+  /// standing on nothing.
+  ///
+  /// The readback adopts `isMuted` and nothing else. No write leaves this pass,
+  /// which the recorded writes assert.
+  @Test func alatchedValueRegisterStillReadsTheMuteRegister() async {
+    let panel = PerCommandDDC([VCP.audioMuteScreenBlank: (current: 2, max: 2)]) // unmuted
+    let harness = Harness(command: .volume, savedValue: 0.5, writer: panel) { prefs in
+      prefs.startupAction = .read
+      prefs.enableMuteUnmute = true // wire mode: the mute lives on 0x8D
+    }
+    // Two silent passes on 0x62 and the value register is latched.
+    await harness.controller.refreshFromHardware()
+    await harness.controller.refreshFromHardware()
+    #expect(harness.controller.readEvidence == .noReply)
+    #expect(harness.controller.isMuted == false)
+    let valueReads = await panel.reads(of: VCP.audioSpeakerVolume)
+    #expect(valueReads > 0, "control: the value register was asked before the latch")
+
+    // The panel is muted from its own buttons while the value register stays quiet.
+    await panel.setAnswer((current: 1, max: 2), for: VCP.audioMuteScreenBlank)
+    await harness.controller.refreshFromHardware()
+    #expect(
+      await panel.reads(of: VCP.audioSpeakerVolume) == valueReads,
+      "the latch still spares the value register"
+    )
+    #expect(harness.controller.isMuted, "the mute register was asked and its answer adopted")
+    #expect(harness.prefs.muted)
+    #expect(await panel.recordedWrites().isEmpty, "a readback writes nothing")
   }
 
   // MARK: - The mute queue's own drain (the register the strand is about)

--- a/CandelaKit/Tests/CandelaKitTests/DDCValueControllerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCValueControllerTests.swift
@@ -874,9 +874,14 @@ struct DDCValueControllerTests {
     #expect(harness.controller.readMax == nil) // nothing was learned; 100 is assumed
   }
 
-  @Test func asilentBusPublishesNoReply() async {
+  /// Two passes, unlike the zeros answer above: the Dell has answered silence on
+  /// a plug-in pass and a clean frame on the next. `BrightnessReadSkipTests` pins
+  /// the rule.
+  @Test func asilentBusPublishesNoReplyOnTheSecondPass() async {
     let harness = Harness(command: .contrast, savedValue: 0.6) { $0.startupAction = .read }
     await harness.controller.refreshFromHardware() // FakeDDC(readResult: nil) by default
+    #expect(harness.controller.readEvidence == .notAttempted)
+    await harness.controller.refreshFromHardware()
     #expect(harness.controller.readEvidence == .noReply)
   }
 
@@ -957,6 +962,10 @@ struct DDCValueControllerTests {
   /// this suite green: the case that separates them is a zeros answer followed by
   /// a pass that hears nothing, where the carried seed republishes `.allZeros`.
   /// Within a pass attempts still fold worst-wins; only the seed is per-pass.
+  ///
+  /// Zeros and silence are different findings, so the zeros pass does not count
+  /// towards the silence after it: taking them as a pair flipped this panel to
+  /// "Not answering" on one bad pass. The zeros verdict stands until the second.
   @Test func apassThatHearsOnlySilenceReportsSilenceNotTheOldZeros() async {
     let harness = Harness(command: .contrast, savedValue: 0.6) { $0.startupAction = .read }
     await harness.fake.setReadResult((current: 0, max: 0))
@@ -964,6 +973,9 @@ struct DDCValueControllerTests {
     #expect(harness.controller.readEvidence == .allZeros)
 
     await harness.fake.setReadResult(nil) // the bus goes quiet: every try returns nil
+    await harness.controller.refreshFromHardware()
+    #expect(harness.controller.readEvidence == .allZeros)
+
     await harness.controller.refreshFromHardware()
     #expect(harness.controller.readEvidence == .noReply)
   }

--- a/CandelaKit/Tests/CandelaKitTests/DDCWireDegradationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCWireDegradationTests.swift
@@ -185,11 +185,20 @@ struct DDCWireDegradationTests {
     await harness.ddc.setWritesSucceed(false)
     await failWrites(harness, count: 2)
 
-    await harness.controller.setHDRMode(.alwaysOn)
-    await harness.controller.setHDRMode(.off)
+    // Observe an external HDR window so no exit re-apply races the failure
+    // count. Candela's own HDR door is covered by the adjacent round-trip test.
+    await harness.hdr?.stubEnabled(true)
+    _ = await harness.hdr?.measuredHDREnabled(displayID: Harness.displayID)
+    await harness.controller.noteHDRStateMayHaveChanged()
+    await harness.hdr?.stubEnabled(false)
+    _ = await harness.hdr?.measuredHDREnabled(displayID: Harness.displayID)
+    await harness.controller.noteHDRStateMayHaveChanged()
 
     await failWrites(harness, count: 2, from: 0.75)
     #expect(!harness.controller.isWireUnresponsive)
+    // The counter must still work after the reset: one more failed write trips it.
+    await failWrites(harness, count: 1, from: 0.6)
+    #expect(harness.controller.isWireUnresponsive)
   }
 
   /// The built-in routes native, so nothing it does is evidence about a cable it

--- a/CandelaKit/Tests/CandelaKitTests/DiagnosticsCopyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DiagnosticsCopyTests.swift
@@ -17,11 +17,13 @@ struct DiagnosticsCopyTests {
 
   // MARK: - The three distinctions this type exists to keep
 
-  /// Readback has three answers past "not asked", not two. "Not answering" is a
-  /// display that stayed silent; "write-only" is one on the bus that takes every
-  /// command and never answers a read. That is the MAG, permanently, and folding
-  /// the two would delete the only sentence that names the fault.
-  @Test func readbackHasThreeAnswersAndNoneIsTheOther() {
+  /// Readback has four answers past "no answer recorded", not two. "Not
+  /// answering" is a display that stayed silent; "write-only" is one on the bus
+  /// that takes every command and never answers a read, which is the MAG,
+  /// permanently; a refusal is the display naming a code it does not carry, and
+  /// that one is not a fault at all. Folding any pair deletes a sentence that
+  /// names what happened.
+  @Test func readbackHasFourAnswersAndNoneIsTheOther() {
     #expect(
       DiagnosticsCopy.readEvidence(.answered, app: Self.app)
         == "This display answers reads")
@@ -32,22 +34,56 @@ struct DiagnosticsCopyTests {
       DiagnosticsCopy.readEvidence(.allZeros, app: Self.app)
         == "Write-only: this display takes commands but never answers a read")
     #expect(
+      DiagnosticsCopy.readEvidence(.refused, app: Self.app)
+        == "This display answered that it does not carry the value Candela asked for")
+    #expect(
       DiagnosticsCopy.readEvidence(.notAttempted, app: Self.app)
-        == "Candela has not read from this display")
+        == "Candela has not recorded an answer from this display yet")
 
-    // Four inputs, four sentences. A duplicate here is a collapsed state.
-    let all = [DDCReadEvidence.notAttempted, .answered, .allZeros, .noReply]
+    // Five inputs, five sentences. A duplicate here is a collapsed state.
+    let all = [DDCReadEvidence.notAttempted, .answered, .allZeros, .noReply, .refused]
       .map { DiagnosticsCopy.readEvidence($0, app: Self.app) }
-    #expect(Set(all).count == 4)
+    #expect(Set(all).count == 5)
+  }
+
+  /// The unasked sentences claim only what the record holds. One silent pass is
+  /// held rather than published (`DDCReadSkipLatch`), so a display that WAS asked
+  /// and said nothing back still reads `.notAttempted` here, and "has not read
+  /// from this display" was a claim about the wire that these cannot make.
+  @Test func theUnaskedSentencesSayNoAnswerRatherThanNoAttempt() {
+    for sentence in [
+      DiagnosticsCopy.readEvidence(.notAttempted, app: Self.app),
+      DiagnosticsCopy.readbackVerdict(.notAttempted),
+      DiagnosticsCopy.brightnessScale(
+        didReadMax: false, maxValue: 100, evidence: .notAttempted, app: Self.app),
+    ] {
+      #expect(sentence.lowercased().contains("answer"), "claims more than the record: \(sentence)")
+      #expect(!sentence.lowercased().contains("has not asked"), "claims more: \(sentence)")
+      #expect(!sentence.lowercased().contains("not asked yet"), "claims more: \(sentence)")
+    }
   }
 
   /// The short form the hub's chevron preview and the report's `readback:` field
   /// carry, capitalised as the page capitalises it.
-  @Test func theShortReadbackVerdictKeepsTheSameThreeStates() {
-    #expect(DiagnosticsCopy.readbackVerdict(.notAttempted) == "Not asked yet")
+  @Test func theShortReadbackVerdictKeepsEveryState() {
+    #expect(DiagnosticsCopy.readbackVerdict(.notAttempted) == "No answer recorded yet")
     #expect(DiagnosticsCopy.readbackVerdict(.answered) == "Answers reads")
     #expect(DiagnosticsCopy.readbackVerdict(.allZeros) == "Write-only")
     #expect(DiagnosticsCopy.readbackVerdict(.noReply) == "Not answering")
+    // The headline the fold exists for, at the surface that shows it: a display
+    // that replied is summarised as replying, whatever the reply said. This is a
+    // whole-display summary, and worst-of-three lands on a refusal only when
+    // nothing else was asked (brightness command off, volume refused), so the
+    // alternative was summarising a display by the one register it lacks.
+    #expect(DiagnosticsCopy.readbackVerdict(.refused) == "Answers reads")
+    #expect(
+      DiagnosticsCopy.readbackVerdict(
+        DDCReadEvidence.worst([.notAttempted, .refused, .notAttempted])) == "Answers reads")
+    // The distinction is not lost, only moved: the page's own sentence still
+    // names the refusal, and so does the per-command read log.
+    #expect(
+      DiagnosticsCopy.readEvidence(.refused, app: Self.app)
+        != DiagnosticsCopy.readEvidence(.answered, app: Self.app))
   }
 
   /// The capability request has FOUR states, and the middle two are the ones an
@@ -85,7 +121,7 @@ struct DiagnosticsCopyTests {
     #expect(
       DiagnosticsCopy.brightnessScale(
         didReadMax: false, maxValue: 100, evidence: .notAttempted, app: Self.app)
-        == "Assumed 100: Candela has not asked this display for its scale")
+        == "Assumed 100: Candela has not recorded an answer about this display's scale")
     #expect(
       DiagnosticsCopy.brightnessScale(
         didReadMax: false, maxValue: 100, evidence: .allZeros, app: Self.app)
@@ -93,6 +129,12 @@ struct DiagnosticsCopyTests {
     #expect(
       DiagnosticsCopy.brightnessScale(
         didReadMax: false, maxValue: 100, evidence: .noReply, app: Self.app)
+        == "Assumed 100: the display did not report one")
+    // A refused brightness register did report something, and what it reported
+    // is that there is nothing to report.
+    #expect(
+      DiagnosticsCopy.brightnessScale(
+        didReadMax: false, maxValue: 100, evidence: .refused, app: Self.app)
         == "Assumed 100: the display did not report one")
   }
 
@@ -453,6 +495,9 @@ struct DiagnosticsCopyTests {
     }
     #expect(verdict(.answered) == "Brightness is being sent to this display and accepted.")
     #expect(verdict(.notAttempted) == "Brightness is being sent to this display and accepted.")
+    // A refused register is not a caveat about the brightness command: it names
+    // a code the display does not carry.
+    #expect(verdict(.refused) == "Brightness is being sent to this display and accepted.")
     #expect(
       verdict(.allZeros)
         == "Brightness is being sent to this display and accepted, but it never answers a read.")
@@ -761,13 +806,13 @@ struct DiagnosticsCopyTests {
   /// bake in the literal.
   @Test func theProductNameIsNeverBakedIn() {
     let renamed = DiagnosticsCopy.readEvidence(.notAttempted, app: "Lumen")
-    #expect(renamed == "Lumen has not read from this display")
+    #expect(renamed == "Lumen has not recorded an answer from this display yet")
     #expect(!renamed.contains("Candela"))
 
     #expect(
       DiagnosticsCopy.brightnessScale(
         didReadMax: false, maxValue: 100, evidence: .notAttempted, app: "Lumen")
-        == "Assumed 100: Lumen has not asked this display for its scale")
+        == "Assumed 100: Lumen has not recorded an answer about this display's scale")
   }
 
   /// Hardware is always a "display" in user-visible copy. The type and
@@ -800,7 +845,7 @@ struct DiagnosticsCopyTests {
 
   /// Every sentence this type can produce, for the rules that bind all of them.
   private static func everySentence() -> [String] {
-    let evidences: [DDCReadEvidence] = [.notAttempted, .answered, .allZeros, .noReply]
+    let evidences: [DDCReadEvidence] = [.notAttempted, .answered, .allZeros, .noReply, .refused]
     let paths: [BrightnessPath] = [
       .native, .hardware, .software(.gamma), .software(.overlay),
       .combined(switchingValue: 0.25, backend: .gamma),

--- a/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
@@ -1,0 +1,75 @@
+import CoreGraphics
+import os
+import Testing
+@testable import CandelaKit
+
+/// `syncFromNativeBeforeStep`: the read a brightness key takes before it steps, so
+/// a value moved in Control Center while the poller was on its long interval does
+/// not jump back on the first press.
+@MainActor
+@Suite("Media-key freshness")
+struct MediaKeyFreshnessTests {
+  /// A panel whose brightness something else can move between calls.
+  private func makePanel(at value: Float) -> (Harness, OSAllocatedUnfairLock<Float>) {
+    let hardware = OSAllocatedUnfairLock(initialState: value)
+    let harness = Harness(role: .builtIn, readNative: { _ in hardware.withLock { $0 } })
+    return (harness, hardware)
+  }
+
+  private func near(_ a: Double, _ b: Double) -> Bool { abs(a - b) <= 1e-6 }
+
+  @Test func theStepStartsFromTheLiveRead() {
+    let (h, hardware) = makePanel(at: 0.5)
+    #expect(near(h.controller.brightness, 0.5))
+    hardware.withLock { $0 = 0.75 } // moved in Control Center, unobserved
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.75))
+    // One chiclet up from where the panel actually is.
+    #expect(h.controller.step(isUp: true, isFine: false) == 0.8125)
+  }
+
+  /// The positive control: without the read, the same press is the jump.
+  @Test func withoutTheReadTheFirstPressJumpsBack() {
+    let (h, hardware) = makePanel(at: 0.5)
+    hardware.withLock { $0 = 0.75 }
+    #expect(h.controller.step(isUp: true, isFine: false) == 0.5625)
+  }
+
+  @Test func aQueuedAdoptionIsRetired() {
+    let (h, hardware) = makePanel(at: 0.5)
+    let queued = h.controller.expectedNative().generation
+    hardware.withLock { $0 = 0.75 }
+    h.controller.syncFromNativeBeforeStep()
+    // An adoption the poller queued before the read describes an older look at the
+    // same panel, so it must not land on top of the fresh one.
+    #expect(h.controller.adoptExternal(0.4, generation: queued) == 0)
+    #expect(near(h.controller.brightness, 0.75))
+  }
+
+  @Test func quantizationNoiseIsNotAMove() {
+    let (h, hardware) = makePanel(at: 0.5)
+    hardware.withLock { $0 = 0.505 }
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.5))
+  }
+
+  /// Off the native path the register is DDC's, and this read must never go
+  /// looking for it.
+  @Test func nothingIsReadOffTheNativePath() async {
+    let h = Harness(hdrEnabled: false, readNative: { _ in 0.9 })
+    await h.prime()
+    h.controller.setBrightness(0.5)
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.5))
+  }
+
+  /// A read under a lock dim reads OUR write, not the user's value, and folding it
+  /// in would corrupt what the restore returns to.
+  @Test func nothingIsReadUnderATemporaryDim() {
+    let (h, hardware) = makePanel(at: 0.5)
+    h.controller.beginTemporaryDim(factor: 0.3)
+    hardware.withLock { $0 = 0.15 }
+    h.controller.syncFromNativeBeforeStep()
+    #expect(near(h.controller.brightness, 0.5))
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/MediaKeyFreshnessTests.swift
@@ -9,6 +9,37 @@ import Testing
 @MainActor
 @Suite("Media-key freshness")
 struct MediaKeyFreshnessTests {
+  @Test(arguments: [false, true])
+  func consecutiveKeysReachTheDisplayAfterAnExternalMove(isUp: Bool) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    #expect(panel.hardware.withLock { $0.value } == 0.5)
+    panel.hardware.withLock { $0.value = isUp ? 0.46 : 0.54 }
+
+    let expected: [Float] = isUp ? [0.5, 0.5625, 0.625] : [0.5, 0.4375, 0.375]
+    for value in expected {
+      panel.controller.syncFromNativeBeforeStep()
+      #expect(panel.controller.step(isUp: isUp, isFine: false) == Double(value))
+      await panel.controller.waitForPendingWrites()
+      #expect(panel.hardware.withLock { $0.value } == value)
+    }
+  }
+
+  @Test(arguments: [Float(0.5), Float(0.505)])
+  func unchangedReadsDoNotCauseRedundantWrites(read: Float) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    panel.hardware.withLock { $0.value = read }
+
+    panel.controller.syncFromNativeBeforeStep()
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+
+    #expect(panel.hardware.withLock { $0.writes } == [0.5])
+  }
+
   /// A panel whose brightness something else can move between calls.
   private func makePanel(at value: Float) -> (Harness, OSAllocatedUnfairLock<Float>) {
     let hardware = OSAllocatedUnfairLock(initialState: value)
@@ -71,5 +102,35 @@ struct MediaKeyFreshnessTests {
     hardware.withLock { $0 = 0.15 }
     h.controller.syncFromNativeBeforeStep()
     #expect(near(h.controller.brightness, 0.5))
+  }
+}
+
+/// Keeps the real controller, applier and coalescer; only the display I/O is replaced.
+@MainActor
+struct NativeFreshnessPanel {
+  let controller: BrightnessController
+  let hardware: OSAllocatedUnfairLock<(value: Float, writes: [Float])>
+
+  init(at value: Float) {
+    let hardware = OSAllocatedUnfairLock(initialState: (value: value, writes: [Float]()))
+    self.hardware = hardware
+    controller = BrightnessController(
+      writer: FakeDDC(readResult: nil),
+      backends: BrightnessBackends(
+        applierNative: NativeBrightnessApplier(displayID: 7, apply: { value, _ in
+          hardware.withLock {
+            $0.value = value
+            $0.writes.append(value)
+          }
+          return true
+        }),
+        hdr: nil, shade: nil, gamma: nil,
+        readNative: { _ in hardware.withLock { $0.value } }
+      ),
+      prefs: DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "native-freshness"),
+      displayID: 7,
+      role: .builtIn,
+      wireSiblings: []
+    )
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/ModeApplyVerificationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ModeApplyVerificationTests.swift
@@ -53,6 +53,17 @@ struct ModeApplyVerificationTests {
         == .honoured)
   }
 
+  /// The edges of the half-hertz tolerance: an NTSC rate and its integer twin
+  /// collapse into one match, a real neighbouring rate does not.
+  @Test func theRefreshToleranceCollapsesNTSCAndKeepsRealRatesApart() {
+    #expect(
+      ModeApplyVerification.verdict(requested: mode(hz: 60), achieved: mode(hz: 59.94))
+        == .honoured)
+    #expect(
+      ModeApplyVerification.verdict(requested: mode(hz: 60), achieved: mode(hz: 61))
+        == .unhonoured)
+  }
+
   /// No readable mode is not evidence the mode landed, so it takes the same
   /// answer as a miss.
   @Test func anUnreadableModeIsUnhonoured() {

--- a/CandelaKit/Tests/CandelaKitTests/ModeApplyVerificationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ModeApplyVerificationTests.swift
@@ -1,0 +1,83 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import CandelaKit
+
+/// `CGCompleteDisplayConfiguration` can return `.success` over a mode it did not
+/// apply; the mirroring path had already measured the platform doing that.
+@Suite("Mode apply verification")
+struct ModeApplyVerificationTests {
+  private func mode(
+    id: Int32 = 1,
+    logical: (Int, Int) = (2560, 1080),
+    pixels: (Int, Int) = (5120, 2160),
+    hz: Double = 120,
+    native: Bool = false
+  ) -> DisplayMode {
+    DisplayMode(
+      ioModeID: id, logicalWidth: logical.0, logicalHeight: logical.1,
+      pixelWidth: pixels.0, pixelHeight: pixels.1, refreshHz: hz, isNative: native)
+  }
+
+  /// The Dell publishes 42 pairs alike in everything but the mode number, and the
+  /// live read can answer with either, so an id compare would fail every apply.
+  @Test func equalGeometryUnderDifferentIdsIsHonoured() {
+    #expect(
+      ModeApplyVerification.verdict(requested: mode(id: 7), achieved: mode(id: 291)) == .honoured)
+  }
+
+  @Test func aSizeMissIsUnhonoured() {
+    #expect(
+      ModeApplyVerification.verdict(
+        requested: mode(), achieved: mode(logical: (1920, 1080))) == .unhonoured)
+    // The 1x twin of the same logical size: the display is scanning out half the
+    // pixels the user asked for.
+    #expect(
+      ModeApplyVerification.verdict(
+        requested: mode(), achieved: mode(pixels: (2560, 1080))) == .unhonoured)
+  }
+
+  /// A rate-only change looks identical on screen, so nobody answering the keep
+  /// card would notice a display left at the rate it started on.
+  @Test func aRefreshOnlyMissIsUnhonoured() {
+    #expect(
+      ModeApplyVerification.verdict(requested: mode(hz: 120), achieved: mode(hz: 60))
+        == .unhonoured)
+  }
+
+  /// CoreGraphics reports 59.997 for a 60 Hz mode, and an exact compare would
+  /// call every honoured apply a failure.
+  @Test func refreshNoiseIsStillHonoured() {
+    #expect(
+      ModeApplyVerification.verdict(requested: mode(hz: 60), achieved: mode(hz: 59.997))
+        == .honoured)
+  }
+
+  /// No readable mode is not evidence the mode landed, so it takes the same
+  /// answer as a miss.
+  @Test func anUnreadableModeIsUnhonoured() {
+    #expect(ModeApplyVerification.verdict(requested: mode(), achieved: nil) == .unhonoured)
+  }
+
+  /// `isNative` is a fact about the panel, not part of a mode's identity; the
+  /// live read carries whatever flag the panel reports.
+  @Test func theNativeFlagDoesNotDecideTheVerdict() {
+    #expect(
+      ModeApplyVerification.verdict(requested: mode(native: true), achieved: mode(native: false))
+        == .honoured)
+  }
+
+  /// Callers branch on this: only a refusal may be reported as "nothing changed",
+  /// so sharing `CGError.failure` with a never-opened transaction would hide it.
+  @Test func anUnhonouredCommitIsDistinguishableFromARefusal() {
+    let committed = DisplayConfigError(
+      unhonouredCommit: .init(requested: mode(), achieved: mode(logical: (1920, 1080))))
+    #expect(committed.didCommit)
+    #expect(committed.cgErrorCode == DisplayConfigError.unhonouredCommitCode)
+    #expect(committed.cgErrorCode != CGError.failure.rawValue)
+    #expect(committed.unhonouredCommit?.achieved?.logicalWidth == 1920)
+
+    #expect(!DisplayConfigError(cgErrorCode: CGError.failure.rawValue).didCommit)
+    #expect(!DisplayConfigError(cgErrorCode: -1).didCommit)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/ModeApplyVerificationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ModeApplyVerificationTests.swift
@@ -92,3 +92,150 @@ struct ModeApplyVerificationTests {
     #expect(!DisplayConfigError(cgErrorCode: -1).didCommit)
   }
 }
+
+/// The bounded settle both apply paths verify through. The window server lands a
+/// mode change asynchronously, so one immediate read can describe the OUTGOING
+/// mode and report an honoured apply as unhonoured.
+@Suite("Mode apply settle")
+struct ModeApplySettleTests {
+  private let configurator = CoreGraphicsDisplayConfigurator()
+
+  /// Time the test moves by hand, so the settle spends none.
+  private final class FakeClock {
+    private var seconds: TimeInterval = 0
+    func now() -> Date { Date(timeIntervalSinceReferenceDate: seconds) }
+    func advance(_ interval: TimeInterval) { seconds += interval }
+  }
+
+  /// An honoured apply pays nothing: the read is taken before any sleep.
+  @Test func aReadingThatAlreadyMatchesCostsOneRead() {
+    let clock = FakeClock()
+    var reads = 0
+    var sleeps = 0
+    let observed = configurator.settled(
+      now: clock.now, sleep: { sleeps += 1; clock.advance($0) },
+      read: {
+        reads += 1
+        return 7
+      }, until: { $0 == 7 })
+    #expect(observed == 7)
+    #expect(reads == 1)
+    #expect(sleeps == 0)
+  }
+
+  /// The whole point: a mode still landing on the first look is re-read rather
+  /// than reported as a divergence.
+  @Test func aLateArrivalIsSeenOnALaterRead() {
+    let clock = FakeClock()
+    var reads = 0
+    let observed = configurator.settled(
+      now: clock.now, sleep: { clock.advance($0) },
+      read: {
+        reads += 1
+        return reads < 3 ? 1 : 7
+      }, until: { $0 == 7 })
+    #expect(observed == 7)
+    #expect(reads == 3)
+  }
+
+  /// A change that never lands returns the LAST reading, not the first: the
+  /// caller reports what the display says now, and the error it throws carries
+  /// that geometry. Bounded, so a wedged display cannot hold the thread.
+  @Test func aChangeThatNeverLandsIsBoundedAndReturnsTheLastReading() {
+    let clock = FakeClock()
+    var reads = 0
+    var slept: TimeInterval = 0
+    let observed = configurator.settled(
+      now: clock.now,
+      sleep: {
+        slept += $0
+        clock.advance($0)
+      },
+      read: {
+        reads += 1
+        return reads
+      }, until: { _ in false })
+    #expect(observed == reads)
+    #expect(reads > 1)
+    // The bound, with one poll interval of overshoot allowed: the deadline is
+    // checked before each sleep rather than after it.
+    #expect(slept <= CoreGraphicsDisplayConfigurator.modeSettleWindow
+      + CoreGraphicsDisplayConfigurator.modeSettlePoll)
+  }
+
+  private func revealed(id: Int32) -> DisplayMode {
+    DisplayMode(
+      ioModeID: id, logicalWidth: 3440, logicalHeight: 1440,
+      pixelWidth: 6880, pixelHeight: 2880, refreshHz: 120, isNative: false)
+  }
+
+  /// Through the revealed path's OWN settle-and-verdict, not a predicate the test
+  /// wrote: the requested id is the one the loop keeps comparing against, so a
+  /// mode still landing on the first look is waited for rather than reported as a
+  /// divergence.
+  @Test func theRevealedSettleWaitsForTheRequestedId() {
+    let clock = FakeClock()
+    let mode = revealed(id: 291)
+    var reads = 0
+    let observed = configurator.settledRevealedModeID(
+      requested: mode, now: clock.now, sleep: { clock.advance($0) },
+      read: {
+        reads += 1
+        return reads < 3 ? 7 : mode.ioModeID
+      })
+    #expect(observed == mode.ioModeID)
+    #expect(reads == 3)
+  }
+
+  /// The requested side is FIXED across the loop, which is what "like with like"
+  /// means here: a read side that keeps changing to other ids never satisfies it,
+  /// and the loop ends on the bound with the last id read, which is what the
+  /// caller reports.
+  @Test func theRevealedSettleNeverAcceptsAnotherId() {
+    let clock = FakeClock()
+    let mode = revealed(id: 291)
+    var reads = 0
+    let observed = configurator.settledRevealedModeID(
+      requested: mode, now: clock.now, sleep: { clock.advance($0) },
+      read: {
+        reads += 1
+        return Int32(reads)
+      })
+    #expect(observed != mode.ioModeID)
+    #expect(observed == Int32(reads))
+    #expect(reads > 1)
+  }
+
+  /// A display that reports no mode at all is not one the mode landed on, and it
+  /// does not end the settle early either.
+  @Test func theRevealedSettleTreatsAnUnreadableModeAsNotLanded() {
+    let clock = FakeClock()
+    let mode = revealed(id: 291)
+    var reads = 0
+    let observed = configurator.settledRevealedModeID(
+      requested: mode, now: clock.now, sleep: { clock.advance($0) },
+      read: {
+        reads += 1
+        return reads < 2 ? nil : mode.ioModeID
+      })
+    #expect(observed == mode.ioModeID)
+    #expect(reads == 2)
+  }
+
+  /// An honoured revealed apply pays nothing: one read, no sleep.
+  @Test func theRevealedSettleCostsNothingOnAnHonouredApply() {
+    let clock = FakeClock()
+    let mode = revealed(id: 291)
+    var reads = 0
+    var sleeps = 0
+    let observed = configurator.settledRevealedModeID(
+      requested: mode, now: clock.now, sleep: { _ in sleeps += 1 },
+      read: {
+        reads += 1
+        return mode.ioModeID
+      })
+    #expect(observed == mode.ioModeID)
+    #expect(reads == 1)
+    #expect(sleeps == 0)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/ModePreviewSessionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ModePreviewSessionTests.swift
@@ -397,7 +397,7 @@ struct ModePreviewSessionTests {
     _ = await session.begin(mode: mode(2), on: 7)
 
     let previewed = await session.previewedMode
-    // The question is still the mode that was asked for: Keep re-applies it.
+    // The requested mode identifies the preview while recovery names the result.
     #expect(previewed?.mode == mode(2))
     #expect(previewed?.unhonouredCommit?.requested == mode(2))
     #expect(previewed?.unhonouredCommit?.achieved == mode(9))
@@ -441,17 +441,21 @@ struct ModePreviewSessionTests {
     #expect(await session.revert(answer(2)) == .reverted)
   }
 
-  /// Keep re-applies what the user ASKED for, so an unhonoured commit cannot
-  /// become permanent by being kept: the session-scope apply verifies again.
-  @Test func keepingAfterAnUnhonouredCommitCommitsTheRequestedMode() async {
+  /// A mode that never appeared cannot be approved by answering its recovery UI.
+  @Test func keepingAfterAnUnhonouredCommitAppliesNothing() async {
     let fake = FakeConfigurator()
     fake.current = mode(1)
     fake.divergeNextApplyTo = mode(9)
     let session = ModePreviewSession(configurator: fake)
     _ = await session.begin(mode: mode(2), on: 7)
 
-    #expect(await session.confirm(answer(2)) == .committed)
-    #expect(fake.applied.last == .init(modeID: 2, scope: .session))
+    let before = fake.applied
+    #expect(await session.confirm(answer(2)) != .committed)
+    #expect(fake.applied == before)
+    #expect(await session.hasOutstandingPreview)
+    #expect(await session.isCountingDown)
+    #expect(await session.revert(answer(2)) == .reverted)
+    #expect(fake.current == mode(1))
   }
 
   @Test func tickingAfterResolutionDoesNothing() async {
@@ -792,5 +796,131 @@ struct ModePreviewSessionTests {
 
     fake.failWith = nil
     #expect(await session.confirm(answer(2)) == .committed)
+  }
+}
+
+extension ModePreviewSessionTests {
+  private func distinctMode(
+    _ id: Int32, width: Int, height: Int,
+    provenance: ModeProvenance = .coreGraphics
+  ) -> DisplayMode {
+    DisplayMode(
+      ioModeID: id, logicalWidth: width, logicalHeight: height,
+      pixelWidth: width * 2, pixelHeight: height * 2,
+      refreshHz: 60, isNative: false, provenance: provenance)
+  }
+
+  @Test func keepCannotCommitARevealedModeThatWasNeverPreviewed() async {
+    let original = distinctMode(1, width: 1720, height: 720)
+    let requested = distinctMode(
+      2, width: 2048, height: 858, provenance: .coreGraphicsServices)
+    let actuallyPreviewed = distinctMode(9, width: 1920, height: 804)
+    let fake = FakeConfigurator()
+    fake.current = original
+    fake.divergeNextApplyTo = actuallyPreviewed
+    let session = ModePreviewSession(configurator: fake, countdownSeconds: 30)
+    let started = await session.begin(mode: requested, on: 7)
+    #expect(started.failureError == nil)
+    #expect(fake.current == actuallyPreviewed)
+    #expect(fake.applied == [.init(modeID: requested.ioModeID, scope: .preview)])
+    #expect(await session.previewedMode?.unhonouredCommit?.achieved == actuallyPreviewed)
+
+    let answer = PreviewedMode(displayID: 7, mode: requested)
+    let outcome = await session.confirm(answer)
+
+    // This answer was given while another mode was visible. Only a fresh
+    // preview can make the requested mode eligible for a session commit.
+    #expect(outcome != .committed)
+    #expect(!fake.applied.contains(.init(modeID: requested.ioModeID, scope: .session)))
+    #expect(await session.hasOutstandingPreview)
+    #expect(await session.isCountingDown)
+
+    // A rejected Keep preserves the original rollback.
+    #expect(await session.revert(answer) == .reverted)
+    #expect(fake.current == original)
+  }
+
+  @Test func achievedEvidenceFollowsRepeatedCommittedFailures() async {
+    let original = distinctMode(1, width: 1720, height: 720)
+    let requested = distinctMode(2, width: 2048, height: 858)
+    let firstAchieved = distinctMode(9, width: 1920, height: 804)
+    let secondAchieved = distinctMode(8, width: 1280, height: 536)
+    let fake = FakeConfigurator()
+    fake.current = original
+    fake.divergeNextApplyTo = firstAchieved
+    let session = ModePreviewSession(configurator: fake, countdownSeconds: 30)
+    let started = await session.begin(mode: requested, on: 7)
+    #expect(started.failureError == nil)
+    #expect(await session.previewedMode?.unhonouredCommit?.achieved == firstAchieved)
+
+    fake.divergeNextApplyTo = secondAchieved
+    let answer = PreviewedMode(displayID: 7, mode: requested)
+    let outcome = await session.revert(answer)
+    let secondFailure = DisplayConfigError(
+      unhonouredCommit: .init(requested: original, achieved: secondAchieved))
+    #expect(outcome == .failed(secondFailure))
+    #expect(fake.current == secondAchieved)
+    #expect(await session.hasOutstandingPreview)
+
+    // All three confirmation surfaces use this field for the present-tense
+    // sentence identifying the resolution the display is showing.
+    #expect(await session.previewedMode?.unhonouredCommit?.achieved == secondAchieved)
+
+    // A later refusal moves nothing and must not erase the latest observation.
+    fake.failWith = DisplayConfigError(cgErrorCode: CGError.cannotComplete.rawValue)
+    _ = await session.revert(answer)
+    #expect(fake.current == secondAchieved)
+    #expect(await session.previewedMode?.unhonouredCommit?.achieved == secondAchieved)
+  }
+}
+
+extension ModePreviewSessionTests {
+  @Test func aDelayedRecoveryAnswerCannotKeepAFreshPreviewOfTheSameMode() async throws {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    fake.divergeNextApplyTo = mode(9)
+    let session = ModePreviewSession(configurator: fake)
+    _ = await session.begin(mode: mode(2), on: 7)
+    let recoveryAnswer = try #require(await session.previewedMode)
+    _ = await session.begin(mode: mode(2), on: 7)
+    let before = fake.applied
+    #expect(await session.confirm(recoveryAnswer) == .stale)
+    #expect(fake.applied == before)
+    #expect(await session.isCountingDown)
+    #expect(await session.confirm(answer(2)) == .committed)
+  }
+
+  @Test func aFailedKeepUpdatesEvidenceAndRefusesADelayedSecondKeep() async throws {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    let session = ModePreviewSession(configurator: fake)
+    _ = await session.begin(mode: mode(2), on: 7)
+    let renderedBeforeFailure = try #require(await session.previewedMode)
+    fake.divergeNextApplyTo = mode(9)
+    let failure = PreviewOutcome.failed(
+      DisplayConfigError(unhonouredCommit: .init(requested: mode(2), achieved: mode(9))))
+    #expect(await session.confirm(renderedBeforeFailure) == failure)
+    #expect(await session.previewedMode?.unhonouredCommit?.achieved == mode(9))
+    let before = fake.applied
+    #expect(await session.confirm(renderedBeforeFailure) == failure)
+    #expect(fake.applied == before)
+    #expect(await session.isCountingDown)
+    #expect(await session.revert(renderedBeforeFailure) == .reverted)
+    #expect(fake.current == mode(1))
+  }
+
+  @Test func aRefusedFreshPreviewPreservesRecoveryEvidenceAndTheFallback() async {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    fake.divergeNextApplyTo = mode(9)
+    let session = ModePreviewSession(configurator: fake, countdownSeconds: 1)
+    _ = await session.begin(mode: mode(2), on: 7)
+    fake.failWith = DisplayConfigError(cgErrorCode: 1001)
+    #expect(await session.begin(mode: mode(3), on: 7).failureError != nil)
+    #expect(await session.previewedMode?.unhonouredCommit?.achieved == mode(9))
+    #expect(await session.confirm(answer(3)) == .stale)
+    fake.failWith = nil
+    #expect(await session.tick() == .reverted)
+    #expect(fake.current == mode(1))
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/ModePreviewSessionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ModePreviewSessionTests.swift
@@ -29,6 +29,7 @@ final class FakeConfigurator: DisplayConfiguring, @unchecked Sendable {
   private var _current: DisplayMode?
   private var _failWith: DisplayConfigError?
   private var _failOnlyDisplay: CGDirectDisplayID?
+  private var _divergeNextApplyTo: DisplayMode?
   private var _available: [DisplayMode] = []
   private var _appliedMirroring: [AppliedMirroring] = []
   private var _configuredDisplays: [ConfiguredDisplay] = []
@@ -62,6 +63,15 @@ final class FakeConfigurator: DisplayConfiguring, @unchecked Sendable {
   var failOnlyDisplay: CGDirectDisplayID? {
     get { lock.withLock { _failOnlyDisplay } }
     set { lock.withLock { _failOnlyDisplay = newValue } }
+  }
+
+  /// Accept the next apply, COMMIT it, and put the display on a different mode:
+  /// the measured `CGCompleteDisplayConfiguration` behaviour. One-shot, like
+  /// `divergeNextMirroringTo`, so the recovery can land. Distinct from
+  /// `failWith`, which refuses before anything moves.
+  var divergeNextApplyTo: DisplayMode? {
+    get { lock.withLock { _divergeNextApplyTo } }
+    set { lock.withLock { _divergeNextApplyTo = newValue } }
   }
 
   var available: [DisplayMode] {
@@ -116,6 +126,14 @@ final class FakeConfigurator: DisplayConfiguring, @unchecked Sendable {
       }
       _applied.append(Applied(modeID: mode.ioModeID, scope: scope))
       _appliedDisplayIDs.append(displayID)
+      // Recorded and moved BEFORE the throw, the way production does it: this
+      // transaction committed, and only then did the readback disagree.
+      if let diverted = _divergeNextApplyTo {
+        _divergeNextApplyTo = nil
+        _current = diverted
+        throw DisplayConfigError(
+          unhonouredCommit: .init(requested: mode, achieved: diverted))
+      }
       _current = mode
     }
   }
@@ -347,6 +365,37 @@ struct ModePreviewSessionTests {
     let result = await session.begin(mode: mode(2), on: 7)
     #expect(result.failureError == DisplayConfigError(cgErrorCode: 1001))
     #expect(fake.applied.isEmpty)
+  }
+
+  /// The readback can fail on a commit that WENT THROUGH. Refusing the preview
+  /// there would leave a mode nobody picked on the glass with no countdown.
+  @Test func aCommittedButUnhonouredApplyArmsTheRevertRatherThanRefusing() async {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    fake.divergeNextApplyTo = mode(9)
+    let session = ModePreviewSession(configurator: fake, countdownSeconds: 1)
+
+    let result = await session.begin(mode: mode(2), on: 7)
+    #expect(result.failureError == nil)
+    #expect(await session.hasOutstandingPreview)
+    #expect(await session.isCountingDown)
+    // Back to the mode captured BEFORE the apply, never the one CoreGraphics
+    // substituted for it.
+    #expect(await session.tick() == .reverted)
+    #expect(fake.applied.last == .init(modeID: 1, scope: .session))
+  }
+
+  /// Keep re-applies what the user ASKED for, so an unhonoured commit cannot
+  /// become permanent by being kept: the session-scope apply verifies again.
+  @Test func keepingAfterAnUnhonouredCommitCommitsTheRequestedMode() async {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    fake.divergeNextApplyTo = mode(9)
+    let session = ModePreviewSession(configurator: fake)
+    _ = await session.begin(mode: mode(2), on: 7)
+
+    #expect(await session.confirm(answer(2)) == .committed)
+    #expect(fake.applied.last == .init(modeID: 2, scope: .session))
   }
 
   @Test func tickingAfterResolutionDoesNothing() async {

--- a/CandelaKit/Tests/CandelaKitTests/ModePreviewSessionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ModePreviewSessionTests.swift
@@ -385,6 +385,62 @@ struct ModePreviewSessionTests {
     #expect(fake.applied.last == .init(modeID: 1, scope: .session))
   }
 
+  /// What the commit ACHIEVED travels out with the preview. Without it the
+  /// surfaces asking "keep this resolution?" can name only the resolution that
+  /// was asked for, on a screen showing something else, and the person
+  /// answering has no way to see the difference.
+  @Test func anUnhonouredCommitTravelsOutWithThePreview() async {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    fake.divergeNextApplyTo = mode(9)
+    let session = ModePreviewSession(configurator: fake)
+    _ = await session.begin(mode: mode(2), on: 7)
+
+    let previewed = await session.previewedMode
+    // The question is still the mode that was asked for: Keep re-applies it.
+    #expect(previewed?.mode == mode(2))
+    #expect(previewed?.unhonouredCommit?.requested == mode(2))
+    #expect(previewed?.unhonouredCommit?.achieved == mode(9))
+  }
+
+  /// The control: an honoured commit carries nothing, so no surface can draw
+  /// that caption over an ordinary preview.
+  @Test func anHonouredCommitCarriesNoAchievedGeometry() async {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    let session = ModePreviewSession(configurator: fake)
+    _ = await session.begin(mode: mode(2), on: 7)
+
+    #expect(await session.previewedMode?.unhonouredCommit == nil)
+  }
+
+  /// A second pick on the same display replaces it: the divergence belonged to
+  /// the apply that is now history, and a stale caption would name a resolution
+  /// nothing is showing.
+  @Test func aFreshPreviewDoesNotInheritTheLastOnesDivergence() async {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    fake.divergeNextApplyTo = mode(9)
+    let session = ModePreviewSession(configurator: fake)
+    _ = await session.begin(mode: mode(2), on: 7)
+    #expect(await session.previewedMode?.unhonouredCommit != nil)
+
+    _ = await session.begin(mode: mode(3), on: 7)
+    #expect(await session.previewedMode?.unhonouredCommit == nil)
+  }
+
+  /// An ANSWER is matched on the display and the mode alone, so a surface that
+  /// rendered the preview before the divergence was known still resolves it.
+  @Test func anAnswerCarryingNoAchievedGeometryStillResolvesThePreview() async {
+    let fake = FakeConfigurator()
+    fake.current = mode(1)
+    fake.divergeNextApplyTo = mode(9)
+    let session = ModePreviewSession(configurator: fake)
+    _ = await session.begin(mode: mode(2), on: 7)
+
+    #expect(await session.revert(answer(2)) == .reverted)
+  }
+
   /// Keep re-applies what the user ASKED for, so an unhonoured commit cannot
   /// become permanent by being kept: the session-scope apply verifies again.
   @Test func keepingAfterAnUnhonouredCommitCommitsTheRequestedMode() async {

--- a/CandelaKit/Tests/CandelaKitTests/OledCareCadenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/OledCareCadenceTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import CandelaKit
+
+/// The cadence term a displayed nomination gets, and the state test the fast
+/// term and the input monitor share. The three-term truth table this extends
+/// lives in `LockDimTests`.
+@Suite("OLED care cadence (displayed nomination)")
+struct OledCareCadenceNominationTests {
+  /// The defect: the old fast term counted any overlay, so a nomination on an
+  /// `.active` display held the loop at 10 Hz. No input clears that mask.
+  @Test func aDisplayedNominationTicksAtTheWindowFollowIntervalRatherThanFast() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: true
+      ) == OledCareCadence.windowFollow
+    )
+    #expect(OledCareCadence.windowFollow == .seconds(1))
+  }
+
+  /// The geometry refresh under the mask is throttled at one second, so the
+  /// slow fall-through would double the wait a moved window's dim sheds in.
+  @Test func theWindowFollowIntervalSitsBetweenFastAndSlow() {
+    #expect(OledCareCadence.fast < OledCareCadence.windowFollow)
+    #expect(OledCareCadence.windowFollow < OledCareCadence.slow)
+  }
+
+  /// Every term that means a restore is owed still outranks it: the mask can
+  /// wait a second, a person's input cannot wait past the restore gate.
+  @Test func everyFastTermOutranksADisplayedNomination() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: true, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: true
+      ) == OledCareCadence.fast
+    )
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: true, verificationPending: false,
+        nominationDisplayed: true
+      ) == OledCareCadence.fast
+    )
+    // A mask change sets the verification marker, which is how a new mask still
+    // lands its achieved-state check at 100 ms.
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: true,
+        nominationDisplayed: true
+      ) == OledCareCadence.fast
+    )
+  }
+
+  /// Nothing on screen, nothing to follow: the term has to be off for the idle
+  /// cost this exists to cut to be cut at all.
+  @Test func noNominationLeavesTheOtherTermsAlone() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: false
+      ) == OledCareCadence.slow
+    )
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: false, anythingEnrolled: false
+      ) == OledCareCadence.idle
+    )
+    // The default matters: the parameter was added below the three the existing
+    // truth table passes, and every one of those cells omits it.
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false
+      ) == OledCareCadence.slow
+    )
+  }
+
+  /// A mask on screen is work in flight, whatever the caller believes about
+  /// enrollment. Contradictory input, decided toward the shorter interval for
+  /// the reason `anythingEnrolled` defaults to true.
+  @Test func aDisplayedNominationOutranksTheIdleFallThrough() {
+    #expect(
+      OledCareCadence.interval(
+        anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+        nominationDisplayed: true, anythingEnrolled: false
+      ) == OledCareCadence.windowFollow
+    )
+  }
+
+  /// The states an input event should end. `.active` is excluded even though it
+  /// can hold a nomination overlay, and `.suspended` holds nothing to end.
+  @Test func onlyTheDimsAnInputEndsLiftOnInput() {
+    #expect(OledDimState.idleDim.liftsOnInput)
+    #expect(OledDimState.blackout.liftsOnInput)
+    #expect(OledDimState.lockDim.liftsOnInput)
+    #expect(OledDimState.unfocusedDim.liftsOnInput)
+    #expect(!OledDimState.active.liftsOnInput)
+    #expect(!OledDimState.suspended.liftsOnInput)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/PrefPropagationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PrefPropagationTests.swift
@@ -185,6 +185,12 @@ struct PrefPropagationTests {
     // row is added to it, not swapped in.
     #expect(PrefPropagation.effects(forChange: .unavailableDDC)
       == [.refreshUI, .rearmTap, .reapplyDimming, .rebuildPanel])
+    // Sync is one of the poll cadence's consumers, so turning it on rebuilds the
+    // poll job rather than leaving it asleep on a long interval. It still writes
+    // nothing to hardware: no `.reapplyDimming`.
+    #expect(PrefPropagation.effects(forChange: .enableBrightnessSync)
+      == [.refreshUI, .rebuildPanel, .restartBrightnessPoll])
+    #expect(!PrefPropagation.effects(forChange: .showContrast).contains(.restartBrightnessPoll))
   }
 
   @Test func oledCarePrefsFanOutToOledCare() {

--- a/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
@@ -9,6 +9,36 @@ import Testing
 @MainActor
 @Suite("Surface brightness read")
 struct SurfaceBrightnessReadTests {
+  @Test(arguments: [false, true])
+  func aKeyAfterSurfaceAdoptionReachesTheDisplay(isUp: Bool) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    #expect(panel.hardware.withLock { $0.value } == 0.5)
+    panel.hardware.withLock { $0.value = isUp ? 0.46 : 0.54 }
+
+    #expect(panel.controller.adoptNativeForSurface() != 0)
+    panel.controller.syncFromNativeBeforeStep()
+    #expect(panel.controller.step(isUp: isUp, isFine: false) == 0.5)
+    await panel.controller.waitForPendingWrites()
+
+    #expect(panel.hardware.withLock { $0.value } == 0.5)
+  }
+
+  @Test(arguments: [Float(0.5), Float(0.505)])
+  func unchangedSurfaceReadsDoNotCauseRedundantWrites(read: Float) async {
+    let panel = NativeFreshnessPanel(at: 0.75)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+    panel.hardware.withLock { $0.value = read }
+
+    #expect(panel.controller.adoptNativeForSurface() == 0)
+    panel.controller.setBrightness(0.5)
+    await panel.controller.waitForPendingWrites()
+
+    #expect(panel.hardware.withLock { $0.writes } == [0.5])
+  }
+
   /// An external on the native path (HDR live), with a panel something else can
   /// move between calls and a store seeded with the value published at launch.
   private func nativeExternal(

--- a/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/SurfaceBrightnessReadTests.swift
@@ -1,0 +1,136 @@
+import CoreGraphics
+import os
+import Testing
+@testable import CandelaKit
+
+/// `adoptNativeForSurface`: the read a surface takes as it opens. Unlike the key
+/// route it has no `step()` behind it to write the value down, so it publishes,
+/// persists and hands back a delta for the sync fan-out.
+@MainActor
+@Suite("Surface brightness read")
+struct SurfaceBrightnessReadTests {
+  /// An external on the native path (HDR live), with a panel something else can
+  /// move between calls and a store seeded with the value published at launch.
+  private func nativeExternal(
+    at value: Float
+  ) async -> (Harness, OSAllocatedUnfairLock<Float>) {
+    let hardware = OSAllocatedUnfairLock(initialState: value)
+    let h = Harness(
+      hdrEnabled: true,
+      settle: .milliseconds(5),
+      seed: [Harness.storageKey: 1.0],
+      readNative: { _ in hardware.withLock { $0 } }
+    )
+    await h.prime()
+    await h.controller.setHDRMode(.alwaysOn)
+    // The entry assert submits; drained here so the in-flight gate is not what the
+    // assertions below are measuring.
+    await h.controller.waitForPendingWrites()
+    return (h, hardware)
+  }
+
+  private func near(_ a: Double, _ b: Double) -> Bool { abs(a - b) <= 1e-6 }
+
+  @Test func aSurfaceReadPersistsWhatItPublishes() async {
+    let (h, hardware) = await nativeExternal(at: 1.0)
+    #expect(h.store.values[Harness.storageKey] == 1.0)
+    hardware.withLock { $0 = 0.75 } // moved in Control Center, unobserved
+
+    let delta = h.controller.adoptNativeForSurface()
+
+    #expect(near(h.controller.brightness, 0.75))
+    #expect(near(delta, -0.25))
+    // The defect this pins: the bare snap published 0.75 and left 1.0 in the store,
+    // which is what the next launch restore would have written to the glass.
+    #expect(near(h.store.values[Harness.storageKey] ?? -1, 0.75))
+  }
+
+  @Test func aSurfaceReadDuringConvergenceIsANoOp() async {
+    let (h, hardware) = await nativeExternal(at: 1.0)
+    let generation = h.controller.expectedNative().generation
+    h.controller.adoptExternal(0.6, generation: generation)
+    #expect(h.controller.isConvergingFromExternal())
+    let published = h.controller.brightness
+    let stored = h.store.values[Harness.storageKey]
+    hardware.withLock { $0 = 0.6 }
+
+    #expect(h.controller.adoptNativeForSurface() == 0)
+
+    // The poller owns this move and lands it within a few ticks, fanning each eased
+    // step out as it goes; ending it here would leave the other displays short.
+    #expect(h.controller.brightness == published)
+    #expect(h.store.values[Harness.storageKey] == stored)
+    #expect(h.controller.isConvergingFromExternal())
+  }
+
+  @Test func nothingIsReadWhileTheEpochIsClosed() async {
+    let (h, hardware) = await nativeExternal(at: 1.0)
+    h.controller.setEpochProvider({ 1 }, isCurrent: { _ in false })
+    hardware.withLock { $0 = 0.75 }
+
+    #expect(h.controller.adoptNativeForSurface() == 0)
+    #expect(near(h.controller.brightness, 1.0))
+
+    // The positive control: the same read with the epoch open takes the value, so
+    // the assertion above is about the gate and not about a read that never works.
+    h.controller.setEpochProvider({ 1 }, isCurrent: { _ in true })
+    #expect(h.controller.adoptNativeForSurface() != 0)
+    #expect(near(h.controller.brightness, 0.75))
+  }
+}
+
+/// A native applier that holds every write until released, so a test can keep the
+/// coalescer's queue in flight without racing its drain.
+private actor GatedNativeApplier: BrightnessApplying {
+  nonisolated let accepts = HardwareTargetKind.native
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  private var released = false
+
+  func apply(_: HardwareTarget) async -> Bool {
+    if !released {
+      await withCheckedContinuation { waiters.append($0) }
+    }
+    return true
+  }
+
+  func release() {
+    released = true
+    for waiter in waiters { waiter.resume() }
+    waiters.removeAll()
+  }
+}
+
+/// The freshness read's in-flight gate, on the panel that has key repeat and no DDC
+/// wire. Its own suite because the applier has to be gated at construction.
+@MainActor
+@Suite("Freshness read against a queued write")
+struct FreshnessReadInFlightTests {
+  @Test func nothingIsReadWhileOurOwnWriteIsStillQueued() async {
+    let hardware = OSAllocatedUnfairLock<Float>(initialState: 0.75)
+    let applier = GatedNativeApplier()
+    let controller = BrightnessController(
+      writer: FakeDDC(readResult: nil),
+      backends: BrightnessBackends(
+        applierNative: applier, hdr: nil, shade: nil, gamma: nil,
+        readNative: { _ in hardware.withLock { $0 } }
+      ),
+      prefs: DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "t"),
+      displayID: 7,
+      role: .builtIn,
+      wireSiblings: []
+    )
+    #expect(controller.brightness == 0.75)
+
+    controller.setBrightness(0.5)
+    // The panel has not moved yet: the write is parked in the applier. A key repeat
+    // reading here would snap published state back to 0.75 and re-step from it.
+    controller.syncFromNativeBeforeStep()
+    #expect(controller.brightness == 0.5)
+
+    // The positive control: once the queue is empty the same read is taken.
+    await applier.release()
+    await controller.waitForPendingWrites()
+    controller.syncFromNativeBeforeStep()
+    #expect(controller.brightness == 0.75)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import CandelaKit
+
+@Suite("Media-key tap lifecycle")
+struct TapLifecyclePolicyTests {
+  private let brightness: Set<MediaKey> = [.brightnessUp, .brightnessDown]
+  private let everything: Set<MediaKey> = [
+    .brightnessUp, .brightnessDown, .volumeUp, .volumeDown, .mute,
+  ]
+
+  @Test func watchingNothingAndStillWatchingNothingDoesNothing() {
+    #expect(TapLifecyclePolicy.action(previous: [], next: [], grantHeld: true) == .nothing)
+  }
+
+  @Test func theFirstWatchedKeyStartsTheTap() {
+    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: true) == .start)
+    #expect(TapLifecyclePolicy.action(previous: [], next: [.mute], grantHeld: true) == .start)
+  }
+
+  @Test func losingTheLastWatchedKeyStopsTheTap() {
+    #expect(TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: true) == .stop)
+    #expect(TapLifecyclePolicy.action(previous: everything, next: [], grantHeld: true) == .stop)
+  }
+
+  /// Equal sets included: the flag for the alternate brightness keys rides the
+  /// same config and reaches the tap only through a reconfigure.
+  @Test func aTapThatStaysUpIsReconfigured() {
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: true)
+        == .reconfigure)
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: brightness, grantHeld: true)
+        == .reconfigure)
+    #expect(
+      TapLifecyclePolicy.action(previous: everything, next: [.mute], grantHeld: true)
+        == .reconfigure)
+  }
+
+  @Test func nothingStartsWithoutTheGrant() {
+    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: false) == .nothing)
+    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: false) == .nothing)
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: false)
+        == .nothing)
+    #expect(
+      TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: false) == .nothing)
+  }
+
+  /// No armed set at all is a tap that could not be built, not a tap watching
+  /// nothing, and this path is not the one that can fix it.
+  @Test func aTapThatNeverArmedIsNotRestartedFromHere() {
+    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: true) == .nothing)
+    #expect(TapLifecyclePolicy.action(previous: nil, next: [], grantHeld: true) == .nothing)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
@@ -55,8 +55,20 @@ struct TapLifecyclePolicyTests {
   @Test func aTapThatFailedToArmIsRetriedOnTheNextEdge() {
     #expect(action(previous: nil, next: brightness) == .start)
     #expect(action(previous: nil, next: [.mute]) == .start)
-    // Still nothing to watch, so still nothing to build.
-    #expect(action(previous: nil, next: []) == .nothing)
+  }
+
+  /// Nothing to watch and no tap to watch with. Nothing is built, but the empty set
+  /// is still committed: left unrecorded it reads as a tap that could not run, and
+  /// diagnostics says "not running" for keys released on purpose.
+  @Test func wantingNothingWithNoTapRecordsTheEmptySet() {
+    #expect(action(previous: nil, next: []) == .recordEmpty)
+  }
+
+  /// The grant outranks it: with no grant no tap can run, which is what "not
+  /// running" means, so there is no empty set to commit.
+  @Test func nothingIsRecordedWithoutTheGrant() {
+    #expect(action(previous: nil, next: [], grantHeld: false) == .nothing)
+    #expect(action(previous: [], next: [], grantHeld: false) == .nothing)
   }
 
   /// The one failure a retry cannot fix; without the latch every reconfigure and

--- a/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/TapLifecyclePolicyTests.swift
@@ -8,48 +8,66 @@ struct TapLifecyclePolicyTests {
     .brightnessUp, .brightnessDown, .volumeUp, .volumeDown, .mute,
   ]
 
+  /// The ordinary rig: the grant is held and the tap can run. A cell that is
+  /// about either of those says so.
+  private func action(
+    previous: Set<MediaKey>?,
+    next: Set<MediaKey>,
+    grantHeld: Bool = true,
+    permanentlyUnavailable: Bool = false
+  ) -> TapLifecycleAction {
+    TapLifecyclePolicy.action(
+      previous: previous, next: next,
+      grantHeld: grantHeld, permanentlyUnavailable: permanentlyUnavailable)
+  }
+
   @Test func watchingNothingAndStillWatchingNothingDoesNothing() {
-    #expect(TapLifecyclePolicy.action(previous: [], next: [], grantHeld: true) == .nothing)
+    #expect(action(previous: [], next: []) == .nothing)
   }
 
   @Test func theFirstWatchedKeyStartsTheTap() {
-    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: true) == .start)
-    #expect(TapLifecyclePolicy.action(previous: [], next: [.mute], grantHeld: true) == .start)
+    #expect(action(previous: [], next: brightness) == .start)
+    #expect(action(previous: [], next: [.mute]) == .start)
   }
 
   @Test func losingTheLastWatchedKeyStopsTheTap() {
-    #expect(TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: true) == .stop)
-    #expect(TapLifecyclePolicy.action(previous: everything, next: [], grantHeld: true) == .stop)
+    #expect(action(previous: brightness, next: []) == .stop)
+    #expect(action(previous: everything, next: []) == .stop)
   }
 
   /// Equal sets included: the flag for the alternate brightness keys rides the
   /// same config and reaches the tap only through a reconfigure.
   @Test func aTapThatStaysUpIsReconfigured() {
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: true)
-        == .reconfigure)
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: brightness, grantHeld: true)
-        == .reconfigure)
-    #expect(
-      TapLifecyclePolicy.action(previous: everything, next: [.mute], grantHeld: true)
-        == .reconfigure)
+    #expect(action(previous: brightness, next: everything) == .reconfigure)
+    #expect(action(previous: brightness, next: brightness) == .reconfigure)
+    #expect(action(previous: everything, next: [.mute]) == .reconfigure)
   }
 
   @Test func nothingStartsWithoutTheGrant() {
-    #expect(TapLifecyclePolicy.action(previous: [], next: brightness, grantHeld: false) == .nothing)
-    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: false) == .nothing)
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: everything, grantHeld: false)
-        == .nothing)
-    #expect(
-      TapLifecyclePolicy.action(previous: brightness, next: [], grantHeld: false) == .nothing)
+    #expect(action(previous: [], next: brightness, grantHeld: false) == .nothing)
+    #expect(action(previous: nil, next: brightness, grantHeld: false) == .nothing)
+    #expect(action(previous: brightness, next: everything, grantHeld: false) == .nothing)
+    #expect(action(previous: brightness, next: [], grantHeld: false) == .nothing)
   }
 
-  /// No armed set at all is a tap that could not be built, not a tap watching
-  /// nothing, and this path is not the one that can fix it.
-  @Test func aTapThatNeverArmedIsNotRestartedFromHere() {
-    #expect(TapLifecyclePolicy.action(previous: nil, next: brightness, grantHeld: true) == .nothing)
-    #expect(TapLifecyclePolicy.action(previous: nil, next: [], grantHeld: true) == .nothing)
+  /// A nil armed set is usually a start that failed for something a later one need
+  /// not hit, so the next edge that wants keys tries again.
+  @Test func aTapThatFailedToArmIsRetriedOnTheNextEdge() {
+    #expect(action(previous: nil, next: brightness) == .start)
+    #expect(action(previous: nil, next: [.mute]) == .start)
+    // Still nothing to watch, so still nothing to build.
+    #expect(action(previous: nil, next: []) == .nothing)
+  }
+
+  /// The one failure a retry cannot fix; without the latch every reconfigure and
+  /// menu close would retry and re-log, forever.
+  @Test func aPermanentlyUnavailableTapIsNeverRetried() {
+    #expect(action(previous: nil, next: brightness, permanentlyUnavailable: true) == .nothing)
+    #expect(action(previous: [], next: brightness, permanentlyUnavailable: true) == .nothing)
+    #expect(action(previous: nil, next: [], permanentlyUnavailable: true) == .nothing)
+    // The app cannot reach this pairing: the latch is set only where a start
+    // failed, and that state records no watched set. Answered anyway.
+    #expect(
+      action(previous: brightness, next: everything, permanentlyUnavailable: true) == .nothing)
   }
 }


### PR DESCRIPTION
Mode changes, DDC reads and write pacing now use achieved display state. Merge #59 first. This branch includes #59 and its fixes, with the poller overlap resolved, so the remaining diff narrows to this work once #59 lands.

Addresses #52. The remaining manual hardware checks were deferred and the issue closed at the maintainer's request; unrun checks are documented below.

## What changed
- **A mode apply is verified.** The published-mode path re-reads the current mode after the commit with a bounded settle and compares geometry, never the mode identifier, then throws a distinct committed-but-unhonoured error carrying what the display shows. A preview treats that as the display having moved and arms the revert countdown with the mode it captured before applying; the checkup sweep records it as not observed with the achieved geometry; the failure copy and the tooltips for mode applies no longer print a CoreGraphics code for a commit CoreGraphics reported as successful (mirroring and arrangement keep their existing wording); an unhonoured preview offers Revert only and cannot Keep an unseen mode. Settings, the floating window, the menu panel and guided setup explain recovery and show the latest achieved geometry. Failed committed Keep/Revert attempts update that evidence; refusals before commit preserve it. The original fallback and countdown survive failures, and an old recovery answer cannot approve a fresh preview of the same mode.
- **A failed DDC reply read is a failure, and a refusal is an answer.** The transport tracks the reply read separately from the write, fills the reply buffer with a sentinel so only a buffer the panel changed to zeros counts as answered-with-zeros, retries a failed read call once and a malformed frame up to the full ladder, ends the ladder on a result-code refusal that echoes the asked command, and surfaces frame, zeros, refused or silent, which the controllers map to their read evidence. A refused register ranks as an answer in the display's summary and stops only its own reads. The MAG now reads as Write-only instead of Not answering.
- **A silent panel is asked twice, then skipped.** The brightness, volume and contrast controllers skip their read while their own evidence says the panel never answers, latching only after two consecutive counting passes of the same nothing; a read pass triggered by a display reconfiguration discards silence outright, since a renegotiating link is silent by measurement. Wake, every reconfiguration, a rebind and an HDR exit clear the skip; a rebind or change to the first effective read register resets the displayed verdict and learned maximum. Correcting a refused remap therefore retries the new register immediately. Trailing write-only remap changes preserve the read latch. Results from an old in-flight register generation cannot alter the new register's evidence or scale. A busy-bus miss on a panel that answers never shows as Not answering. A read result is adopted only if no write was issued since it began, while the panel's reported maximum is recorded regardless.
- **DDC write pacing is measured.** Each display's service records when its last I2C call returned and a write sleeps only the part of the 10 ms floor the bus still owes, shared across the services discovery rebuilds on every refresh. An isolated write reaches the wire at once; back-to-back writes, a read followed by a write, retries and the capabilities read keep exactly the spacing they had.

## Verification
Current head `c430405e` includes #59 and has the same tree as the deployed integration build: `e0f1c09d1444ef21c578b19dcf1f02aa3de34f62`.

- 2,512 engine tests passed in 20 consecutive full runs during a Release build; 560 app tests passed after project regeneration.
- New regression coverage checks no write on recovery Keep, retryable rollback, latest achieved evidence, stale recovery answers, all recovery copy, and first-register changes for brightness, volume and contrast, including in-flight changes.
- Original failing cases were reproduced before the fixes. Poll cadence and HDR-reset tests also fail under deliberate mutations of their production behavior; their fixes are shared with #59.
- Release build, debug-marker scan with a positive control, and Developer ID signing checks passed before and after installation.
- On this build, built-in native brightness stepped correctly after an external move, including a repeated previous target; original brightness was restored. The rotated Dell previewed 1296 x 2304 at 120 Hz and Revert restored 1440 x 2560 at 120 Hz. The normal confirmation banner was visually inspected. The app read a valid DDC frame from the Dell and zeros from the write-only MAG after deployment and mode changes.

Earlier hardware measurements for the original changes (not repeated in full for this follow-up):

On the rig: the Dell's Diagnostics row reads "Answers reads" and the MAG's "Write-only" (was "Not answering"), and both survive two reconfigurations during which the Dell answered silent on the busy wire each time; the DDC read log names each panel by its hashed tag with the outcome; a mode apply and revert on the rotated Dell through the probe read back the applied mode both ways with no false failure; a six-key brightness burst coalesced to two writes and `candela-probe get` read the register at the last written value; write start-to-end fell to 2 to 5 ms on an idle bus from the 10 ms floor; the MAG in HDR and back out left the poller and the read evidence in the expected states.

Deferred at the maintainer's request when merging (not recorded as passed): the forced-mismatch recovery UI and keyboard/VoiceOver behavior on a live display (covered by engine/app tests, but not reproduced on hardware), changing a refused remap to a supported register in the running app, a sleep and wake cycle for the wake clear, an unattended reapply across a dock cycle, a refused register under the Ask-the-display startup action (the Dell's volume register, read from the log as outcome=refused). Recorded on the branch as a decision rather than shipped: skipping the pacing floor entirely on a successful write, which needs Dell readback evidence first. One class limit to know: a sink that takes longer than half a second to report a committed mode (some TVs, DisplayLink adapters) would have every honoured pick arm its countdown with the old geometry; the three panels here all report within the window.
