### PR TITLE
Prepare version 1.0.3

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -70,7 +70,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.rydersel.Candela
-        MARKETING_VERSION: "1.0.2"
+        MARKETING_VERSION: "1.0.3"
         # One number, not two: the build number is the version. Sparkle compares
         # CFBundleVersion, so every shipped build needs its own value, and a
         # direct-download app has no reason to hide a rebuild behind an


### PR DESCRIPTION
Prepare both app version fields for 1.0.3 after the focused fixes in #62, #63, #64, #66, #69 and #73.

The combined candidate passed all 2,512 engine and 586 app tests, Release compilation, the debug-marker scan with its positive control, and Developer ID signing checks. Both app version fields equal 1.0.3. The app and disk image passed notarization, stapling and Gatekeeper checks, and Sparkle installed the exact signed candidate executable. Live checks passed for display-mode feedback and recovery, audio-route refresh, layout corrections, post-update navigation and confirmation, and Copy/Save Report.

The final merged source must match the verified candidate before the release tag and distribution feeds are published.
