### PR TITLE
Add GitHub support links in About and future release notes

### DIFF
--- a/.github/RELEASE_NOTES_FOOTER.md
+++ b/.github/RELEASE_NOTES_FOOTER.md
@@ -1,0 +1,4 @@
+
+---
+
+Support Candela: [Star on GitHub](https://github.com/Rydersel/Candela).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,18 @@ takes a week.
 - No em dashes in user-visible text or in new comments.
 - English only. No localization tooling.
 
+## GitHub release notes
+
+After the changes, append the contents of
+[`.github/RELEASE_NOTES_FOOTER.md`](.github/RELEASE_NOTES_FOOTER.md) to the
+GitHub release description. GitHub does not apply this file automatically;
+include it when preparing the description, including when using generated
+release notes.
+
+Keep the original change-only notes for Sparkle. Its appcast generator
+accepts only `New`, `Changed`, `Fixed`, and `Removed` sections with change
+bullets, so the GitHub support footer belongs only in the GitHub description.
+
 ## Two rules that protect hardware
 
 Read these before touching anything that writes to a display.

--- a/Candela/App/AppInfo.swift
+++ b/Candela/App/AppInfo.swift
@@ -5,6 +5,8 @@ enum AppInfo {
   /// rename stays a one-line change.
   static let productName = "Candela"
 
+  static let repositoryURL = URL(string: "https://github.com/Rydersel/Candela")!
+
   /// The build number is the same string (project.yml sets one from the
   /// other), so there is no second number to show anywhere.
   static var version: String {

--- a/Candela/Settings/AboutPane.swift
+++ b/Candela/Settings/AboutPane.swift
@@ -5,9 +5,6 @@ import SwiftUI
 /// `@MainActor` matches every other pane: on `View` only `body` is isolated,
 /// and both `SettingsActions` and `UpdaterModel` are `@MainActor` types.
 ///
-/// No Donate button and no project links: every fork link points at a
-/// project Candela is not.
-///
 /// Sparkle owns every updater setting (`SUEnableAutomaticChecks` and friends
 /// are its schema, not `PrefName` cases), so writes here go through
 /// `UpdaterModel` and we persist nothing.
@@ -63,8 +60,14 @@ struct AboutPane: View {
       // display's Diagnostics page, which disappears with the display; this one
       // survives the monitor that just stopped working.
       SettingsCardSection(title: "Support") {
-        SettingsActionRow("Covers every display. The report doesn't include serial numbers.") {
+        SettingsActionRow("Covers every display. The report doesn't include serial numbers.", dividerFollows: true) {
           DiagnosticsReportActions()
+        }
+        SettingsCardDivider()
+        SettingsActionRow("\(AppInfo.productName) is free and open source.") {
+          Link("Star on GitHub", destination: AppInfo.repositoryURL)
+            .buttonStyle(SettingsSecondaryButtonStyle())
+            .accessibilityLabel("Star on GitHub")
         }
       }
 


### PR DESCRIPTION
## What

Add a secondary "Star on GitHub" link to Settings > About > Support, pointing directly to Candela's repository. Add a reusable GitHub release-note footer and document the manual step for including it in future release descriptions.

## Why

Give people already using Candela a quiet way to support the project. The footer is for GitHub release descriptions only; Sparkle keeps its strict change-only notes.

## Hardware verification

Hardware-free UI and documentation changes. The app was built without launching it or issuing display commands. The link uses SwiftUI's standard browser-opening behavior and the existing secondary button style.

## Checks

- [x] `make check`: 2,512 engine tests and 586 app tests passed
- [x] `make build` passes
- [x] No new custom action logic; static repository URL and standard SwiftUI Link
- [x] Release-footer use is documented as manual and GitHub-only
- [x] No ticket numbers in source comments or new em dashes
