### PR TITLE
Align display captions and keep Use Current on one line

### DIFF
--- a/Candela/Settings/DisplayHubView.swift
+++ b/Candela/Settings/DisplayHubView.swift
@@ -471,13 +471,14 @@ struct DisplayHubView: View {
                 guard !audioNameFocused else { return } // never fight a live edit
                 audioNameDraft = prefs.audioDeviceNameOverride
               }
-              .frame(width: 180)
+              .frame(minWidth: 100, idealWidth: 180, maxWidth: 180)
               .prefIdentifier(.audioDeviceNameOverride, persistenceKey: persistenceKey)
             Button("Use Current") {
               audioNameDraft = currentOutput?.name ?? ""
               commitAudioName()
             }
             .buttonStyle(SettingsSecondaryButtonStyle())
+            .fixedSize(horizontal: true, vertical: false)
             .accessibilityLabel("Use Current")
             .disabled(currentOutput == nil)
           }
@@ -602,7 +603,10 @@ struct DisplayHubView: View {
     SettingsCardSection {
       // The only hedge on the page, and it sits before the navigation rather
       // than on the sub-page, where it would arrive too late to save the trip.
-      SettingRow("Settings most displays don't need.") {
+      SettingRow(
+        "Settings most displays don't need.",
+        captionLeadingInset: NavigationRow.contentHorizontalInset
+      ) {
         NavigationRow(title: "Advanced", value: advancedPreview) { path.append(.advanced) }
           .focused($focusedRow, equals: .advanced)
       }

--- a/Candela/Settings/NavigationRow.swift
+++ b/Candela/Settings/NavigationRow.swift
@@ -17,6 +17,8 @@ import SwiftUI
 /// `.accessibilityAction` gives the press back but not the focus. The `Button`
 /// is already one element with the button trait and merges its own content.
 struct NavigationRow: View {
+  static let contentHorizontalInset: CGFloat = 6
+
   let title: String
   let value: String?
   var spokenValue: String? = nil
@@ -46,7 +48,7 @@ struct NavigationRow: View {
         }
       }
       .padding(.vertical, 6)
-      .padding(.horizontal, 6)
+      .padding(.horizontal, Self.contentHorizontalInset)
       // The lift is the only thing saying a card row is a doorway; the chevron
       // alone reads as decoration at this density.
       .background(

--- a/Candela/Settings/SettingsComponents.swift
+++ b/Candela/Settings/SettingsComponents.swift
@@ -93,16 +93,27 @@ struct SettingRow<Control: View>: View {
   @Environment(\.isEnabled) private var isEnabled
 
   private let caption: SettingsCaption?
+  private let captionLeadingInset: CGFloat
   private let safety: SafetySentence?
   private let controlLabel: LocalizedStringKey?
   private let control: Control
 
-  init(_ caption: LocalizedStringKey? = nil, @ViewBuilder control: () -> Control) {
-    self.init(caption: caption.map { SettingsCaption($0) }, control: control)
+  init(
+    _ caption: LocalizedStringKey? = nil,
+    captionLeadingInset: CGFloat = 0,
+    @ViewBuilder control: () -> Control
+  ) {
+    self.init(caption: caption.map { SettingsCaption($0) },
+              captionLeadingInset: captionLeadingInset, control: control)
   }
 
-  init(caption: SettingsCaption?, @ViewBuilder control: () -> Control) {
+  init(
+    caption: SettingsCaption?,
+    captionLeadingInset: CGFloat = 0,
+    @ViewBuilder control: () -> Control
+  ) {
     self.caption = caption
+    self.captionLeadingInset = captionLeadingInset
     self.safety = nil
     self.controlLabel = nil
     self.control = control()
@@ -131,6 +142,7 @@ struct SettingRow<Control: View>: View {
   ) {
     self.caption = caption
     self.safety = safety
+    self.captionLeadingInset = 0
     self.controlLabel = label
     self.control = control(label)
   }
@@ -171,6 +183,7 @@ struct SettingRow<Control: View>: View {
         .foregroundStyle(SettingsTheme.faintColor)
         .fixedSize(horizontal: false, vertical: true)
         .opacity(isEnabled ? 1 : SettingsTheme.disabledOpacity)
+        .padding(.leading, captionLeadingInset)
     }
   }
 


### PR DESCRIPTION
The display hub's Advanced subtitle now shares the label's leading edge, and Use Current keeps a single-line label while the audio-name field can shrink to fit. Actions and neighboring row spacing are preserved.

Closes #65.

Validation: before/after captures of the actual Settings components reproduce both defects and show the corrections at normal and narrower widths, including a wrapped caption. Both fixes were also verified in the installed release candidate, including Advanced navigation and Use Current after audio-route changes. Independent review passed. The combined candidate passed all 2,512 engine tests and 574 app tests, plus Release and signing checks.

All PR CI checks pass. The first engine CI run encountered the existing timing-sensitive test tracked in #67; rerunning passed without changing production code or weakening tests.
