### PR TITLE
Include volume and sound output in diagnostic reports

### DIFF
--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -719,18 +719,49 @@ final class AppModel {
   /// contract, bare pref names and never composed `UserDefaults` keys, is
   /// `DiagnosticsPrefSummary`'s, where a test pins every line it emits.
   func diagnosticsSnapshot() -> DiagnosticsReportSnapshot {
-    DiagnosticsReportSnapshot(
+    // One output snapshot keeps every display's match verdict consistent.
+    let audioOutput = audioDevices.defaultOutputDevice()
+    return DiagnosticsReportSnapshot(
       appVersion: AppInfo.version,
       osVersion: osVersionText,
       safeMode: safeMode,
       accessibilityGranted: accessibility.isGranted,
       launchAtLogin: launchAtLoginText,
-      displays: allControlledStates.map(diagnosticsEntry),
+      displays: allControlledStates.map { diagnosticsEntry($0, audioOutput: audioOutput) },
       recentEvents: recentDisplayEvents
     )
   }
 
-  private func diagnosticsEntry(_ state: DisplayState) -> DiagnosticsReportSnapshot.DisplayEntry {
+  func diagnosticsVolumeAvailability(_ state: DisplayState) -> String {
+    guard builtIn?.id != state.id else { return "Not applicable: built-in display" }
+    let key = state.display.persistenceKey
+    let prefs = DisplayPrefs(persistenceKey: key)
+    return DiagnosticsCopy.volumeAvailability(
+      override: prefs.audioSinkOverride,
+      isAvailable: state.volume.isAvailable,
+      support: volumeSupport[key],
+      hasDescription: capabilityString[key] != nil,
+      forceSoftware: prefs.forceSoftware,
+      app: AppInfo.productName
+    )
+  }
+
+  func diagnosticsSoundOutput(_ state: DisplayState, device: AudioOutputDevice?) -> String {
+    guard builtIn?.id != state.id else { return "Not applicable: built-in display" }
+    guard let device else { return DiagnosticsCopy.noDefaultOutputDevice }
+    let prefs = DisplayPrefs(persistenceKey: state.display.persistenceKey)
+    return DiagnosticsCopy.audioMatch(
+      deviceName: device.name,
+      matches: AudioRoutingPolicy.displayMatchesDevice(
+        deviceName: device.name, rawDisplayName: state.display.name,
+        nameOverride: prefs.audioDeviceNameOverride
+      )
+    )
+  }
+
+  private func diagnosticsEntry(
+    _ state: DisplayState, audioOutput: AudioOutputDevice?
+  ) -> DiagnosticsReportSnapshot.DisplayEntry {
     let persistenceKey = state.display.persistenceKey
     let prefs = DisplayPrefs(persistenceKey: persistenceKey)
     let facts = hardwareFacts[persistenceKey]
@@ -771,7 +802,9 @@ final class AppModel {
       hdrEngaged: state.controller.isHDREngaged,
       nonDefaultPrefs: DiagnosticsPrefSummary.nonDefaultPrefs(
         prefs, remembersMode: displayModes.isRemembering(state.id)
-      )
+      ),
+      volumeAvailability: diagnosticsVolumeAvailability(state),
+      soundOutput: diagnosticsSoundOutput(state, device: audioOutput)
     )
   }
 

--- a/Candela/Settings/DiagnosticsPage.swift
+++ b/Candela/Settings/DiagnosticsPage.swift
@@ -463,14 +463,7 @@ struct DiagnosticsPage: View {
     if !isBuiltIn {
       SettingsCardDivider()
       LabeledContent("Volume") {
-        valueText(DiagnosticsCopy.volumeAvailability(
-          override: prefs.audioSinkOverride,
-          isAvailable: state.volume.isAvailable,
-          support: model.volumeSupport[persistenceKey],
-          hasDescription: capabilities != nil,
-          forceSoftware: prefs.forceSoftware,
-          app: AppInfo.productName
-        ))
+        valueText(model.diagnosticsVolumeAvailability(state))
       }
       .help(DiagnosticsPageCopy.volumeHelp)
 
@@ -658,17 +651,7 @@ struct DiagnosticsPage: View {
   }
 
   private var audioMatchText: String {
-    guard let device = model.audioDevices.defaultOutputDevice() else {
-      return DiagnosticsCopy.noDefaultOutputDevice
-    }
-    return DiagnosticsCopy.audioMatch(
-      deviceName: device.name,
-      matches: AudioRoutingPolicy.displayMatchesDevice(
-        deviceName: device.name,
-        rawDisplayName: state.display.name,
-        nameOverride: prefs.audioDeviceNameOverride
-      )
-    )
+    model.diagnosticsSoundOutput(state, device: model.audioDevices.defaultOutputDevice())
   }
 
   // MARK: - Actions

--- a/CandelaAppTests/DiagnosticsSnapshotTests.swift
+++ b/CandelaAppTests/DiagnosticsSnapshotTests.swift
@@ -1,0 +1,92 @@
+import CandelaKit
+import Foundation
+import Testing
+
+@Suite("Diagnostics audio snapshot")
+@MainActor
+struct DiagnosticsSnapshotTests {
+  private func model(audio: FakeAudio, capabilities: String? = nil) async -> AppModel {
+    let discovery = ScriptedDiscovery([
+      (id: 70001, key: "report-left-\(UUID().uuidString)", name: "Left Monitor"),
+      (id: 70002, key: "report-right-\(UUID().uuidString)", name: "Right Monitor"),
+    ])
+    let model = AppModel(
+      shade: FakeShade(), gamma: FakeGamma(), hdrToggling: FakeHDR(),
+      audioDevices: audio, discoverDisplays: {
+        let entries = discovery.discover($0)
+        for entry in entries { (entry.writer as? FakeDDCWriter)?.capabilities = capabilities }
+        return entries
+      })
+    _ = await model.refresh()
+    return model
+  }
+
+  @Test func reportIncludesVolumeReasonWithoutTreatingAnUnansweredDisplayAsUnsupported() async {
+    let model = await model(audio: FakeAudio())
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(report.contains("  volume: Available: Candela"))
+    #expect(report.contains("so the control stays on"))
+    #expect(!report.contains("volume: Unavailable"))
+  }
+
+  @Test func reportAssociatesTheAudioMatchWithTheCorrectDisplay() async {
+    let audio = FakeAudio(device: .init(id: 1, name: "Right Monitor", canSetOwnVolume: false))
+    let model = await model(audio: audio)
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    let sections = report.components(separatedBy: "\ndisplay: ")
+    let left = sections.first { $0.hasPrefix("Left Monitor\n") }
+    let right = sections.first { $0.hasPrefix("Right Monitor\n") }
+    #expect(left?.contains("  sound output: Right Monitor: not matched to this display") == true)
+    #expect(right?.contains("  sound output: Right Monitor: matched to this display") == true)
+  }
+
+  @Test func nextReportReflectsAChangedOrRemovedOutputWithoutOpeningDiagnostics() async {
+    let audio = FakeAudio(device: .init(id: 1, name: "Left Monitor", canSetOwnVolume: false))
+    let model = await model(audio: audio)
+    let before = model.diagnosticsSnapshot()
+    audio.device = .init(id: 2, name: "Headphones", canSetOwnVolume: true)
+    let after = model.diagnosticsSnapshot()
+    audio.device = nil
+    let removed = model.diagnosticsSnapshot()
+    #expect(DiagnosticsReport.render(before).contains("sound output: Left Monitor: matched"))
+    #expect(DiagnosticsReport.render(after).contains("sound output: Headphones: not matched"))
+    #expect(!DiagnosticsReport.render(after).contains("sound output: Left Monitor"))
+    #expect(DiagnosticsReport.render(removed).contains(
+      "sound output: macOS reports no default output device"))
+  }
+
+  @Test(arguments: [
+    ("(vcp(10 12 62))", "Available: this display lists the volume command"),
+    ("(vcp(10 12))", "Unavailable: this display's description parsed cleanly and does not list the volume command"),
+    ("(broken)", "Available: Candela could not read a command list out of this display's description, so the control stays on"),
+  ])
+  func reportPreservesTheCapabilityVerdict(capabilities: String, reason: String) async throws {
+    let model = await model(audio: FakeAudio(), capabilities: capabilities)
+    let display = try #require(model.displays.first)
+    let key = display.display.persistenceKey
+    for _ in 0..<200 where model.volumeSupport[key] == nil { await Task.yield() }
+    _ = try #require(model.volumeSupport[key])
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(report.contains("  volume: \(reason)\n"))
+  }
+
+  @Test func reportUsesTheDisplaysVolumeAndAudioNameOverrides() async throws {
+    let audio = FakeAudio(device: .init(id: 1, name: "Desk Speakers", canSetOwnVolume: false))
+    let model = await model(audio: audio)
+    let display = try #require(model.displays.first)
+    let key = display.display.persistenceKey
+    let prefs = DisplayPrefs(persistenceKey: key)
+    defer {
+      UserDefaults.standard.removeObject(forKey: "audioDeviceNameOverride.\(key)")
+      UserDefaults.standard.removeObject(forKey: "audioSinkOverride.\(key)")
+    }
+    prefs.audioDeviceNameOverride = "Desk Speakers"
+    prefs.audioSinkOverride = .forceNone
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(report.contains("volume: Unavailable: you set this display's volume slider to always off"))
+    #expect(report.contains("sound output: Desk Speakers: matched to this display"))
+    prefs.audioSinkOverride = .forcePresent
+    #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains(
+      "volume: Available: you set this display's volume slider to always on"))
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsReport.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsReport.swift
@@ -15,6 +15,8 @@ public struct DiagnosticsReportSnapshot: Sendable {
     public let controlMethod: String
     public let readbackVerdict: String
     public let hdrEngaged: Bool
+    public let volumeAvailability: String
+    public let soundOutput: String
     /// Rendered verbatim; the caller scrubs these, not the renderer. Bare pref
     /// name and value only (`forceSw = true`), never a full storage key: a
     /// persistence key carries the display's serial.
@@ -23,7 +25,7 @@ public struct DiagnosticsReportSnapshot: Sendable {
     public init(name: String, hardwareName: String, connection: String?,
                 manufacturer: String?, hasSerial: Bool, currentMode: String?,
                 controlMethod: String, readbackVerdict: String, hdrEngaged: Bool,
-                nonDefaultPrefs: [String]) {
+                nonDefaultPrefs: [String], volumeAvailability: String, soundOutput: String) {
       self.name = name
       self.hardwareName = hardwareName
       self.connection = connection
@@ -34,6 +36,8 @@ public struct DiagnosticsReportSnapshot: Sendable {
       self.readbackVerdict = readbackVerdict
       self.hdrEngaged = hdrEngaged
       self.nonDefaultPrefs = nonDefaultPrefs
+      self.volumeAvailability = volumeAvailability
+      self.soundOutput = soundOutput
     }
   }
 
@@ -87,6 +91,8 @@ public enum DiagnosticsReport {
           "  control method: \(display.controlMethod)",
           "  readback: \(display.readbackVerdict)",
           "  hdr: \(display.hdrEngaged ? "engaged" : "off")",
+          "  volume: \(display.volumeAvailability)",
+          "  sound output: \(display.soundOutput)",
         ]
         if display.nonDefaultPrefs.isEmpty {
           lines.append("  non-default settings: none")

--- a/CandelaKit/Tests/CandelaKitTests/DiagnosticsReportTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DiagnosticsReportTests.swift
@@ -8,7 +8,9 @@ struct DiagnosticsReportTests {
           manufacturer: "Dell", hasSerial: true,
           currentMode: "1296 × 2304 at 120 Hz", controlMethod: "Hardware (DDC)",
           readbackVerdict: "answers reads", hdrEngaged: false,
-          nonDefaultPrefs: nonDefaultPrefs)
+          nonDefaultPrefs: nonDefaultPrefs,
+          volumeAvailability: "Unavailable: this display lists no volume command",
+          soundOutput: "Headphones: not matched to this display")
   }
 
   private func snapshot() -> DiagnosticsReportSnapshot {
@@ -47,7 +49,9 @@ struct DiagnosticsReportTests {
       name: "Left", hardwareName: "DELL U2725QE", connection: nil,
       manufacturer: nil, hasSerial: false, currentMode: nil,
       controlMethod: "Software (gamma)", readbackVerdict: "never asked",
-      hdrEngaged: true, nonDefaultPrefs: [])
+      hdrEngaged: true, nonDefaultPrefs: [],
+      volumeAvailability: "Available: not asked yet",
+      soundOutput: "macOS reports no default output device")
     let s = DiagnosticsReportSnapshot(
       appVersion: "1", osVersion: "2", safeMode: true, accessibilityGranted: false,
       launchAtLogin: "disabled", displays: [e], recentEvents: [])
@@ -81,7 +85,9 @@ struct DiagnosticsReportTests {
         name: "Right", hardwareName: "MSI MAG 341C", connection: "HDMI",
         manufacturer: "MSI", hasSerial: false, currentMode: "3440 × 1440 at 175 Hz",
         controlMethod: "Hardware (DDC)", readbackVerdict: "write-only",
-        hdrEngaged: false, nonDefaultPrefs: ["forceSw = true", "minDDCOverride.brightness = 12"])],
+        hdrEngaged: false, nonDefaultPrefs: ["forceSw = true", "minDDCOverride.brightness = 12"],
+        volumeAvailability: "Available: no usable answer",
+        soundOutput: "MSI MAG 341C: matched to this display")],
       recentEvents: ["12:01 MSI MAG 341C arrived", "12:00 DELL U2725QE departed"])
     let text = DiagnosticsReport.render(s)
     for needle in ["Left", "Right", "MSI MAG 341C", "write-only",
@@ -108,7 +114,9 @@ struct DiagnosticsReportTests {
       name: "Left", hardwareName: "DELL U2725QE", connection: nil,
       manufacturer: nil, hasSerial: true, currentMode: nil,
       controlMethod: "Software (gamma)", readbackVerdict: "never asked",
-      hdrEngaged: true, nonDefaultPrefs: [])
+      hdrEngaged: true, nonDefaultPrefs: [],
+      volumeAvailability: "Available: not asked yet",
+      soundOutput: "macOS reports no default output device")
     let s = DiagnosticsReportSnapshot(
       appVersion: "1", osVersion: "2", safeMode: false, accessibilityGranted: true,
       launchAtLogin: "enabled", displays: [e], recentEvents: [])


