### PR TITLE
Confirm completed updates and deliver Settings navigation reliably

### DIFF
--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -671,7 +671,7 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
       }
       // Here rather than at the top of launch for the same reason as the setup
       // flow: the window's display rows derive over the discovered list.
-      if UpdateRelaunch.consume() {
+      if updaterModel.completion.consumeRelaunch() {
         SettingsOpener.open(at: .pane(.about))
       }
       // Virtual display launch prelude: normalize the slot prefs, log

--- a/Candela/App/UpdateRelaunch.swift
+++ b/Candela/App/UpdateRelaunch.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import Sparkle
 
 /// Sparkle's "Install and Relaunch" brings a menu-bar app back with no window,
@@ -6,14 +7,17 @@ import Sparkle
 /// the relaunch on disk; the next launch consumes the mark and opens About.
 enum UpdateRelaunch {
   static let defaultsKey = "openSettingsAfterUpdateRelaunch"
+  static let previousVersionKey = "versionBeforeUpdateRelaunch"
 
-  static func mark(in defaults: UserDefaults = .standard) {
+  static func mark(in defaults: UserDefaults = .standard, version: String = AppInfo.version) {
+    defaults.set(version, forKey: previousVersionKey)
     defaults.set(true, forKey: defaultsKey)
   }
 
   static func consume(in defaults: UserDefaults = .standard) -> Bool {
     guard defaults.bool(forKey: defaultsKey) else { return false }
     defaults.removeObject(forKey: defaultsKey)
+    defaults.removeObject(forKey: previousVersionKey)
     return true
   }
 }
@@ -23,5 +27,46 @@ enum UpdateRelaunch {
 final class UpdateRelaunchDelegate: NSObject, SPUUpdaterDelegate {
   func updaterWillRelaunchApplication(_: SPUUpdater) {
     UpdateRelaunch.mark()
+  }
+}
+
+/// Session-only feedback; consuming the relaunch mark prevents later launches
+/// or Settings visits from celebrating the same update again.
+@MainActor @Observable
+final class UpdateCompletionState {
+  struct Notice: Identifiable, Equatable {
+    let id = UUID()
+    let version: String
+  }
+
+  private(set) var notice: Notice?
+
+  func consumeRelaunch(
+    in defaults: UserDefaults = .standard, version: String = AppInfo.version
+  ) -> Bool {
+    let previous = defaults.string(forKey: UpdateRelaunch.previousVersionKey)
+    guard UpdateRelaunch.consume(in: defaults) else { return false }
+    // Sparkle's hook precedes installation. An aborted update may leave the
+    // mark behind, so only a changed, known version earns success feedback.
+    if let previous, !previous.isEmpty, previous != "?",
+       !version.isEmpty, version != "?", previous != version {
+      notice = Notice(version: version)
+    }
+    return true
+  }
+
+  func dismiss(_ id: UUID) {
+    guard notice?.id == id else { return }
+    notice = nil
+  }
+
+  func dismissAfterDelay(_ id: UUID, delay: Duration = .seconds(8)) async {
+    do {
+      try await Task.sleep(for: delay)
+      try Task.checkCancellation()
+      dismiss(id)
+    } catch {
+      // Closing or changing pages cancels the view's task.
+    }
   }
 }

--- a/Candela/App/UpdaterModel.swift
+++ b/Candela/App/UpdaterModel.swift
@@ -13,6 +13,7 @@ import Sparkle
 /// over foreign storage.
 @MainActor @Observable
 final class UpdaterModel {
+  let completion = UpdateCompletionState()
   @ObservationIgnored private let controller: SPUStandardUpdaterController
   // Sparkle holds its delegate weakly, so the model owns it.
   @ObservationIgnored private let relaunchDelegate = UpdateRelaunchDelegate()

--- a/Candela/Settings/AboutPane.swift
+++ b/Candela/Settings/AboutPane.swift
@@ -96,6 +96,7 @@ struct AboutPane: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.top, 4)
     }
+    .modifier(UpdateCompletionOverlay(state: updater.completion))
   }
 
   // MARK: - Hero

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CandelaKit
+import Observation
 import SwiftUI
 
 /// Sidebar navigation over a pane registry.
@@ -184,7 +185,7 @@ struct SettingsRootView: View {
         fallbackTitle: selectedPaneTitle,
         navigationToken: currentPathDepth,
         onWindowVisibility: { windowVisibility = $0 }))
