### PR TITLE
Show progress and prevent repeat resolution selections

### DIFF
--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -290,7 +290,17 @@ final class DisplayModeCoordinator {
   /// that window queues behind it and would commit the NEW mode while the banner
   /// still named the old one: correct ordering, wrong intent. Set synchronously so
   /// the disable lands in the same body evaluation as the click.
-  private(set) var isApplying = false
+  var isApplying: Bool { !pendingSelections.isEmpty }
+
+  struct ApplyingSelection {
+    let mode: DisplayMode
+    let displayID: CGDirectDisplayID
+  }
+
+  /// The first queued selection owns the current change, even when another
+  /// caller has already queued a different size or display behind it.
+  var applyingSelection: ApplyingSelection? { pendingSelections.first }
+  private var pendingSelections: [ApplyingSelection] = []
   /// Displays whose user has applied a size in THIS session: a person who
   /// just chose a size has answered the recommendation for now, and the durable
   /// opt-out is the dismissal pref.
@@ -375,7 +385,6 @@ final class DisplayModeCoordinator {
   @ObservationIgnored private var surfaces: [CGDirectDisplayID: PreviewSurface] = [:]
   @ObservationIgnored private let countdown = PreviewCountdownDriver()
   @ObservationIgnored private let queue = PreviewQueue()
-  @ObservationIgnored private var inFlightSelects = 0
   /// Displays anything has asked about. `handleDisplaysChanged` re-enumerates
   /// these rather than only the cached ones, so a display that departs and returns
   /// under the same ID gets its catalog back: a nil catalog renders as nothing at
@@ -1033,10 +1042,9 @@ final class DisplayModeCoordinator {
   ) {
     // Raised HERE, synchronously, not inside the queued operation: the banner's
     // buttons have to be disabled by the time the reconfiguration starts, so
-    // nobody can confirm a mode they are not reading. Counted rather than boolean,
-    // so two queued selects do not have the first completion clear the flag.
-    inFlightSelects += 1
-    isApplying = true
+    // nobody can confirm a mode they are not reading. Retain each request so
+    // busy feedback names the active operation across the entire queue.
+    pendingSelections.append(ApplyingSelection(mode: mode, displayID: displayID))
     queue.enqueue {
       // Routed on PROVENANCE: a synthesized row's sentinel mode ID denotes
       // nothing in either mode-ID space, so no configuration transaction could
@@ -1047,8 +1055,7 @@ final class DisplayModeCoordinator {
       } else {
         await self.performSelect(mode, on: displayID, from: origin, surface: surface)
       }
-      self.inFlightSelects -= 1
-      if self.inFlightSelects == 0 { self.isApplying = false }
+      self.pendingSelections.removeFirst()
     }
   }
 
@@ -1065,7 +1072,8 @@ final class DisplayModeCoordinator {
     _ mode: DisplayMode, on displayID: CGDirectDisplayID,
     from origin: PreviewOrigin, surface: PreviewSurface, currentModeID: Int32?
   ) {
-    guard mode.ioModeID != currentModeID else { return }
+    // The view may not have redrawn its disabled state before a repeat click.
+    guard !isApplying, mode.ioModeID != currentModeID else { return }
     select(mode, on: displayID, from: origin, surface: surface)
   }
 

--- a/Candela/Settings/AllModesPage.swift
+++ b/Candela/Settings/AllModesPage.swift
@@ -71,6 +71,10 @@ struct AllModesPage: View {
   /// list at all.
   private var listMode: ListMode { chosenListMode ?? .recommended }
 
+  private var feedback: ModeChangeFeedback {
+    ModeChangeFeedback(coordinator: coordinator, displayID: displayID)
+  }
+
   var body: some View {
     // The scaffold's reading variant: it owns the scroller, and the two hooks
     // that land the page on the mode in use need that scroller's proxy.
@@ -90,6 +94,9 @@ struct AllModesPage: View {
       // RESOLVED mode, so a catalog arriving and flipping the default scrolls.
       .onChange(of: listMode) { _, _ in scrollToCurrent(proxy) }
 
+      if let caption = feedback.caption {
+        SettingsRowNote(verbatim: caption)
+      }
       // A nil catalog is "not enumerated yet", NOT "no modes". It renders as
       // nothing, so no empty state flashes on every push.
       if let catalog {
@@ -521,6 +528,7 @@ struct AllModesPage: View {
         }
       }
     }
+    .disabled(feedback.controlsDisabled)
     .id(row.id)
     .focused($focusedRow, equals: row.id)
   }
@@ -921,12 +929,13 @@ private struct ModeChoiceButtonStyle: ButtonStyle {
   let isHovering: Bool
   let isCurrent: Bool
   let accent: Color
+  @Environment(\.isEnabled) private var isEnabled
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
       .background(shape.fill(fill(pressed: configuration.isPressed)))
       .overlay(ring)
-      .opacity(configuration.isPressed ? 0.85 : 1)
+      .opacity(isEnabled ? (configuration.isPressed ? 0.85 : 1) : SettingsTheme.disabledOpacity)
   }
 
   private var shape: RoundedRectangle {

--- a/Candela/Settings/ResolutionRows.swift
+++ b/Candela/Settings/ResolutionRows.swift
@@ -2,6 +2,25 @@ import CandelaKit
 import CoreGraphics
 import SwiftUI
 
+/// Shared presentation for every Settings size and rate control. Both the
+/// disable and its explanation read the coordinator's live operation queue.
+@MainActor
+struct ModeChangeFeedback {
+  let coordinator: DisplayModeCoordinator
+  let displayID: CGDirectDisplayID
+
+  var controlsDisabled: Bool { coordinator.isApplying }
+
+  var caption: String? {
+    guard coordinator.isApplying, let selection = coordinator.applyingSelection else { return nil }
+    let target = selection.displayID == displayID ? "this display" : "another display"
+    if selection.mode.isSynthesized {
+      return "Applying a rendered size on \(target). This can take tens of seconds; size and refresh rate controls are unavailable until it finishes."
+    }
+    return "Changing \(target). Size and refresh rate controls are unavailable until it finishes."
+  }
+}
+
 /// The one apply path every resolution control in the settings window goes
 /// through. A value rather than a method on a view, because two panes offer the
 /// same choice and a second copy would be a second place to get the preview
@@ -36,8 +55,8 @@ struct ResolutionSelection {
 
   func apply(_ mode: DisplayMode, in catalog: DisplayModeCoordinator.Catalog) {
     // No `Task` here. `selectFromList` is fire-and-forget into the
-    // coordinator's queue, which is what serialises two fast clicks; one Task
-    // per click is how the banner ends up naming a different mode than the one
+    // coordinator's queue, with a synchronous busy guard for repeat clicks; one
+    // Task per click is how the banner ends up naming a different mode than the one
     // "Keep" would commit.
     //
     // `.settings` routes a failed `begin()` to the banner region, which the
@@ -77,12 +96,19 @@ struct DisplaySizeRows: View {
     )
   }
 
+  private var feedback: ModeChangeFeedback {
+    ModeChangeFeedback(coordinator: model.displayModes, displayID: displayID)
+  }
+
   var body: some View {
+    if let caption = feedback.caption {
+      SettingsRowNote(verbatim: caption)
+    }
     if !catalog.rows.isEmpty {
       SettingRow("Changes how big text and windows look.") {
-        sizePicker
+        sizePicker.disabled(feedback.controlsDisabled)
       }
-      refreshPicker
+      refreshPicker.disabled(feedback.controlsDisabled)
       synthesizedRateRow
     } else if !catalog.all.isEmpty {
       // Every size this panel reports is under the usability floor, so the

--- a/CandelaAppTests/Fakes/SynthesisFakes.swift
+++ b/CandelaAppTests/Fakes/SynthesisFakes.swift
@@ -171,6 +171,8 @@ final class FakeSynthesisDisplayConfigurator: DisplayConfiguring, @unchecked Sen
   var onMirrorApplied: (@Sendable () -> Void)?
   /// Throw from `apply`, to reach the engage tail's bounce fallback.
   var refusesModeApplies = false
+  /// Suspends a hardware apply so tests can observe the coordinator mid-change.
+  var onModeApply: (@Sendable () -> Void)?
   /// A committed mode failure for coordinator recovery tests, consumed once.
   var nextModeApplyFailure: DisplayConfigError?
 
@@ -196,6 +198,7 @@ final class FakeSynthesisDisplayConfigurator: DisplayConfiguring, @unchecked Sen
   /// the call. The tail's achieved-state check then answers false, which is what
   /// puts the bounce under test.
   func apply(_ mode: DisplayMode, to displayID: CGDirectDisplayID, scope _: DisplayConfigScope) throws {
+    onModeApply?()
     if refusesModeApplies { throw DisplayConfigError(cgErrorCode: CGError.failure.rawValue) }
     world.recordApply(mode, to: displayID)
     if let failure = nextModeApplyFailure {

--- a/CandelaAppTests/ModeChangeFeedbackTests.swift
+++ b/CandelaAppTests/ModeChangeFeedbackTests.swift
@@ -1,0 +1,196 @@
+import CandelaKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@Suite("Settings mode change feedback") @MainActor
+struct ModeChangeFeedbackTests {
+  @Test func repeatedListRequestsCannotReplaceTheChangeAlreadyStarting() async throws {
+    let fixture = SynthesisFixture(secondPanel: true)
+    defer { fixture.forgetPrefs() }
+    let first = try #require(fixture.modes.catalogs[SynthesisFixture.panelID])
+    let second = try #require(fixture.modes.catalogs[SynthesisFixture.secondPanelID])
+    let wanted = try #require(first.all.first { $0.ioModeID == 2 })
+    let selection = ResolutionSelection(
+      coordinator: fixture.modes, displayID: SynthesisFixture.panelID, surface: .settingsBanner
+    )
+    let current = try #require(first.current)
+    selection.apply(current, in: first)
+    expectIdle(fixture.modes)
+    #expect(fixture.modes.preview == nil)
+    selection.apply(wanted, in: first)
+    #expect(fixture.modes.isApplying)
+    // Same main-actor turn: a disabled view has not yet had a chance to redraw.
+    fixture.modes.selectFromList(
+      wanted, on: SynthesisFixture.secondPanelID, from: .settings,
+      surface: .settingsBanner, currentModeID: second.alreadyOnScreenModeID
+    )
+    await fixture.settle()
+    #expect(!fixture.modes.isApplying)
+    #expect(fixture.modes.preview?.displayID == SynthesisFixture.panelID)
+    await fixture.revertAnyPreview()
+    selection.apply(wanted, in: first)
+    await fixture.settle()
+    if let preview = fixture.modes.preview {
+      _ = await fixture.modes.confirm(preview)
+    } else {
+      Issue.record("A new choice must be accepted after the previous one reverts")
+    }
+    #expect(fixture.modes.preview == nil)
+    expectIdle(fixture.modes)
+  }
+
+  @Test(arguments: [false, true])
+  func ordinaryChangesStayBusyUntilSuccessOrFailure(fails: Bool) async throws {
+    let fixture = SynthesisFixture(secondPanel: true)
+    defer { fixture.forgetPrefs() }
+    let catalog = try #require(fixture.modes.catalogs[SynthesisFixture.panelID])
+    let wanted = try #require(catalog.all.first { $0.ioModeID == 2 })
+    let suspension = ModeApplySuspension()
+    fixture.configurator.onModeApply = { suspension.block() }
+    fixture.configurator.refusesModeApplies = fails
+    expectIdle(fixture.modes)
+    fixture.modes.selectFromList(
+      wanted, on: SynthesisFixture.panelID, from: .settings,
+      surface: .settingsBanner, currentModeID: catalog.alreadyOnScreenModeID
+    )
+    expectBusy(fixture.modes, rendered: false)
+    let entered = await suspension.waitUntilEntered()
+    #expect(entered)
+    expectBusy(fixture.modes, rendered: false)
+    suspension.resume()
+    await fixture.settle()
+    expectIdle(fixture.modes)
+    if fails {
+      #expect(fixture.modes.startFailure != nil)
+      #expect(fixture.modes.preview == nil)
+    } else {
+      #expect(fixture.modes.preview?.mode == wanted)
+      // Recovery is outside the selection gate and remains answerable.
+      await fixture.revertAnyPreview()
+      #expect(fixture.modes.preview == nil)
+      expectIdle(fixture.modes)
+    }
+  }
+
+  @Test func renderedChangeKeepsItsLongCaptionUntilTheEngineFinishes() async throws {
+    let fixture = SynthesisFixture(secondPanel: true)
+    defer { fixture.forgetPrefs() }
+    let stop = try #require(fixture.modes.catalogs[SynthesisFixture.panelID]?.syntheticStops.first)
+    let suspension = ModeApplySuspension()
+    fixture.host.onCreate = { suspension.block() }
+    fixture.modes.select(
+      SyntheticSizeCatalog.row(for: stop), on: SynthesisFixture.panelID,
+      from: .settings, surface: .settingsBanner
+    )
+    expectBusy(fixture.modes, rendered: true)
+    let entered = await suspension.waitUntilEntered()
+    #expect(entered)
+    expectBusy(fixture.modes, rendered: true)
+    suspension.resume()
+    await fixture.settle()
+    expectIdle(fixture.modes)
+    #expect(fixture.modes.preview?.synthesized?.size == stop)
+    await fixture.revertAnyPreview()
+    expectIdle(fixture.modes)
+    #expect(fixture.modes.preview == nil)
+    #expect(fixture.synthesis.pairings.isEmpty)
+  }
+
+  @Test func queuedOperationsKeepTheActiveCaptionAndNeverClearBusyBetweenChanges() async throws {
+    let fixture = SynthesisFixture(secondPanel: true)
+    defer { fixture.forgetPrefs() }
+    let stop = try #require(fixture.modes.catalogs[SynthesisFixture.panelID]?.syntheticStops.first)
+    let second = try #require(fixture.modes.catalogs[SynthesisFixture.secondPanelID])
+    let wanted = try #require(second.all.first { $0.ioModeID == 2 })
+    let ordinary = ModeApplySuspension()
+    let rendered = ModeApplySuspension()
+    fixture.configurator.onModeApply = { ordinary.block() }
+    fixture.host.onCreate = { rendered.block() }
+    fixture.modes.select(wanted, on: SynthesisFixture.panelID,
+                         from: .settings, surface: .settingsBanner)
+    // Direct coordinator clients retain serial queue semantics.
+    fixture.modes.select(
+      SyntheticSizeCatalog.row(for: stop), on: SynthesisFixture.secondPanelID,
+      from: .settings, surface: .settingsBanner
+    )
+    let firstEntered = await ordinary.waitUntilEntered()
+    #expect(firstEntered)
+    expectBusy(fixture.modes, rendered: false)
+    ordinary.resume()
+    let secondEntered = await rendered.waitUntilEntered()
+    #expect(secondEntered)
+    #expect(fixture.modes.isApplying)
+    let feedback = ModeChangeFeedback(coordinator: fixture.modes, displayID: SynthesisFixture.panelID)
+    #expect(feedback.controlsDisabled)
+    #expect(feedback.caption?.contains("another display") == true)
+    #expect(feedback.caption?.contains("tens of seconds") == true)
+    rendered.resume()
+    await fixture.settle()
+    expectIdle(fixture.modes)
+    #expect(fixture.modes.preview?.displayID == SynthesisFixture.secondPanelID)
+    await fixture.revertAnyPreview()
+  }
+
+  @Test func cancellationQueuedDuringAnApplyClearsItsFeedbackAndPreview() async throws {
+    let fixture = SynthesisFixture()
+    defer { fixture.forgetPrefs() }
+    let catalog = try #require(fixture.modes.catalogs[SynthesisFixture.panelID])
+    let wanted = try #require(catalog.all.first { $0.ioModeID == 2 })
+    let suspension = ModeApplySuspension()
+    fixture.configurator.onModeApply = { suspension.block() }
+    fixture.modes.select(wanted, on: SynthesisFixture.panelID,
+                         from: .settings, surface: .settingsBanner)
+    let entered = await suspension.waitUntilEntered()
+    #expect(entered)
+    let cancellation = Task { await fixture.modes.endOutstandingPreview() }
+    suspension.resume()
+    #expect(await cancellation.value)
+    expectIdle(fixture.modes)
+    #expect(fixture.modes.preview == nil)
+  }
+
+  private func expectIdle(_ coordinator: DisplayModeCoordinator) {
+    #expect(!coordinator.isApplying)
+    let feedback = ModeChangeFeedback(coordinator: coordinator, displayID: SynthesisFixture.panelID)
+    #expect(!feedback.controlsDisabled)
+    #expect(feedback.caption == nil)
+  }
+
+  private func expectBusy(_ coordinator: DisplayModeCoordinator, rendered: Bool) {
+    #expect(coordinator.isApplying)
+    let here = ModeChangeFeedback(coordinator: coordinator, displayID: SynthesisFixture.panelID)
+    let elsewhere = ModeChangeFeedback(coordinator: coordinator, displayID: SynthesisFixture.secondPanelID)
+    #expect(here.controlsDisabled)
+    #expect(elsewhere.controlsDisabled)
+    #expect(here.caption?.contains("this display") == true)
+    #expect(elsewhere.caption?.contains("another display") == true)
+    #expect(here.caption?.contains("tens of seconds") == rendered)
+    #expect(elsewhere.caption?.contains("tens of seconds") == rendered)
+  }
+}
+
+/// Only the synchronous hardware boundary blocks; the test awaits off the pool.
+/// Immutable semaphores provide the cross-executor synchronization.
+private final class ModeApplySuspension: Sendable {
+  private let entered = DispatchSemaphore(value: 0)
+  private let proceed = DispatchSemaphore(value: 0)
+
+  func block() {
+    entered.signal()
+    if proceed.wait(timeout: .now() + 5) == .success {
+      // Keep the gate open for later applies and recovery calls.
+      proceed.signal()
+    }
+  }
+
+  func resume() { proceed.signal() }
+
+  func waitUntilEntered() async -> Bool {
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global().async {
+        continuation.resume(returning: self.entered.wait(timeout: .now() + 5) == .success)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Settings now shows a busy caption and disables size and refresh-rate selections while a display mode change runs. Rendered sizes carry a longer-running message, and the caption identifies when another display is changing. Repeated list selections are rejected immediately. Keep and Revert remain available during the subsequent preview.

Addresses the busy-feedback portion of #54. Catalog enumeration, reconnect handling and saved-layout work remain open.

Validation: regression tests suspend actual coordinator operations for ordinary and rendered changes; mutation checks confirmed that missing captions and enabled controls fail. Independent review and all PR CI checks passed. The combined candidate passed 2,512 engine tests and 574 app tests, plus Release and signing checks.

Live verification: the Dell ordinary-size change showed its busy caption with both controls disabled, then cleared it and enabled controls for the confirmation preview. On the MAG, choosing a rendered 3096 × 1296 size disabled every mode row with the longer-running caption; completion cleared the caption and re-enabled the rows for the Keep/Revert preview. Revert restored the original 3440 × 1440 at 175 Hz and cleared the preview. Independent system readings confirmed the original modes, mirror state and display arrangement were restored. More sizes was restored to off.
