### PR TITLE
Sync 1.0.3 release note wording

### DIFF
--- a/site/public/appcast.xml
+++ b/site/public/appcast.xml
@@ -19,7 +19,7 @@
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
       <description sparkle:format="markdown"><![CDATA[
 ## New
-- Updates: updates from 1.0.3 onward show a brief, dismissible version confirmation.
+- Updates: updates from 1.0.3 onward show a brief, dismissible version confirmation after being installed.
 
 ## Changed
 - Controls: background polling is optimized to reduce CPU usage while idle.


### PR DESCRIPTION
Keep the Sparkle confirmation bullet in sync with the published GitHub release wording. The release packages and signature are unchanged.

Validated matching release notes and a successful production site build.