-    .onAppear {
+    .onChange(of: SettingsOpener.requestID, initial: true) { _, _ in
       if let pending = SettingsOpener.pendingSelection {
         SettingsOpener.pendingSelection = nil
         selection = pending
@@ -1118,9 +1119,24 @@ private struct SettingsWindowConfigurator: NSViewRepresentable {
 /// and puts the window back behind the frontmost app (measured).
 @MainActor
 enum SettingsOpener {
-  /// Set before `open()`: the window comes up inside that call and its
-  /// `onAppear` reads this once, so a later assignment misses it.
-  static var pendingSelection: SettingsDestination?
+  @MainActor @Observable fileprivate final class NavigationRequest {
+    var destination: SettingsDestination?
+    var id = UUID()
+  }
+
+  private static let request = NavigationRequest()
+
+  /// Observed by the root for both initial and already-mounted delivery.
+  static var requestID: UUID { request.id }
+
+  static var pendingSelection: SettingsDestination? {
+    get { request.destination }
+    set {
+      request.destination = newValue
+      // Repeated destinations are new requests, even within one view update.
+      if newValue != nil { request.id = UUID() }
+    }
+  }
 
   static func open(at destination: SettingsDestination) {
     pendingSelection = destination

--- a/Candela/Settings/Theme/SettingsTheme.swift
+++ b/Candela/Settings/Theme/SettingsTheme.swift
@@ -24,6 +24,8 @@ enum SettingsTheme {
   static let faintColor = OnboardingStyle.faintColor
   static let cardFill = OnboardingStyle.cardFill
   static let cardStroke = OnboardingStyle.cardStroke
+  /// Opaque so a transient notice stays legible above page content and when inactive.
+  static let noticeFill = Color(red: 0.10, green: 0.11, blue: 0.15)
 
   /// Destructive actions never borrow the destination accent, which everywhere
   /// else in this window means "this is on".

--- a/Candela/Settings/UpdateCompletionNotice.swift
+++ b/Candela/Settings/UpdateCompletionNotice.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+@MainActor
+struct UpdateCompletionOverlay: ViewModifier {
+  let state: UpdateCompletionState
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.accessibilityVoiceOverEnabled) private var voiceOver
+
+  func body(content: Content) -> some View {
+    content
+      .overlay(alignment: .top) {
+        if let notice = state.notice {
+          UpdateCompletionNotice(version: notice.version, reduceMotion: reduceMotion) {
+            state.dismiss(notice.id)
+          }
+            .frame(maxWidth: 420)
+            .padding(.horizontal, 24)
+            .padding(.top, 16)
+            .transition(.opacity)
+            .id(notice.id)
+        }
+      }
+      .animation(Motion.notice(reduceMotion: reduceMotion), value: state.notice?.id)
+      .task(id: voiceOver ? nil : state.notice?.id) {
+        guard let notice = state.notice, !voiceOver else { return }
+        await state.dismissAfterDelay(notice.id)
+      }
+      .onDisappear {
+        if let notice = state.notice { state.dismiss(notice.id) }
+      }
+  }
+}
+
+struct UpdateCompletionNotice: View {
+  let version: String
+  let reduceMotion: Bool
+  let dismiss: () -> Void
+  @Environment(\.settingsAccent) private var lighting
+  @State private var appeared = false
+
+  var body: some View {
+    HStack(spacing: 14) {
+      ZStack {
+        Circle().fill(lighting.accent.opacity(0.14))
+        Circle()
+          .trim(from: 0, to: appeared || reduceMotion ? 1 : 0)
+          .stroke(lighting.accent.opacity(0.65), style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+          .rotationEffect(.degrees(-90))
+        Image(systemName: "checkmark")
+          .font(.system(size: 19, weight: .semibold))
+          .foregroundStyle(lighting.accent)
+          .scaleEffect(appeared || reduceMotion ? 1 : 0.8)
+      }
+      .frame(width: 44, height: 44)
+      .accessibilityHidden(true)
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Update complete")
+          .font(.headline)
+          .foregroundStyle(SettingsTheme.titleColor)
+        Text("You're running \(AppInfo.productName) \(version).")
+          .font(.callout)
+          .foregroundStyle(SettingsTheme.bodyColor)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .accessibilityElement(children: .combine)
+      Spacer(minLength: 4)
+      Button(action: dismiss) {
+        Image(systemName: "xmark")
+          .font(.system(size: 11, weight: .semibold))
+          .frame(width: 28, height: 28)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(SettingsTheme.bodyColor)
+      .accessibilityLabel("Dismiss update confirmation")
+      .help("Dismiss update confirmation")
+    }
+    .padding(16)
+    .background {
+      RoundedRectangle(cornerRadius: SettingsTheme.cardRadius, style: .continuous)
+        .fill(SettingsTheme.noticeFill)
+        .overlay {
+          RoundedRectangle(cornerRadius: SettingsTheme.cardRadius, style: .continuous)
+            .stroke(lighting.accent.opacity(0.3), lineWidth: 1)
+        }
+    }
+    .shadow(color: .black.opacity(0.25), radius: 16, y: 8)
+    .onAppear {
+      withAnimation(reduceMotion ? nil : .easeOut(duration: 0.55)) { appeared = true }
+    }
+  }
+}

--- a/CandelaAppTests/SettingsOpenNavigationTests.swift
+++ b/CandelaAppTests/SettingsOpenNavigationTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import CandelaKit
+import SwiftUI
+import Testing
+
+@Suite("Directed Settings navigation", .serialized)
+@MainActor
+struct SettingsOpenNavigationTests {
+  @Test func aRequestReachesTheMountedRootWithoutAnotherAppearance() async throws {
+    SettingsOpener.pendingSelection = nil
+    defer { SettingsOpener.pendingSelection = nil }
+    let fixture = Fixture()
+    defer { fixture.detach() }
+    try await fixture.expectTitle("General")
+
+    // Publish through the same destination slot as open(at:), without
+    // activating the test process or sending an application menu action.
+    SettingsOpener.pendingSelection = .pane(.keyboard)
+    try await fixture.expectTitle("Keyboard")
+    #expect(SettingsOpener.pendingSelection == nil)
+  }
+
+  @Test func anEarlyRequestIsConsumedOnceAndOrdinaryReappearanceKeepsSelection() async throws {
+    SettingsOpener.pendingSelection = .pane(.keyboard)
+    defer { SettingsOpener.pendingSelection = nil }
+    let fixture = Fixture()
+    defer { fixture.detach() }
+    try await fixture.expectTitle("Keyboard")
+    #expect(SettingsOpener.pendingSelection == nil)
+
+    fixture.actions.reveal(.pane(.general))
+    try await fixture.expectTitle("General")
+    fixture.reattach()
+    try await fixture.expectTitle("General")
+    #expect(SettingsOpener.pendingSelection == nil)
+
+    SettingsOpener.pendingSelection = .pane(.keyboard)
+    try await fixture.expectTitle("Keyboard")
+    #expect(SettingsOpener.pendingSelection == nil)
+    fixture.actions.reveal(.pane(.general))
+    try await fixture.expectTitle("General")
+    SettingsOpener.pendingSelection = .pane(.keyboard)
+    try await fixture.expectTitle("Keyboard")
+    #expect(SettingsOpener.pendingSelection == nil)
+  }
+
+  @MainActor private final class Fixture {
+    let actions: SettingsActions
+    let window: NSWindow
+    let host: NSView
+
+    init() {
+      let model = TestFixtures.appModel()
+      actions = SettingsActions(model: model)
+      host = NSHostingView(rootView: SettingsRootView()
+        .environment(model)
+        .environment(actions)
+        .transaction { $0.disablesAnimations = true })
+      window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 1100, height: 680),
+        styleMask: [.titled], backing: .buffered, defer: false)
+      window.isReleasedWhenClosed = false
+      window.contentView = host
+      host.layoutSubtreeIfNeeded()
+    }
+
+    func expectTitle(_ title: String) async throws {
+      for _ in 0..<100 {
+        host.layoutSubtreeIfNeeded()
+        if window.title == title { return }
+        try await Task.sleep(for: .milliseconds(10))
+      }
+      #expect(window.title == title)
+    }
+
+    func reattach() {
+      window.contentView = nil
+      window.contentView = host
+      host.layoutSubtreeIfNeeded()
+    }
+
+    func detach() {
+      window.contentView = nil
+      window.close()
+    }
+  }
+}

--- a/CandelaAppTests/UpdateCompletionTests.swift
+++ b/CandelaAppTests/UpdateCompletionTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Observation
+import Testing
+
+@Suite("Update completion confirmation")
+@MainActor
+struct UpdateCompletionTests {
+  let defaults = UserDefaults(suiteName: "update-completion-tests-\(UUID().uuidString)")!
+
+  @Test func ordinaryLaunchDoesNotProduceAConfirmation() {
+    let state = UpdateCompletionState()
+    #expect(!state.consumeRelaunch(in: defaults, version: "1.0.3"))
+    #expect(state.notice == nil)
+  }
+
+  @Test func anAbortedUpdateDoesNotCelebrateAnUnchangedVersion() {
+    let state = UpdateCompletionState()
+    UpdateRelaunch.mark(in: defaults, version: "1.0.3")
+    #expect(state.consumeRelaunch(in: defaults, version: "1.0.3"))
+    #expect(state.notice == nil)
+    #expect(!state.consumeRelaunch(in: defaults, version: "1.0.4"))
+    #expect(state.notice == nil)
+  }
+
+  @Test func legacyMarkersOpenAboutWithoutClaimingVerifiedSuccess() {
+    let state = UpdateCompletionState()
+    defaults.set(true, forKey: UpdateRelaunch.defaultsKey)
+    #expect(state.consumeRelaunch(in: defaults, version: "1.0.3"))
+    #expect(state.notice == nil)
+  }
+
+  @Test func aMarkedUpdatePublishesTheRunningVersionExactlyOnce() throws {
+    let state = UpdateCompletionState()
+    UpdateRelaunch.mark(in: defaults, version: "1.0.2")
+    #expect(state.consumeRelaunch(in: defaults, version: "2.1.7"))
+    let notice = try #require(state.notice)
+    #expect(notice.version == "2.1.7")
+    state.dismiss(notice.id)
+    #expect(state.notice == nil)
+    #expect(!state.consumeRelaunch(in: defaults, version: "2.1.7"))
+    #expect(state.notice == nil)
+    #expect(!UpdateCompletionState().consumeRelaunch(in: defaults, version: "2.1.7"))
+  }
+
+  @Test func aPreviousDismissalCannotRemoveANewerConfirmation() throws {
+    let state = UpdateCompletionState()
+    UpdateRelaunch.mark(in: defaults, version: "1.0.2")
+    _ = state.consumeRelaunch(in: defaults, version: "1.0.3")
+    let first = try #require(state.notice)
+    UpdateRelaunch.mark(in: defaults, version: "1.0.2")
+    _ = state.consumeRelaunch(in: defaults, version: "1.0.4")
+    let second = try #require(state.notice)
+    state.dismiss(first.id)
+    #expect(state.notice == second)
+  }
+
+  @Test func timeoutDismissesTheConfirmation() async throws {
+    let state = UpdateCompletionState()
+    UpdateRelaunch.mark(in: defaults, version: "1.0.2")
+    _ = state.consumeRelaunch(in: defaults, version: "1.0.3")
+    let notice = try #require(state.notice)
+    await state.dismissAfterDelay(notice.id, delay: .zero)
+    #expect(state.notice == nil)
+  }
+
+  @Test func cancellingTheViewTaskDoesNotActLikeAnExpiredTimer() async throws {
+    let state = UpdateCompletionState()
+    UpdateRelaunch.mark(in: defaults, version: "1.0.2")
+    _ = state.consumeRelaunch(in: defaults, version: "1.0.3")
+    let notice = try #require(state.notice)
+    let task = Task { await state.dismissAfterDelay(notice.id, delay: .seconds(60)) }
+    task.cancel()
+    await task.value
+    #expect(state.notice == notice)
+    state.dismiss(notice.id)
+    #expect(state.notice == nil)
+  }
+}

--- a/CandelaAppTests/UpdateRelaunchTests.swift
+++ b/CandelaAppTests/UpdateRelaunchTests.swift
@@ -14,5 +14,6 @@ struct UpdateRelaunchTests {
     #expect(UpdateRelaunch.consume(in: defaults) == true)
     #expect(UpdateRelaunch.consume(in: defaults) == false)
     #expect(defaults.object(forKey: UpdateRelaunch.defaultsKey) == nil)
+    #expect(defaults.object(forKey: UpdateRelaunch.previousVersionKey) == nil)
   }
 }


### PR DESCRIPTION
After Install and Relaunch, Candela opens About even if Settings appeared before the navigation request arrived. When the running version differs from the version recorded before installation, About shows a brief “Update complete” confirmation naming the actual version.

The confirmation uses one short checkmark animation, a dismiss button and an eight-second timeout. Reduce Motion removes the animation; VoiceOver keeps the message available until dismissed. It does not block Settings or replay on ordinary launches and later visits. Legacy relaunch markers still open About, while unchanged versions after an aborted installation cannot show a false success message.

Closes #68. Closes #71.

Validation: independent review passed. Regression tests cover early and late Settings navigation, repeated requests, ordinary reopening, successful version change, aborted updates, legacy markers, one-time consumption, dismissal, timeout and cancellation. Actual-component visual checks cover standard and Reduce Motion appearances. The final combined candidate passed all 2,512 engine and 586 app tests. A real signed Sparkle update installed the exact final executable and opened About with the completion message. The installed notice was visually verified and manually dismissed, and an ordinary relaunch showed no replay. The final app and disk image passed notarization, stapling and Gatekeeper checks.

