### PR TITLE
Refresh audio output settings when the system route changes

### DIFF
--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -44,6 +44,24 @@ final class AppModel {
   /// test target can fake it; production uses CoreAudio.
   let audioDevices: any AudioDeviceProviding
 
+  /// UI state published by the audio listener. Key routing still reads the
+  /// provider at execution time, before a queued UI update may have arrived.
+  private(set) var defaultAudioOutput: AudioOutputDevice?
+
+  /// Installs the app's single audio callback and delivers routing changes on main.
+  func startObservingAudioOutput(onChange: @escaping @MainActor () -> Void) {
+    audioDevices.setOnDefaultOutputChange { [weak self] in
+      Task { @MainActor in
+        guard let self else { return }
+        let output = self.audioDevices.defaultOutputDevice()
+        if self.defaultAudioOutput != output {
+          self.defaultAudioOutput = output
+        }
+        onChange()
+      }
+    }
+  }
+
   /// ONE gate for every display-reconfiguring feature: display modes,
   /// mirroring, rotation and arrangement. Declared before all four because each
   /// takes it as a required init parameter; a defaulted gate would give each

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -284,8 +284,8 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
 
     // Re-arm volume keys when the default output device changes. The
     // handler fires on the CoreAudio listener queue; hop to main for the tap.
-    model.audioDevices.setOnDefaultOutputChange { [weak self] in
-      Task { @MainActor in self?.refreshTapConfig() }
+    model.startObservingAudioOutput { [weak self] in
+      self?.refreshTapConfig()
     }
 
     // Re-arm when a capabilities probe lands. The watched set is gated on

--- a/Candela/Settings/DiagnosticsPage.swift
+++ b/Candela/Settings/DiagnosticsPage.swift
@@ -658,7 +658,7 @@ struct DiagnosticsPage: View {
   }
 
   private var audioMatchText: String {
-    guard let device = model.audioDevices.defaultOutputDevice() else {
+    guard let device = model.defaultAudioOutput else {
       return DiagnosticsCopy.noDefaultOutputDevice
     }
     return DiagnosticsCopy.audioMatch(

--- a/Candela/Settings/DisplayHubView.swift
+++ b/Candela/Settings/DisplayHubView.swift
@@ -374,9 +374,7 @@ struct DisplayHubView: View {
   // MARK: - Sound
 
   @ViewBuilder private var soundCard: some View {
-    // `defaultOutputDevice()` does a blocking HAL round-trip when the CoreAudio
-    // listener has not primed its cache: read it once, not once per consumer.
-    let currentOutput = model.audioDevices.defaultOutputDevice()
+    let currentOutput = model.defaultAudioOutput
 
     SettingsCardSection(title: "Sound") {
       LabeledContent("Volume keys") {

--- a/CandelaAppTests/AudioOutputObservationTests.swift
+++ b/CandelaAppTests/AudioOutputObservationTests.swift
@@ -1,0 +1,120 @@
+import CandelaKit
+import Foundation
+import Observation
+import os
+import Testing
+
+@Suite("Default audio output observation", .timeLimit(.minutes(1))) @MainActor
+struct AudioOutputObservationTests {
+  private let speakers = AudioOutputDevice(id: 1, name: "Speakers", canSetOwnVolume: true)
+  private let monitor = AudioOutputDevice(id: 2, name: "Monitor", canSetOwnVolume: false)
+
+  private func model(_ audio: SignalingAudio) -> AppModel {
+    AppModel(shade: FakeShade(), gamma: FakeGamma(), hdrToggling: FakeHDR(),
+             audioDevices: audio, safeMode: true)
+  }
+
+  // Removing the publication from the real listener hop must fail even when
+  // nothing else in AppModel changes. Each callback is completed before checking.
+  @Test func initialOutputChangesRemovalAndReturnNotifyObservers() async {
+    let audio = SignalingAudio()
+    let model = model(audio)
+    let (events, continuation) = AsyncStream<Void>.makeStream()
+    defer { continuation.finish() }
+    var callbacks = events.makeAsyncIterator()
+    model.startObservingAudioOutput { continuation.yield(()) }
+    #expect(model.defaultAudioOutput == nil)
+
+    let renamed = AudioOutputDevice(id: 2, name: "Monitor renamed", canSetOwnVolume: false)
+    let native = AudioOutputDevice(id: 2, name: "Monitor renamed", canSetOwnVolume: true)
+    let cases: [(AudioOutputDevice?, Bool)] = [
+      (nil, false), (speakers, true), (monitor, true), (nil, true),
+      (speakers, true), (speakers, false), (renamed, true), (native, true),
+    ]
+    for (output, shouldNotify) in cases {
+      let notified = OSAllocatedUnfairLock(initialState: false)
+      withObservationTracking {
+        _ = model.defaultAudioOutput
+      } onChange: {
+        notified.withLock { $0 = true }
+      }
+      await Task.detached { audio.publish(output) }.value
+      _ = await callbacks.next()
+      #expect(model.defaultAudioOutput == output)
+      #expect(notified.withLock { $0 } == shouldNotify)
+    }
+  }
+
+  // UI reads must never initiate a cold HAL fetch. The initial provider result
+  // arrives through the same callback as subsequent route changes.
+  @Test func constructionAndUIReadsWaitForInitialPublication() async {
+    let audio = SignalingAudio()
+    let model = model(audio)
+    let (events, continuation) = AsyncStream<Void>.makeStream()
+    defer { continuation.finish() }
+    var callbacks = events.makeAsyncIterator()
+    model.startObservingAudioOutput { continuation.yield(()) }
+    _ = model.defaultAudioOutput
+    #expect(audio.readCount == 0)
+    let initialOutput = monitor
+    await Task.detached { audio.publish(initialOutput) }.value
+    _ = await callbacks.next()
+    #expect(model.defaultAudioOutput?.name == "Monitor")
+  }
+
+  // A key arriving before the listener's main-actor hop must still ask the
+  // provider. Replacing audioMatchingDisplays' live read with UI state breaks it.
+  @Test func keyExecutionReadsProviderBeforeUIReceivesRouteChange() async {
+    let audio = SignalingAudio()
+    let model = model(audio)
+    let (events, continuation) = AsyncStream<Void>.makeStream()
+    defer { continuation.finish() }
+    var callbacks = events.makeAsyncIterator()
+    model.startObservingAudioOutput { continuation.yield(()) }
+    audio.publish(speakers)
+    _ = await callbacks.next()
+
+    do {
+      // No suspension while this process-local test preference is changed.
+      let previous = UserDefaults.standard.object(forKey: "multiKeyboardVolume")
+      defer {
+        if let previous { UserDefaults.standard.set(previous, forKey: "multiKeyboardVolume") }
+        else { UserDefaults.standard.removeObject(forKey: "multiKeyboardVolume") }
+      }
+      DisplayPrefs(persistenceKey: "app").multiKeyboardVolume = .audioDeviceNameMatching
+      audio.publish(monitor)
+      let readsBeforePress = audio.readCount
+      KeyActionExecutor(model: model, hud: nil).execute(.stepVolume(isUp: true, isFine: false))
+      #expect(audio.readCount == readsBeforePress + 1)
+      #expect(model.defaultAudioOutput?.name == "Speakers")
+    }
+    _ = await callbacks.next()
+    #expect(model.defaultAudioOutput?.name == "Monitor")
+  }
+}
+
+/// Replaces only CoreAudio I/O. Real app callback registration, main-actor
+/// delivery and Observation remain under test. Locking permits background events.
+private final class SignalingAudio: AudioDeviceProviding, Sendable {
+  private struct State {
+    var device: AudioOutputDevice?
+    var handler: (@Sendable () -> Void)?
+    var reads = 0
+  }
+  private let state = OSAllocatedUnfairLock(initialState: State())
+  var readCount: Int { state.withLock { $0.reads } }
+  func defaultOutputDevice() -> AudioOutputDevice? {
+    state.withLock { $0.reads += 1; return $0.device }
+  }
+  func outputDeviceNames() -> [String] { [] }
+  func setOnDefaultOutputChange(_ handler: (@Sendable () -> Void)?) {
+    state.withLock { $0.handler = handler }
+  }
+  func publish(_ device: AudioOutputDevice?) {
+    let handler = state.withLock { state in
+      state.device = device
+      return state.handler
+    }
+    handler?()
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Audio/AudioDeviceProviding.swift
+++ b/CandelaKit/Sources/CandelaKit/Audio/AudioDeviceProviding.swift
@@ -24,6 +24,7 @@ public protocol AudioDeviceProviding: Sendable {
   /// `defaultOutputDevice()`. No production callers: volume-slider gating reads the
   /// DDC capabilities string instead.
   func outputDeviceNames() -> [String]
-  /// Fires on default-output-device change (any thread). Pass nil to clear.
+  /// Fires when the initial default-output snapshot is ready and on subsequent
+  /// default-output-device changes (any thread). Pass nil to clear.
   func setOnDefaultOutputChange(_ handler: (@Sendable () -> Void)?)
 }

--- a/CandelaKit/Sources/CandelaKit/Audio/CoreAudioDeviceProvider.swift
+++ b/CandelaKit/Sources/CandelaKit/Audio/CoreAudioDeviceProvider.swift
@@ -51,6 +51,9 @@ public final class CoreAudioDeviceProvider: AudioDeviceProviding, Sendable {
       guard let self else { return }
       let fresh = self.readDefaultOutputDevice()
       self.snapshot.withLock { $0 = .some(fresh) }
+      // Publish the initial result through the same path as route changes,
+      // including nil, after the cache is ready for main-actor consumers.
+      self.handlerLock.withLock { $0 }?()
       let names = self.readOutputDeviceNames()
       self.outputNames.withLock { $0 = names }
     }


### PR DESCRIPTION
Sound and Diagnostics now follow system audio-output changes without requiring an unrelated interaction. AppModel publishes a snapshot from the existing listener delivery; startup lookup stays off the main thread and unchanged values avoid redundant UI notifications. Key execution still reads the provider directly at press time.

Addresses the audio-output portion of #56. The other panel and dimming issues remain open.

Validation: new regression tests failed against the previous behavior and passed after the fix. Independent source review passed. The combined 1.0.3 candidate passed all 2,512 engine tests and 574 app tests, plus Release and signing checks. All PR CI checks pass.

Live verification: switching MacBook speakers to the external display and back updated Diagnostics without further Candela interaction. Use Current selected the correct device after each route change. The temporary device-name override and original audio output were restored.
