### PR TITLE
Cache wallpaper failures and skip unused sampling

### DIFF
--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -8,9 +8,8 @@ import os
 /// OLED care: the idle/blackout timers, the care dim and the hours tracker.
 ///
 /// Owned by `AppModel` for `DisplayModeCoordinator`'s reason: the timers must
-/// outlive whatever window or pane started them. Unlike the sibling
-/// coordinators it takes no dependencies at init: `start(model:)` hands it the
-/// model once, held weakly, and everything else is resolved fresh per tick.
+/// outlive whatever window or pane started them. `start(model:)` hands it the
+/// model once, held weakly, and display state is resolved fresh per tick.
 ///
 /// Shape rules this type is built around, each measured or ruled:
 ///
@@ -232,7 +231,20 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// section reads it.
   private var comparisons: [String: ModelComparison] = [:]
   /// The exposure model's wallpaper backdrop; its cache lives inside it.
-  @ObservationIgnored private let wallpaper = WallpaperLuminanceSource()
+  @ObservationIgnored private let wallpaper: WallpaperLuminanceSource
+
+  @ObservationIgnored private let windowList: (CGDirectDisplayID) -> [WindowSnapshot]
+
+  init(
+    wallpaper: WallpaperLuminanceSource = WallpaperLuminanceSource(),
+    windowList: @escaping (CGDirectDisplayID) -> [WindowSnapshot] = {
+      CGWindowListSource(displayID: $0).onScreenWindows()
+    }
+  ) {
+    self.wallpaper = wallpaper
+    self.windowList = windowList
+  }
+
   /// The most recent accepted reading, panel-native, for the hero's live
   /// thermal view. Not history: it is the frame the accumulator just folded
   /// in, kept so a surface can show what the display looked like at the last