### PR DESCRIPTION
Diagnostic reports omit the Volume availability reason and current Sound output shown in Settings, so audio reports require an additional screenshot. Include both fields for each external display in Copy Report and Save Report, using the same derivation as the Diagnostics page.

The report samples the audio output once per copy, includes its display-name match result, and explicitly distinguishes no output, unanswered capabilities, unsupported volume, and manual overrides. Built-in displays are marked not applicable. No hardware writes, extra probes, serial values, or audio device identifiers are added.

Validation: the full engine suite passed (2,512 tests), the full app suite passed (565 tests), and an independent review found no issues. The combined 1.0.3 branch also passed all 2,512 engine and 586 app tests. Regression tests exercise the rendered report, per-display matching, output changes/removal, capability verdicts, and overrides.

Related to #57. This only addresses the audio-report fields; the remaining diagnostics and lifecycle work stays open. Targeted for 1.0.3.

When combining with #64, preserve the observable default audio output for the Settings page. The combined 1.0.3 branch uses that source while reports take a fresh provider snapshot.

Live verification passed in the installed combined candidate: Copy Report and Save Report produced identical reports. The Dell reported unsupported volume, the MSI reported an unanswered capability probe with volume left available, both named the current MacBook speaker output as unmatched, and the built-in entries were not applicable. The report contained neither the known display serial nor its persistence key.


