### PR TITLE
Invite GitHub support from the site footer and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-e8a13a" alt="MIT license"></a>
 </p>
 
+<p align="center">Find Candela useful? Star this repository to support the project.</p>
+
 <p align="center">
   <img src=".github/assets/hero.webp" width="880" alt="Candela: the headline The display software Apple forgot to ship, beside a display's page, the Health pane, the heat map, and the menu-bar controls">
 </p>

--- a/site/src/GuidePage.tsx
+++ b/site/src/GuidePage.tsx
@@ -1,6 +1,6 @@
 import { Header } from './components/Header'
 import { Footer } from './components/Footer'
-import { guides as copy, hero, navigation } from './content/copy'
+import { guides as copy, githubStarLabel, hero, navigation } from './content/copy'
 import { formatGuideDate, type Guide } from './guides'
 import candelaMark from './assets/candela-c.svg'
 import './components/Guide.css'
@@ -57,7 +57,7 @@ export function GuidePage({ guide, guides }: { guide: Guide; guides: Guide[] }) 
                 {hero.ctaPrimary}
               </a>
               <a className="guide-try-secondary" href="/github?placement=guide">
-                {hero.ctaSecondary}
+                {githubStarLabel}
               </a>
               <span className="guide-try-foss">{hero.foss}</span>
             </div>

--- a/site/src/Guides.test.tsx
+++ b/site/src/Guides.test.tsx
@@ -26,7 +26,7 @@ const brightness: Guide = {
 
 // Every accessible name the site gives a Download or GitHub control, so no
 // chrome escapes the placement sweep.
-const actionNames = ['Download', 'Download for macOS', 'GitHub', 'View on GitHub']
+const actionNames = ['Download', 'Download for macOS', 'GitHub', 'Star on GitHub']
 
 function actionHrefs(queryAllByRole: ReturnType<typeof render>['queryAllByRole']) {
   return actionNames.flatMap((name) =>

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { footer, hero, navigation } from '../content/copy'
+import { footer, githubStarLabel, hero, navigation } from '../content/copy'
 import candelaMark from '../assets/candela-c.svg'
 import './Closing.css'
 
@@ -18,7 +18,7 @@ export function Footer({ placement = 'footer' }: { placement?: 'footer' | 'guide
             {hero.ctaPrimary}
           </a>
           <a className="footer-link" href={`/github?placement=${placement}`}>
-            {hero.ctaSecondary}
+            {githubStarLabel}
           </a>
           <a className="footer-link" href="/guides/">
             {navigation.guides}

--- a/site/src/content/copy.ts
+++ b/site/src/content/copy.ts
@@ -29,6 +29,8 @@ export const hero: {
   foss: "Free and open source, forever.",
 }
 
+export const githubStarLabel = "Star on GitHub"
+
 // The hero's click-to-copy Homebrew pill. The tap repo does not exist yet:
 // creating Rydersel/homebrew-tap with the candela cask is a recorded deploy
 // gate, because the command must work on the day the site does.


### PR DESCRIPTION
## What

Change the website footer and guide-page repository links to "Star on GitHub" and add a short support invitation to the README. The main hero keeps "View on GitHub" and has no extra support sentence.

## Why

Give interested readers a clear way to support Candela while keeping the download path uncluttered. Existing link destinations and analytics placements are preserved.

## Hardware verification

Hardware-free website and documentation changes. Checked the production preview on desktop and mobile.

## Checks

- [x] Website tests: 131 passed
- [x] Website lint and production build pass
- [x] Existing guide tests verify the renamed links retain their analytics placement
- [x] `make check`: 2,512 engine tests and 586 app tests passed on the combined work
- [x] No ticket numbers in source comments or new em dashes