@@ -556,6 +568,7 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// state under freshly resolved IDs, never `repinFrames()` alone, which would
   /// pin an overlay to the wrong panel.
   func displaysReconfigured() {
+    wallpaper.invalidate()
     guard let model, !model.isSafeMode, !resetting else { return }
     clearAllOverlays()
     // Old IDs may already name different panels, so pending removal checks
@@ -1482,7 +1495,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     guard let transform = Self.transform(target),
       let cached = latestSamples[key]
     else { return }
-    let windows = CGWindowListSource(displayID: target.surface).onScreenWindows()
+    let windows = windowList(target.surface)
     var observer = observers[key] ?? WindowObserver()
     let observation = observer.observe(windows, through: transform, at: Date())
     observers[key] = observer
@@ -1592,10 +1605,10 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// Constructed at the point of use rather than stored: the source is a display
   /// ID and one method, and IDs reassign across a replug. This cannot go stale,
   /// because the ID it gets is the one this tick resolved.
-  private func observeWindows(
+  func observeWindows(
     for key: String, on surface: CGDirectDisplayID, through transform: PanelSpaceTransform
   ) {
-    let windows = CGWindowListSource(displayID: surface).onScreenWindows()
+    let windows = windowList(surface)
     // Mutated IN PLACE: `observe` is mutating on a value type, and a local copy
     // would discard every window's age on return, so the stationary threshold
     // could never be reached.
@@ -1616,13 +1629,6 @@ final class OledCareCoordinator: CheckupCareHolding {
     owners.accumulate(observation, elapsed: Self.seconds(Self.samplingInterval))
     ownerHours[key] = owners
 
-    // The model's other inputs run on this permission-free clock too, not only
-    // beside a measured sample: the wallpaper source logs each recompute with
-    // the Screen Recording preflight inline, which is the standing evidence that
-    // the estimate's inputs stay readable while the grant is absent.
-    let appearanceIsDark =
-      NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-    _ = wallpaper.panelGrid(for: surface, appearanceIsDark: appearanceIsDark, through: transform)
     // Only a booked observation dirties the store: an all-uncovered panel adds
     // nothing, and marking it dirty would re-encode an unchanged value.
     if owners.hours.totalSeconds > before { unsavedExposureKeys.insert(key) }
@@ -1730,7 +1736,7 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// so both sides of the comparison cover identical instants and a grant
   /// outage stops them together. Runs inside the accepted branch, so the
   /// epoch, pref, ID, transform and qualification re-checks have all passed.
-  private func bookComparisonPair(
+  func bookComparisonPair(
     for key: String, on target: OledTelemetryTarget,
     measured: [Double], through transform: PanelSpaceTransform
   ) {
@@ -1744,7 +1750,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     // panel has no `NSScreen` for the wallpaper lookup to match at all, so
     // asking about the panel here would compare a measured desktop against a
     // model that fell back to the appearance prior.
-    let windows = CGWindowListSource(displayID: target.surface).onScreenWindows()
+    let windows = windowList(target.surface)
     let appearanceIsDark =
       NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     let wallpaperCells = wallpaper.panelGrid(

--- a/Candela/OledCare/WallpaperLuminanceSource.swift
+++ b/Candela/OledCare/WallpaperLuminanceSource.swift
@@ -116,8 +116,23 @@ final class WallpaperLuminanceSource {
   }
 
   /// One entry per display, so a scheduled-rotation wallpaper cannot grow the
-  /// cache without bound over a multi-week soak.
-  private var cache: [CGDirectDisplayID: (key: CacheKey, cells: [Double])] = [:]
+  /// cache without bound over a multi-week soak. A nil grid remembers an
+  /// unreadable file until its identity changes or the cache is invalidated.
+  private var cache: [CGDirectDisplayID: (key: CacheKey, cells: [Double]?)] = [:]
+
+  private let wallpaperURL: (CGDirectDisplayID) -> URL?
+
+  init(wallpaperURL: @escaping (CGDirectDisplayID) -> URL? = { displayID in
+    guard let screen = WallpaperLuminanceSource.screen(for: displayID) else { return nil }
+    return NSWorkspace.shared.desktopImageURL(for: screen)
+  }) {
+    self.wallpaperURL = wallpaperURL
+  }
+
+  /// Drop sampled and unreadable entries after display reconfiguration.
+  func invalidate() {
+    cache.removeAll()
+  }
 
   /// Panel-physical wallpaper luminance for `displayID`, or nil when the
   /// display has no resolvable screen or the wallpaper cannot be read. Nil is
@@ -127,9 +142,7 @@ final class WallpaperLuminanceSource {
     for displayID: CGDirectDisplayID, appearanceIsDark: Bool,
     through transform: PanelSpaceTransform
   ) -> [Double]? {
-    guard let screen = Self.screen(for: displayID),
-      let url = NSWorkspace.shared.desktopImageURL(for: screen)
-    else {
+    guard let url = wallpaperURL(displayID) else {
       Self.reportRecompute(displayID: displayID, readable: false, appearanceIsDark: appearanceIsDark)
       cache.removeValue(forKey: displayID)
       return nil
@@ -143,11 +156,7 @@ final class WallpaperLuminanceSource {
     let cells = Self.computeGrid(url: url, through: transform)
     Self.reportRecompute(
       displayID: displayID, readable: cells != nil, appearanceIsDark: appearanceIsDark)
-    if let cells {
-      cache[displayID] = (key, cells)
-    } else {
-      cache.removeValue(forKey: displayID)
-    }
+    cache[displayID] = (key, cells)
     return cells
   }
 

--- a/CandelaAppTests/WallpaperLuminanceSourceTests.swift
+++ b/CandelaAppTests/WallpaperLuminanceSourceTests.swift
@@ -1,0 +1,116 @@
+import AppKit
+import CandelaKit
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+
+@Suite("Wallpaper luminance cache") @MainActor
+struct WallpaperLuminanceSourceTests {
+  private let transform = PanelSpaceTransform(
+    displaySize: CGSize(width: 1920, height: 1080), rotation: .standard)
+
+  private func temporaryURL() -> URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".png")
+  }
+
+  private func writeWhiteImage(to url: URL) throws {
+    let context = try #require(CGContext(
+      data: nil, width: 16, height: 16, bitsPerComponent: 8, bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(), bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue))
+    context.setFillColor(CGColor(gray: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 16, height: 16))
+    let image = try #require(context.makeImage())
+    let destination = try #require(CGImageDestinationCreateWithURL(
+      url as CFURL, UTType.png.identifier as CFString, 1, nil))
+    CGImageDestinationAddImage(destination, image, nil)
+    #expect(CGImageDestinationFinalize(destination))
+  }
+
+  @Test("Unreadable wallpaper stays memoized after its file becomes readable")
+  func failureIsMemoized() throws {
+    let url = temporaryURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+    try Data("not an image".utf8).write(to: url)
+    let source = WallpaperLuminanceSource(wallpaperURL: { _ in url })
+    #expect(source.panelGrid(for: 1, appearanceIsDark: false, through: transform) == nil)
+    try writeWhiteImage(to: url)
+    for _ in 0..<3 {
+      #expect(source.panelGrid(for: 1, appearanceIsDark: false, through: transform) == nil)
+    }
+  }
+
+  @Test("Each wallpaper identity component permits retry", arguments: ["url", "appearance", "size", "rotation"])
+  func changedIdentityRetries(component: String) throws {
+    let first = temporaryURL()
+    let second = temporaryURL()
+    defer {
+      try? FileManager.default.removeItem(at: first)
+      try? FileManager.default.removeItem(at: second)
+    }
+    var url = first
+    let source = WallpaperLuminanceSource(wallpaperURL: { _ in url })
+    #expect(source.panelGrid(for: 1, appearanceIsDark: false, through: transform) == nil)
+    try writeWhiteImage(to: first)
+    try writeWhiteImage(to: second)
+    if component == "url" { url = second }
+    let changed = PanelSpaceTransform(
+      displaySize: component == "size" ? CGSize(width: 1080, height: 1920) : transform.displaySize,
+      rotation: component == "rotation" ? .ninety : .standard)
+    let cells = try #require(source.panelGrid(
+      for: 1, appearanceIsDark: component == "appearance", through: changed))
+    #expect(cells.count == 240)
+    #expect(cells.allSatisfy { abs($0 - 1) < 0.000001 })
+    try Data("unreadable again".utf8).write(to: url)
+    #expect(source.panelGrid(
+      for: 1, appearanceIsDark: component == "appearance", through: changed) == cells)
+  }
+
+  @Test("Successful cache retains sampled luminance until explicitly invalidated")
+  func successfulCacheAndInvalidation() throws {
+    let url = temporaryURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+    try writeWhiteImage(to: url)
+    let source = WallpaperLuminanceSource(wallpaperURL: { _ in url })
+    let cells = try #require(source.panelGrid(for: 1, appearanceIsDark: false, through: transform))
+    #expect(cells.count == 240)
+    #expect(cells.allSatisfy { abs($0 - 1) < 0.000001 })
+    try Data("unreadable".utf8).write(to: url)
+    #expect(source.panelGrid(for: 1, appearanceIsDark: false, through: transform) == cells)
+    source.invalidate()
+    #expect(source.panelGrid(for: 1, appearanceIsDark: false, through: transform) == nil)
+    try writeWhiteImage(to: url)
+    #expect(source.panelGrid(for: 1, appearanceIsDark: false, through: transform) == nil)
+    source.invalidate()
+    #expect(source.panelGrid(for: 1, appearanceIsDark: false, through: transform) == cells)
+  }
+
+  @Test("Window observation skips wallpaper while comparison consumes its luminance")
+  func consumers() throws {
+    _ = NSApplication.shared
+    let url = temporaryURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+    try writeWhiteImage(to: url)
+    var requestedDisplays: [CGDirectDisplayID] = []
+    let source = WallpaperLuminanceSource(wallpaperURL: {
+      requestedDisplays.append($0)
+      return url
+    })
+    let coordinator = OledCareCoordinator(wallpaper: source, windowList: { _ in [] })
+    let key = UUID().uuidString
+    // A controlled empty desktop makes the wallpaper the entire model input.
+    let surface: CGDirectDisplayID = 0xFFFF_FFFE
+    coordinator.observeWindows(for: key, on: surface, through: transform)
+    #expect(requestedDisplays.isEmpty)
+    #expect(coordinator.modelComparison(for: key).pairCount == 0)
+    let target = OledTelemetryTarget(panel: surface, topology: MirrorTopology([]))
+    coordinator.bookComparisonPair(
+      for: key, on: target, measured: Array(repeating: 0.5, count: 240), through: transform)
+    #expect(requestedDisplays == [surface])
+    let comparison = coordinator.modelComparison(for: key)
+    #expect(comparison.pairCount == 1)
+    #expect(comparison.modelledCells.allSatisfy { abs($0 - 60) < 0.000001 })
+    #expect(comparison.measuredCells.allSatisfy { abs($0 - 30) < 0.000001 })
+  }
+}


### PR DESCRIPTION
## What
Cache failed wallpaper decodes under the same identity as successful samples, and stop requesting wallpaper data during window observation when its result is unused.

## Why
An unreadable wallpaper previously triggered repeated decoding and logging. Observation also requested a grid that only the exposure comparison consumes. Successful comparison sampling and recompute diagnostics remain unchanged. Cache identity changes and display reconfiguration allow retries.

Addresses the wallpaper portion of #53. Its other care changes remain open.

## Hardware verification
This change needs no display writes. Real ImageIO fixtures verify failed and successful caches, URL/appearance/size/rotation changes, and explicit invalidation. The coordinator test proves observation skips wallpaper while comparison still consumes its luminance. Recompute logging and the Screen Recording diagnostic remain unchanged.

## Checks
- Full engine suite: 2,512 tests passed.
- Host-free app suite: 564 tests passed.
- Regression tests failed against the original behavior before the fix; the real comparison remained a passing positive control.
- Independent specification and code review passed.
- Public commit gate and whitespace checks passed.
