### PR TITLE
Adapt regional dimming to content, activity, and exposure

### DIFF
--- a/Candela/AppKitIslands/MediaKeyEventTap.swift
+++ b/Candela/AppKitIslands/MediaKeyEventTap.swift
@@ -139,6 +139,12 @@ final class MediaKeyEventTap {
       (pingPosted: Date?, pingSeen: Date, probing: Date?, alive: Date)
     >(initialState: (nil, Date(), nil, Date()))
     let callback: EventTapCallback = { type, event in
+      // Record the notification before inspecting its payload: a disabled tap
+      // and a stalled event stream otherwise produce the same watchdog verdict.
+      if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        let marked = event.getIntegerValueField(.eventSourceUserData) == Self.pingMagic
+        Self.watchdogLog.notice("tap disabled: type=\(type.rawValue) pingMarker=\(marked)")
+      }
       // Self-ping marker: our own prober posted this event. Stamp its arrival
       // and swallow it, since it is not for the system.
       if event.getIntegerValueField(.eventSourceUserData) == Self.pingMagic {
@@ -221,6 +227,7 @@ final class MediaKeyEventTap {
         // spinning orphaned.
         CFRunLoopAddSource(runLoop, threadSource, .commonModes)
         CFRunLoopRun()
+        Self.watchdogLog.notice("tap run loop exited")
       }
     }
     thread.name = "MediaKeyEventTap"
@@ -354,8 +361,10 @@ final class MediaKeyEventTap {
           heartbeat.withLock { $0.pingPosted = nil; $0.probing = nil; $0.alive = now.wall }
           continue
         case .wedged(let pingLost, let probeStuck, let proberDead):
+          let pingAge = hb.pingPosted.map { now.wall.timeIntervalSince($0) } ?? -1
+          let seenAge = now.wall.timeIntervalSince(hb.pingSeen)
           Self.watchdogLog.fault(
-            "EMERGENCY: pingLost=\(pingLost) probeStuck=\(probeStuck) proberDead=\(proberDead)"
+            "EMERGENCY: pingLost=\(pingLost) probeStuck=\(probeStuck) proberDead=\(proberDead) pingAge=\(pingAge) lastPingSeenAge=\(seenAge)"
           )
           Self.teardown(watchdogRuntime)
           // Invalidating the port is NOT enough once the wedge has formed

--- a/Candela/OledCare/AdaptiveInputRestore.swift
+++ b/Candela/OledCare/AdaptiveInputRestore.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Coalesces a burst of input while retaining the latest focus/pointer state.
+@MainActor
+final class AdaptiveInputRestore {
+  private let delay: @MainActor () async throws -> Void
+  private let restore: @MainActor () -> Void
+  private var pending: Task<Void, Never>?
+
+  init(delay: @escaping @MainActor () async throws -> Void = {
+    try await Task.sleep(for: .milliseconds(100))
+  }, restore: @escaping @MainActor () -> Void) {
+    self.delay = delay
+    self.restore = restore
+  }
+
+  /// Requests within one burst share a completion handle.
+  @discardableResult
+  func request() -> Task<Void, Never> {
+    if let pending { return pending }
+    let batch = Task { @MainActor [weak self] in
+      guard let delay = self?.delay else { return }
+      do { try await delay() } catch { return }
+      guard !Task.isCancelled, let self else { return }
+      self.pending = nil
+      self.restore()
+    }
+    pending = batch
+    return batch
+  }
+
+  func cancel() {
+    pending?.cancel()
+    pending = nil
+  }
+
+  deinit { pending?.cancel() }
+}

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -120,7 +120,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     /// the cheaper scalar path.
     var nominatedMask: OverlayMask?
     var adaptiveActivity = AdaptiveRegionProtection.Activity(
-      isFocusedDisplay: nil, frontmostPID: nil, pointerCell: nil)
+      isFocusedDisplay: nil, frontmostPID: nil, pointerPosition: nil)
     /// Throttle for `refreshNominationGeometry`; nil until evidence first arrives.
     var lastNominationRefreshAt: SuspendingClock.Instant?
     /// Verification marker: the last render mutated window-server state; verify it on a
@@ -417,7 +417,7 @@ final class OledCareCoordinator: CheckupCareHolding {
           guard let self else { return }
           self.tick()
           interval = self.cadence()
-          if self.anyDimUp() {
+          if self.anyDimUp() || self.needsAdaptiveInput() {
             self.armInputMonitor()
           } else {
             self.disarmInputMonitor()
@@ -881,7 +881,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     let focusedDisplay = needsFocus ? focus.focusedDisplayID() : nil
     let currentFocus = needsFocus ? focus.currentResolvedDisplayID : nil
     let frontmostPID = anyAdaptiveEnabled ? NSWorkspace.shared.frontmostApplication?.processIdentifier : nil
-    let pointer = anyAdaptiveEnabled && idleSeconds < 30 ? CGEvent(source: nil)?.location : nil
+    let pointer = anyAdaptiveEnabled ? CGEvent(source: nil)?.location : nil
     // ID to key resolved fresh every tick; IDs reassign and are never cached as
     // identity. Uniquing defensively: two identical panels can collide on
     // persistenceKey, and a crash would be worse than one of them winning.
@@ -1021,14 +1021,15 @@ final class OledCareCoordinator: CheckupCareHolding {
       // resolves and the `isSynthesis` verdict above describe one instant.
       let target = OledTelemetryTarget(panel: id, topology: topology)
       if state.detectionDimmingEnabled {
-        let pointerCell = pointer.flatMap { point in
-          Self.transform(target)?.cell(forDisplayPoint: CGPoint(
-            x: point.x - CGDisplayBounds(target.surface).minX,
-            y: point.y - CGDisplayBounds(target.surface).minY))
+        let surfaceBounds = CGDisplayBounds(target.surface)
+        let pointerPosition = pointer.map { point in
+          // Keep off-display coordinates: a window spanning displays restores
+          // on both when hovered on either half. The window list does the same.
+          CGPoint(x: point.x - surfaceBounds.minX, y: point.y - surfaceBounds.minY)
         }
         let activity = AdaptiveRegionProtection.Activity(
           isFocusedDisplay: currentFocus.map { $0 == target.surface },
-          frontmostPID: frontmostPID, pointerCell: pointerCell,
+          frontmostPID: frontmostPID, pointerPosition: pointerPosition,
           captureExcludedPID: ProcessInfo.processInfo.processIdentifier)
         if activity != state.adaptiveActivity {
           // A newly raised foreground window must not inherit the cached
@@ -1100,6 +1101,7 @@ final class OledCareCoordinator: CheckupCareHolding {
       anyLockDimEngaged: states.values.contains(where: \.lockDimEngaged),
       verificationPending: states.values.contains(where: \.needsVerify)
         || !pendingRemovalVerifications.isEmpty,
+      windowRestorationPending: adaptiveProtection.values.contains(where: \.isRestoringWindows),
       nominationDisplayed: anyNominationDisplayed(),
       anythingEnrolled: !states.isEmpty
     )
@@ -1129,6 +1131,12 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// harmlessly, since every one of those states takes the fast term first.
   private func anyNominationDisplayed() -> Bool {
     states.values.contains { $0.nominatedMask != nil && $0.lastAppliedAlpha != nil }
+  }
+
+  /// Hovering may remove the last visible mask. Keep listening so leaving it
+  /// starts the grace promptly, without forcing fast polling while parked.
+  private func needsAdaptiveInput() -> Bool {
+    anyNominationDisplayed() || adaptiveProtection.values.contains(where: \.needsInputTracking)
   }
 
   // MARK: - Event-driven restore
@@ -1167,7 +1175,7 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// the monitor stays armed: a mouse move followed by an app switch belongs
   /// in one bounded batch, not two events separated by the slow driver tick.
   private func inputArrived() {
-    if anyNominationDisplayed(), !anyOverlayDimUp(),
+    if needsAdaptiveInput(), !anyOverlayDimUp(),
       !states.values.contains(where: \.lockDimEngaged) {
       adaptiveInputRestore.request()
     } else {
@@ -1403,10 +1411,10 @@ final class OledCareCoordinator: CheckupCareHolding {
     var protection = adaptiveProtection[key] ?? AdaptiveRegionProtection()
     protection.record(displayGrid: grid, cols: cols, rows: rows, through: transform,
                       observation: observation, at: now)
-    adaptiveProtection[key] = protection
     states[key]?.nominatedMask = protection.nominate(
       observation: observation, exposure: accumulators[key]?.map ?? .empty,
-      activity: state.adaptiveActivity, at: now)
+      activity: state.adaptiveActivity, windows: latestWindows[key] ?? [], at: now)
+    adaptiveProtection[key] = protection
   }
 
   private enum VerifyOutcome {
@@ -1539,7 +1547,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     at now: SuspendingClock.Instant
   ) {
     guard state.detectionDimmingEnabled, state.telemetryEnabled,
-      state.windowObservationEnabled, let protection = adaptiveProtection[key]
+      state.windowObservationEnabled, var protection = adaptiveProtection[key]
     else {
       state.nominatedMask = nil
       return
@@ -1565,7 +1573,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     }
     state.nominatedMask = protection.nominate(
       observation: observation, exposure: accumulators[key]?.map ?? .empty,
-      activity: state.adaptiveActivity, at: Date())
+      activity: state.adaptiveActivity, windows: latestWindows[key] ?? [], at: Date())
+    adaptiveProtection[key] = protection
   }
 
   /// The panel-to-surface resolution against the topology AS IT STANDS NOW.

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -113,13 +113,15 @@ final class OledCareCoordinator: CheckupCareHolding {
     /// `.active` is exactly when detection dimming runs.
     var assertionHeld = false
     /// The current nomination in PANEL space. The LUMINANCE half changes only
-    /// when a new sample lands; the WINDOW half is re-read once a second while a
-    /// nomination is displayed (`refreshNominationGeometry`), so a moved window
+    /// when a new sample lands; the WINDOW half is refreshed while evidence is
+    /// present (`refreshNominationGeometry`), so a moved window
     /// sheds its dim in about a second. Nil means "nothing qualifies",
     /// deliberately distinguishable from an all-zero mask: the render then keeps
     /// the cheaper scalar path.
     var nominatedMask: OverlayMask?
-    /// Throttle for `refreshNominationGeometry`; nil until a mask first shows.
+    var adaptiveActivity = AdaptiveRegionProtection.Activity(
+      isFocusedDisplay: nil, frontmostPID: nil, pointerCell: nil)
+    /// Throttle for `refreshNominationGeometry`; nil until evidence first arrives.
     var lastNominationRefreshAt: SuspendingClock.Instant?
     /// Verification marker: the last render mutated window-server state; verify it on a
     /// LATER tick than the one that mutated.
@@ -205,6 +207,10 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// also at what level.
   @ObservationIgnored private var wearTrackers: [String: WearSignalTracker] = [:]
   @ObservationIgnored private let sampler = LuminanceSampler()
+  @ObservationIgnored private var adaptiveProtection: [String: AdaptiveRegionProtection] = [:]
+  @ObservationIgnored private lazy var adaptiveInputRestore = AdaptiveInputRestore { [weak self] in
+    self?.tick()
+  }
   /// Accumulated exposure per panel, by persistenceKey, restored from disk on
   /// first touch and kept for the app's lifetime: wear is a fact about a panel,
   /// not about a connection, exactly like `trackers`.
@@ -361,6 +367,16 @@ final class OledCareCoordinator: CheckupCareHolding {
     // standby edge on the wrong side of it. AppKit posts these on the main
     // thread, which is what `assumeIsolated` asserts and would trap on.
     let center = NSWorkspace.shared.notificationCenter
+    // App activation is observable without Accessibility permission. It covers
+    // keyboard app switching even when the global key monitor cannot see it.
+    sleepWakeObservers.append(center.addObserver(
+      forName: NSWorkspace.didActivateApplicationNotification, object: nil, queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        guard let self, self.states.values.contains(where: \.detectionDimmingEnabled) else { return }
+        self.inputArrived()
+      }
+    })
     sleepWakeObservers.append(center.addObserver(
       forName: NSWorkspace.willSleepNotification, object: nil, queue: nil
     ) { [weak self] _ in
@@ -758,6 +774,7 @@ final class OledCareCoordinator: CheckupCareHolding {
         let hasProducers = existing.telemetryEnabled && existing.windowObservationEnabled
         if !existing.detectionDimmingEnabled || !hasProducers {
           existing.nominatedMask = nil
+          adaptiveProtection.removeValue(forKey: key)
         }
         // The window ages go with it. `WindowObserver` holds a per-window
         // "unchanged since" instant and that clock keeps running while
@@ -855,12 +872,16 @@ final class OledCareCoordinator: CheckupCareHolding {
     let isLocked = lockObserver.isLocked
     let topology = model.mirrorTopology.topology()
     let now = SuspendingClock.now
-    // Focus is sampled only when some enrolled display wants unfocused dim, at
+    // Focus is sampled when an enrolled display wants unfocused or regional dim, at
     // whatever cadence the loop is running, which IS the overlay-up cadence
     // whenever an overlay is up: a clicked display must not stay dimmed for
     // seconds. 0.46 ms per call [MEASURED], under 1% of a core at 10 Hz.
-    let anyUnfocusedEnabled = states.values.contains(where: \.unfocusedDimEnabled)
-    let focusedDisplay = anyUnfocusedEnabled ? focus.focusedDisplayID() : nil
+    let anyAdaptiveEnabled = states.values.contains(where: \.detectionDimmingEnabled)
+    let needsFocus = anyAdaptiveEnabled || states.values.contains(where: \.unfocusedDimEnabled)
+    let focusedDisplay = needsFocus ? focus.focusedDisplayID() : nil
+    let currentFocus = needsFocus ? focus.currentResolvedDisplayID : nil
+    let frontmostPID = anyAdaptiveEnabled ? NSWorkspace.shared.frontmostApplication?.processIdentifier : nil
+    let pointer = anyAdaptiveEnabled && idleSeconds < 30 ? CGEvent(source: nil)?.location : nil
     // ID to key resolved fresh every tick; IDs reassign and are never cached as
     // identity. Uniquing defensively: two identical panels can collide on
     // persistenceKey, and a crash would be worse than one of them winning.
@@ -999,6 +1020,30 @@ final class OledCareCoordinator: CheckupCareHolding {
       // target is built from THIS tick's topology sample, so the surface it
       // resolves and the `isSynthesis` verdict above describe one instant.
       let target = OledTelemetryTarget(panel: id, topology: topology)
+      if state.detectionDimmingEnabled {
+        let pointerCell = pointer.flatMap { point in
+          Self.transform(target)?.cell(forDisplayPoint: CGPoint(
+            x: point.x - CGDisplayBounds(target.surface).minX,
+            y: point.y - CGDisplayBounds(target.surface).minY))
+        }
+        let activity = AdaptiveRegionProtection.Activity(
+          isFocusedDisplay: currentFocus.map { $0 == target.surface },
+          frontmostPID: frontmostPID, pointerCell: pointerCell,
+          captureExcludedPID: ProcessInfo.processInfo.processIdentifier)
+        if activity != state.adaptiveActivity {
+          // A newly raised foreground window must not inherit the cached
+          // geometry of the app it just covered.
+          state.lastNominationRefreshAt = nil
+          state.adaptiveActivity = activity
+        }
+      }
+      // Pauses invalidate short-lived evidence, never cumulative exposure.
+      // History cannot make a post-wake frame instantly count as static.
+      if newState != .active || !awake || isLocked || assertionHeld || hdrSettling {
+        adaptiveProtection.removeValue(forKey: key)
+        state.nominatedMask = nil
+        state.lastNominationRefreshAt = nil
+      }
       updateTelemetry(for: key, state: &state, dimState: newState, on: target, at: now)
       // Mutates the LOCAL copy, deliberately before this tick's render: the
       // sample path's `renominate` writes `states[key]` because it lands
@@ -1064,10 +1109,11 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// cadence but gives an input event nothing to do.
   private func anyDimUp() -> Bool {
     anyOverlayDimUp() || states.values.contains(where: \.lockDimEngaged)
+      || anyNominationDisplayed()
   }
 
-  /// An overlay that is up BECAUSE the display is dimmed, as opposed to detection
-  /// dimming's mask on an `.active` display, which no input clears. `tick()`
+  /// An overlay that is up BECAUSE the whole display is dimmed, as opposed to
+  /// regional protection on an `.active` display. `tick()`
   /// assigns `dimStates` before the driver asks, so this is this tick's verdict.
   /// A display that departed mid-debounce reads as no dim; its teardown
   /// verification rides the pending-removal list, which runs fast on its own.
@@ -1112,15 +1158,22 @@ final class OledCareCoordinator: CheckupCareHolding {
   }
 
   private func disarmInputMonitor() {
+    adaptiveInputRestore.cancel()
     for monitor in inputMonitors { NSEvent.removeMonitor(monitor) }
     inputMonitors.removeAll()
   }
 
-  /// Single-shot: a pointer move is a stream of events and a tick per event would
-  /// run the loop at the input rate. The driver re-arms next turn if a dim is still up.
+  /// Uniform dims retain the immediate, one-shot restore. For regional masks
+  /// the monitor stays armed: a mouse move followed by an app switch belongs
+  /// in one bounded batch, not two events separated by the slow driver tick.
   private func inputArrived() {
-    disarmInputMonitor()
-    tick()
+    if anyNominationDisplayed(), !anyOverlayDimUp(),
+      !states.values.contains(where: \.lockDimEngaged) {
+      adaptiveInputRestore.request()
+    } else {
+      disarmInputMonitor()
+      tick()
+    }
   }
 
   // MARK: - Lock dim (delivered on the wire, not by an overlay)
@@ -1338,23 +1391,22 @@ final class OledCareCoordinator: CheckupCareHolding {
   private func renominate(
     for key: String, grid: [Double], cols: Int, rows: Int, through transform: PanelSpaceTransform
   ) {
-    guard states[key]?.detectionDimmingEnabled == true else {
-      states[key]?.nominatedMask = nil
-      return
-    }
-    guard states[key]?.windowObservationEnabled == true,
-      let observation = latestObservations[key]
+    guard let state = states[key], state.detectionDimmingEnabled,
+      state.telemetryEnabled, state.windowObservationEnabled,
+      !state.assertionHeld, let observation = latestObservations[key]
     else {
-      // No window list means no staticness prior, and the conjunction is the
-      // feature. The pref is checked as well as the value: a retained
-      // observation from before the user switched it off is exactly as stale
-      // as the nomination it would produce.
+      adaptiveProtection.removeValue(forKey: key)
       states[key]?.nominatedMask = nil
       return
     }
-    let panelGrid = transform.panelNativeGrid(fromDisplayGrid: grid, cols: cols, rows: rows)
-    states[key]?.nominatedMask = StaticRegionDetector.nominate(
-      recentGrid: panelGrid, observation: observation, thresholds: .default)
+    let now = Date()
+    var protection = adaptiveProtection[key] ?? AdaptiveRegionProtection()
+    protection.record(displayGrid: grid, cols: cols, rows: rows, through: transform,
+                      observation: observation, at: now)
+    adaptiveProtection[key] = protection
+    states[key]?.nominatedMask = protection.nominate(
+      observation: observation, exposure: accumulators[key]?.map ?? .empty,
+      activity: state.adaptiveActivity, at: now)
   }
 
   private enum VerifyOutcome {
@@ -1393,11 +1445,20 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// sleep): after a reconfiguration the old IDs may name different panels, so a
   /// verify keyed on the new resolution would ask the wrong question.
   private func clearAllOverlays(verifyRemoval: Bool = false) {
+    adaptiveInputRestore.cancel()
+    exposureEpoch += 1
+    adaptiveProtection.removeAll()
+    observers.removeAll()
+    latestObservations.removeAll()
+    latestWindows.removeAll()
     overlay.removeAll()
     for key in states.keys {
       states[key]?.lastAppliedAlpha = nil
       states[key]?.lastAppliedBlackout = false
       states[key]?.needsVerify = verifyRemoval
+      states[key]?.lastAppliedMask = nil
+      states[key]?.nominatedMask = nil
+      states[key]?.lastNominationRefreshAt = nil
       states[key]?.verifyAttempts = 0
     }
   }
@@ -1469,42 +1530,42 @@ final class OledCareCoordinator: CheckupCareHolding {
     persistExposureHistoryIfDue(at: now)
   }
 
-  /// Re-checks the WINDOW half of a displayed nomination on the fast loop.
-  ///
-  /// On the sampling clock alone the mask stayed frozen against window geometry
-  /// for up to a minute, so a dim sat on whatever slid under it after a move,
-  /// which is what burn-in looks like. This re-reads the window list and re-runs
-  /// the pure rule against the cached panel grid. Gated on a mask being
-  /// DISPLAYED: a nomination appearing one slot late is fine, one lingering a
-  /// slot too long is the defect.
-  ///
-  /// Books NOTHING. Owner hours accumulate at the nominal sampling interval
-  /// per observation in `observeWindows`; booking here would multiply them by
-  /// the refresh rate. Refreshing the shared observer is safe because its
-  /// ages are wall-clock spans, not per-call accumulation.
+  /// Refresh geometry once a second while adaptive evidence exists. Activity
+  /// and sample freshness are evaluated on every tick, so an input-driven tick
+  /// can lift the foreground app without waiting for another capture.
+  /// Books no owner hours; the minute observation remains their only writer.
   private func refreshNominationGeometry(
     for key: String, state: inout PerDisplay, on target: OledTelemetryTarget,
     at now: SuspendingClock.Instant
   ) {
-    guard state.nominatedMask != nil, state.detectionDimmingEnabled,
-      state.windowObservationEnabled
-    else { return }
-    if let last = state.lastNominationRefreshAt,
-      now - last < Self.nominationGeometryInterval { return }
-    state.lastNominationRefreshAt = now
-    guard let transform = Self.transform(target),
-      let cached = latestSamples[key]
-    else { return }
-    let windows = windowList(target.surface)
-    var observer = observers[key] ?? WindowObserver()
-    let observation = observer.observe(windows, through: transform, at: Date())
-    observers[key] = observer
-    latestObservations[key] = observation
-    latestWindows[key] = windows
-    // `cells` is already panel-native (re-binned at accept time), matching
-    // what `renominate` derives before calling the same rule.
-    state.nominatedMask = StaticRegionDetector.nominate(
-      recentGrid: cached.cells, observation: observation, thresholds: .default)
+    guard state.detectionDimmingEnabled, state.telemetryEnabled,
+      state.windowObservationEnabled, let protection = adaptiveProtection[key]
+    else {
+      state.nominatedMask = nil
+      return
+    }
+    if state.lastNominationRefreshAt == nil
+      || now - state.lastNominationRefreshAt! >= Self.nominationGeometryInterval {
+      state.lastNominationRefreshAt = now
+      guard let transform = Self.transform(target) else {
+        adaptiveProtection.removeValue(forKey: key)
+        state.nominatedMask = nil
+        return
+      }
+      let windows = windowList(target.surface)
+      var observer = observers[key] ?? WindowObserver()
+      let observation = observer.observe(windows, through: transform, at: Date())
+      observers[key] = observer
+      latestObservations[key] = observation
+      latestWindows[key] = windows
+    }
+    guard let observation = latestObservations[key] else {
+      state.nominatedMask = nil
+      return
+    }
+    state.nominatedMask = protection.nominate(
+      observation: observation, exposure: accumulators[key]?.map ?? .empty,
+      activity: state.adaptiveActivity, at: Date())
   }
 
   /// The panel-to-surface resolution against the topology AS IT STANDS NOW.
@@ -1635,6 +1696,8 @@ final class OledCareCoordinator: CheckupCareHolding {
   }
 
   private func forgetWindowObservation(for key: String) {
+    adaptiveProtection.removeValue(forKey: key)
+    states[key]?.nominatedMask = nil
     observers.removeValue(forKey: key)
     latestObservations.removeValue(forKey: key)
     latestWindows.removeValue(forKey: key)
@@ -1679,7 +1742,12 @@ final class OledCareCoordinator: CheckupCareHolding {
     through transform: PanelSpaceTransform, epoch: Int
   ) {
     states[key]?.sampleInFlight = false
-    guard let sample, epoch == exposureEpoch else { return }
+    guard epoch == exposureEpoch else { return }
+    guard let sample else {
+      adaptiveProtection.removeValue(forKey: key)
+      states[key]?.nominatedMask = nil
+      return
+    }
     // Re-resolved, never re-used: a synthesized size can be disengaged inside
     // the suspension, which moves the desktop back onto the panel and changes
     // both the surface the sample came from and the qualification that let it
@@ -1724,6 +1792,13 @@ final class OledCareCoordinator: CheckupCareHolding {
     // Detection dimming's luminance half nominates here, off the sampling clock:
     // the grid changes once a minute, so recomputing faster reaches the same
     // answer. The window half does NOT wait for it.
+    if state.detectionDimmingEnabled, state.windowObservationEnabled {
+      let windows = windowList(current.surface)
+      var observer = observers[key] ?? WindowObserver()
+      latestObservations[key] = observer.observe(windows, through: transform, at: Date())
+      observers[key] = observer
+      latestWindows[key] = windows
+    }
     renominate(for: key, grid: sample.grid, cols: sample.cols, rows: sample.rows,
                through: transform)
     log.debug("""

--- a/Candela/OledCare/OledCareSignals.swift
+++ b/Candela/OledCare/OledCareSignals.swift
@@ -194,6 +194,14 @@ final class LockStateObserver {
 @MainActor
 final class FocusSampler {
   private var lastResolved: CGDirectDisplayID?
+  private let resolveCurrent: () -> CGDirectDisplayID?
+
+  init(resolver: (() -> CGDirectDisplayID?)? = nil) {
+    resolveCurrent = resolver ?? Self.resolve
+  }
+  /// Unlike the held value used by idle dimming, adaptive protection needs a
+  /// fresh resolution. A transient miss must not nominate a possibly active app.
+  private(set) var currentResolvedDisplayID: CGDirectDisplayID?
 
   /// Forgets the held resolution. The coordinator calls this on every display
   /// reconfiguration, and the reason is ID REASSIGNMENT, not departure: display
@@ -204,17 +212,16 @@ final class FocusSampler {
   /// must read as "no data" and never as "no display focused".
   func invalidate() {
     self.lastResolved = nil
+    currentResolvedDisplayID = nil
   }
 
   func focusedDisplayID() -> CGDirectDisplayID? {
-    if let resolved = self.resolve() {
-      self.lastResolved = resolved
-      return resolved
-    }
-    return self.lastResolved
+    currentResolvedDisplayID = resolveCurrent()
+    if let resolved = currentResolvedDisplayID { lastResolved = resolved }
+    return lastResolved
   }
 
-  private func resolve() -> CGDirectDisplayID? {
+  private static func resolve() -> CGDirectDisplayID? {
     guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
     guard let windows = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID)
       as? [[String: Any]] else { return nil }

--- a/Candela/Settings/OledCareDisplayPage.swift
+++ b/Candela/Settings/OledCareDisplayPage.swift
@@ -536,9 +536,9 @@ struct OledCareDisplayPage: View {
   /// says when it is the live reason.
   ///
   /// Regional protection uses sampled persistence and window ownership. Focus
-  /// and recent pointer activity are exclusions, not an estimate of gaze.
+  /// and the hovered window are exclusions, not an estimate of gaze.
   private var detectionControls: some View {
-    SettingRow("Bright regions that stay unchanged across several samples can dim, with extra protection for areas with higher recorded exposure. Your foreground app and the area around recent pointer activity stay undimmed. Full-screen content and anything holding the screen awake pause this protection. This needs both measurement settings on the Health pane. Sampling can miss motion; turn this off when judging colors or brightness.") {
+    SettingRow("Bright regions that stay unchanged across several samples can dim, with extra protection for areas with higher recorded exposure. Your foreground app and the window under your pointer stay undimmed. After the pointer leaves, regional dimming returns gradually after a short pause. Full-screen content and anything holding the screen awake pause this protection. This needs both measurement settings on the Health pane. Sampling can miss motion; turn this off when judging colors or brightness.") {
       VStack(alignment: .leading, spacing: 6) {
         Toggle("Automatic static-region dimming", isOn: Binding(
           get: { prefs.oledDetectionDimming },

--- a/Candela/Settings/OledCareDisplayPage.swift
+++ b/Candela/Settings/OledCareDisplayPage.swift
@@ -535,15 +535,10 @@ struct OledCareDisplayPage: View {
   /// this control as surely as a video does. The caption lists it; the note
   /// says when it is the live reason.
   ///
-  /// The caption promises exactly what the code delivers. "Full-screen video is
-  /// never dimmed" is the `fullScreenOwner` gate, read from the window list. It
-  /// does NOT promise a WINDOWED video is safe, because bounds stability is not
-  /// content staticness and a player holding a fixed rect passes both halves of
-  /// the conjunction. NOT claimed either: "eases off where you are pointing".
-  /// The pointer is not an input to `StaticRegionDetector` and the coordinator
-  /// supplies none, so that sentence goes in when the falloff exists.
+  /// Regional protection uses sampled persistence and window ownership. Focus
+  /// and recent pointer activity are exclusions, not an estimate of gaze.
   private var detectionControls: some View {
-    SettingRow("Areas that stay bright and unchanged, like a toolbar or a sidebar, are dimmed a little while you work. Full-screen video is never dimmed, and nothing is dimmed while anything is holding the screen awake, including Keep Display Awake. This needs both measurement settings on the Health pane: without them nothing is dimmed.") {
+    SettingRow("Bright regions that stay unchanged across several samples can dim, with extra protection for areas with higher recorded exposure. Your foreground app and the area around recent pointer activity stay undimmed. Full-screen content and anything holding the screen awake pause this protection. This needs both measurement settings on the Health pane. Sampling can miss motion; turn this off when judging colors or brightness.") {
       VStack(alignment: .leading, spacing: 6) {
         Toggle("Automatic static-region dimming", isOn: Binding(
           get: { prefs.oledDetectionDimming },

--- a/CandelaAppTests/AdaptiveFocusSamplerTests.swift
+++ b/CandelaAppTests/AdaptiveFocusSamplerTests.swift
@@ -1,0 +1,29 @@
+import CoreGraphics
+import Testing
+
+@Suite("Adaptive focus freshness")
+@MainActor
+struct AdaptiveFocusSamplerTests {
+  @Test func aMissHoldsIdleFocusButWithholdsAdaptiveFocus() {
+    var next: CGDirectDisplayID? = 5
+    let sampler = FocusSampler(resolver: { next })
+    #expect(sampler.focusedDisplayID() == 5)
+    #expect(sampler.currentResolvedDisplayID == 5)
+    next = nil
+    #expect(sampler.focusedDisplayID() == 5)
+    #expect(sampler.currentResolvedDisplayID == nil)
+    next = 9
+    #expect(sampler.focusedDisplayID() == 9)
+    #expect(sampler.currentResolvedDisplayID == 9)
+  }
+
+  @Test func aReconfigurationForgetsBothFocusReadings() {
+    var next: CGDirectDisplayID? = 5
+    let sampler = FocusSampler(resolver: { next })
+    _ = sampler.focusedDisplayID()
+    sampler.invalidate()
+    #expect(sampler.currentResolvedDisplayID == nil)
+    next = nil
+    #expect(sampler.focusedDisplayID() == nil)
+  }
+}

--- a/CandelaAppTests/AdaptiveInputRestoreTests.swift
+++ b/CandelaAppTests/AdaptiveInputRestoreTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@Suite("Adaptive input restoration")
+@MainActor
+struct AdaptiveInputRestoreTests {
+  @Test func aPointerMoveThenFocusChangeRestoresTheLatestStateInOneBatch() async {
+    let gate = DelayGate()
+    var frontmost = 1
+    var restored: [Int] = []
+    let input = AdaptiveInputRestore(delay: { await gate.wait() }, restore: {
+      restored.append(frontmost)
+    })
+    let first = input.request() // pointer movement
+    await gate.started()
+    frontmost = 2
+    let following = input.request() // included in the pending batch
+    #expect(restored.isEmpty)
+    gate.release()
+    await first.value
+    await following.value
+    #expect(restored == [2])
+    #expect(gate.calls == 1)
+    let next = input.request()
+    await gate.started()
+    gate.release()
+    await next.value
+    #expect(restored == [2, 2])
+  }
+
+  @Test func cancellationPreventsALateRestoreAndAllowsAnotherBatch() async {
+    let gate = DelayGate()
+    var restores = 0
+    let input = AdaptiveInputRestore(delay: { await gate.wait() }, restore: { restores += 1 })
+    let cancelled = input.request()
+    await gate.started()
+    input.cancel()
+    gate.release()
+    await cancelled.value
+    #expect(restores == 0)
+    let next = input.request()
+    await gate.started()
+    gate.release()
+    await next.value
+    #expect(restores == 1)
+  }
+}
+
+@MainActor
+private final class DelayGate {
+  var continuation: CheckedContinuation<Void, Never>?
+  var calls = 0
+  private var startWaiter: CheckedContinuation<Void, Never>?
+  func wait() async {
+    calls += 1
+    await withCheckedContinuation {
+      continuation = $0
+      startWaiter?.resume()
+      startWaiter = nil
+    }
+  }
+  func started() async {
+    guard continuation == nil else { return }
+    await withCheckedContinuation { startWaiter = $0 }
+  }
+  func release() {
+    let held = continuation
+    continuation = nil
+    held?.resume()
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveRegionProtection.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveRegionProtection.swift
@@ -1,0 +1,157 @@
+import CoreGraphics
+import Foundation
+
+/// Short-lived evidence for regional dimming, separate from cumulative exposure.
+///
+/// Six matching minute samples establish five minutes of observed stability.
+/// Only coarse means and per-cell fingerprints survive a capture; neither the
+/// source image nor its pixel array is retained. Sampling can miss motion
+/// between captures and cannot tell a paused photo from an unattended toolbar.
+public struct AdaptiveRegionProtection: Sendable {
+  public struct Activity: Equatable, Sendable {
+    /// Nil means focus could not be resolved, so regional dimming is withheld.
+    public let isFocusedDisplay: Bool?
+    public let frontmostPID: Int32?
+    /// The pointer's panel-native cell while there has been recent input.
+    public let pointerCell: Int?
+
+    public init(isFocusedDisplay: Bool?, frontmostPID: Int32?, pointerCell: Int?,
+                captureExcludedPID: Int32? = nil) {
+      // The capture omits this app, so observed ownership describes what is
+      // behind its windows. Withhold masks rather than dim through its UI.
+      self.isFocusedDisplay = captureExcludedPID != nil && frontmostPID == captureExcludedPID
+        ? nil : isFocusedDisplay
+      self.frontmostPID = frontmostPID
+      self.pointerCell = pointerCell
+    }
+  }
+
+  private struct Evidence: Sendable {
+    var fingerprint: UInt64
+    var windowID: UInt32?
+    var ownerPID: Int32?
+    var since: Date
+    var samples: Int
+  }
+
+  private static let maximumGap: TimeInterval = 90
+  private static let minimumDuration: TimeInterval = 300
+  private var evidence: [Evidence] = []
+  private var brightness: [Double] = []
+  private var lastSample: Date?
+  private var geometry: PanelSpaceTransform?
+  private var captureSize: (cols: Int, rows: Int)?
+
+  public init() {}
+
+  public mutating func record(displayGrid: [Double], cols: Int, rows: Int,
+                              through transform: PanelSpaceTransform,
+                              observation: WindowObservation, at now: Date) {
+    guard now.timeIntervalSinceReferenceDate.isFinite,
+      Self.valid(observation),
+      let fingerprints = Self.fingerprints(displayGrid, cols: cols, rows: rows,
+                                           through: transform)
+    else {
+      self = Self()
+      return
+    }
+    let gap = lastSample.map { now.timeIntervalSince($0) }
+    let continuous = gap.map { $0 > 0 && $0 <= Self.maximumGap } == true
+      && geometry == transform && captureSize?.cols == cols && captureSize?.rows == rows
+      && evidence.count == PanelGrid.cellCount
+    evidence = fingerprints.indices.map { cell in
+      let window = observation.windowIDByCell[cell]
+      let owner = observation.ownerPIDByCell[cell]
+      if continuous, let window, let owner,
+        evidence[cell].fingerprint == fingerprints[cell],
+        evidence[cell].windowID == window, evidence[cell].ownerPID == owner {
+        var held = evidence[cell]
+        held.samples = min(6, held.samples + 1)
+        return held
+      }
+      return Evidence(fingerprint: fingerprints[cell], windowID: window,
+                      ownerPID: owner, since: now, samples: 1)
+    }
+    brightness = transform.panelNativeGrid(fromDisplayGrid: displayGrid, cols: cols, rows: rows)
+    lastSample = now
+    geometry = transform
+    captureSize = (cols, rows)
+  }
+
+  public func nominate(observation: WindowObservation, exposure: ExposureMap,
+                       activity: Activity, at now: Date) -> OverlayMask? {
+    guard Self.valid(observation), observation.fullScreenOwner == nil,
+      evidence.count == PanelGrid.cellCount, brightness.count == PanelGrid.cellCount,
+      let lastSample, now.timeIntervalSinceReferenceDate.isFinite,
+      now >= lastSample, now.timeIntervalSince(lastSample) <= Self.maximumGap,
+      activity.isFocusedDisplay != nil, let frontmostPID = activity.frontmostPID
+    else { return nil }
+
+    // History only adjusts depth after a region qualifies on present evidence.
+    // An immature or malformed record earns no extra dimming.
+    let useHistory = exposure.sampleCount >= ExposureAccumulator.minimumSamplesForAnalysis
+      && exposure.cells.count == PanelGrid.cellCount
+      && exposure.cells.allSatisfy { $0.isFinite && $0 >= 0 }
+      && exposure.mean.isFinite && exposure.mean > 0
+    let mean = useHistory ? exposure.mean : 0
+    var cells = Array(repeating: 0.0, count: PanelGrid.cellCount)
+    for cell in cells.indices {
+      let held = evidence[cell]
+      guard held.samples >= 6, now.timeIntervalSince(held.since) >= Self.minimumDuration,
+        brightness[cell] >= StaticRegionDetector.Thresholds.defaultMinimumLuminance,
+        let window = observation.windowIDByCell[cell],
+        let owner = observation.ownerPIDByCell[cell],
+        held.windowID == window, held.ownerPID == owner,
+        (observation.stationarySecondsByWindowID[window] ?? 0)
+          >= WindowObserver.stationaryThresholdSeconds,
+        owner != frontmostPID,
+        !Self.isNearPointer(cell, pointer: activity.pointerCell)
+      else { continue }
+      // 15% normally, rising to 25% at twice the panel's average exposure.
+      // These are conservative policy limits, not calibrated wear estimates.
+      let extra = useHistory ? min(1, max(0, exposure.cells[cell] / mean - 1)) * 0.10 : 0
+      cells[cell] = min(0.25, StaticRegionDetector.Thresholds.defaultDepth + extra)
+    }
+    let mask = OverlayMask(cells: cells)
+    return mask.peak > 0 ? mask : nil
+  }
+
+  private static func valid(_ observation: WindowObservation) -> Bool {
+    observation.windowIDByCell.count == PanelGrid.cellCount
+      && observation.ownerPIDByCell.count == PanelGrid.cellCount
+      && observation.stationaryByCell.count == PanelGrid.cellCount
+  }
+
+  private static func isNearPointer(_ cell: Int, pointer: Int?) -> Bool {
+    guard let pointer, (0..<PanelGrid.cellCount).contains(pointer) else { return false }
+    return abs(cell % PanelGrid.cols - pointer % PanelGrid.cols) <= 1
+      && abs(cell / PanelGrid.cols - pointer / PanelGrid.cols) <= 1
+  }
+
+  /// Hash the spatial detail before reducing to a mean. Two moving patterns
+  /// with equal average luminance must not look like an unchanged region.
+  /// Quantization ignores small luminance changes within a bin; boundary noise
+  /// can reset stability, which withholds dimming rather than inventing it.
+  private static func fingerprints(_ grid: [Double], cols: Int, rows: Int,
+                                   through transform: PanelSpaceTransform) -> [UInt64]? {
+    let maximumEdge = max(PanelGrid.cols, PanelGrid.rows) * LuminanceReduction.captureOversample
+    guard cols > 0, rows > 0, cols <= maximumEdge, rows <= maximumEdge,
+      grid.count == cols * rows, grid.allSatisfy({ $0.isFinite && $0 >= 0 }),
+      transform.displaySize.width.isFinite, transform.displaySize.height.isFinite,
+      transform.displaySize.width > 0, transform.displaySize.height > 0
+    else { return nil }
+    var hashes = Array(repeating: UInt64(14695981039346656037), count: PanelGrid.cellCount)
+    var covered = Array(repeating: false, count: PanelGrid.cellCount)
+    for y in 0..<rows {
+      for x in 0..<cols {
+        let point = CGPoint(x: (Double(x) + 0.5) / Double(cols) * transform.displaySize.width,
+                            y: (Double(y) + 0.5) / Double(rows) * transform.displaySize.height)
+        guard let cell = transform.cell(forDisplayPoint: point) else { return nil }
+        let value = UInt64((min(1, grid[y * cols + x]) * 31).rounded())
+        hashes[cell] = (hashes[cell] ^ value) &* 1099511628211
+        covered[cell] = true
+      }
+    }
+    return covered.allSatisfy { $0 } ? hashes : nil
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveRegionProtection.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveRegionProtection.swift
@@ -122,10 +122,46 @@ public struct AdaptiveRegionProtection: Sendable {
       // These are conservative policy limits, not calibrated wear estimates.
       let extra = useHistory ? min(1, max(0, exposure.cells[cell] / mean - 1)) * 0.10 : 0
       cells[cell] = min(0.25, StaticRegionDetector.Thresholds.defaultDepth + extra)
-        * (windowScales[window] ?? 1)
+    }
+    cells = Self.featherBoundaries(cells)
+    // Hover changes opacity, not eligibility. Feather first so restoring one
+    // window cannot weaken protection at a neighboring window's boundary.
+    for cell in cells.indices {
+      if let window = observation.windowIDByCell[cell] {
+        cells[cell] *= windowScales[window] ?? 1
+      }
     }
     let mask = OverlayMask(cells: cells)
     return mask.peak > 0 ? mask : nil
+  }
+
+  /// Taper inward over two cells before the renderer interpolates the grid.
+  /// Filtering eligibility (not depth) keeps exposure-weighted interiors intact.
+  /// Only reduce nominated cells: a blur that spread alpha outward would dim
+  /// moving content, foreground windows, and cells with ambiguous ownership.
+  private static func featherBoundaries(_ cells: [Double]) -> [Double] {
+    let weights = [1.0, 4, 6, 4, 1]
+    var result = cells
+    for row in 0..<PanelGrid.rows {
+      for col in 0..<PanelGrid.cols {
+        let cell = row * PanelGrid.cols + col
+        guard cells[cell] > 0 else { continue }
+        var support = 0.0
+        for dy in -2...2 {
+          // There is no adjacent content beyond the physical panel. Clamp so
+          // a region reaching the display edge doesn't acquire a bright rim.
+          let y = min(PanelGrid.rows - 1, max(0, row + dy))
+          for dx in -2...2 {
+            let x = min(PanelGrid.cols - 1, max(0, col + dx))
+            if cells[y * PanelGrid.cols + x] > 0 {
+              support += weights[dy + 2] * weights[dx + 2]
+            }
+          }
+        }
+        result[cell] *= support / 256
+      }
+    }
+    return result
   }
 
   private static func valid(_ observation: WindowObservation) -> Bool {

--- a/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveRegionProtection.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveRegionProtection.swift
@@ -12,17 +12,17 @@ public struct AdaptiveRegionProtection: Sendable {
     /// Nil means focus could not be resolved, so regional dimming is withheld.
     public let isFocusedDisplay: Bool?
     public let frontmostPID: Int32?
-    /// The pointer's panel-native cell while there has been recent input.
-    public let pointerCell: Int?
+    /// Pointer in display-local, top-left coordinates, including beyond its bounds.
+    public let pointerPosition: CGPoint?
 
-    public init(isFocusedDisplay: Bool?, frontmostPID: Int32?, pointerCell: Int?,
+    public init(isFocusedDisplay: Bool?, frontmostPID: Int32?, pointerPosition: CGPoint?,
                 captureExcludedPID: Int32? = nil) {
       // The capture omits this app, so observed ownership describes what is
       // behind its windows. Withhold masks rather than dim through its UI.
       self.isFocusedDisplay = captureExcludedPID != nil && frontmostPID == captureExcludedPID
         ? nil : isFocusedDisplay
       self.frontmostPID = frontmostPID
-      self.pointerCell = pointerCell
+      self.pointerPosition = pointerPosition
     }
   }
 
@@ -41,6 +41,12 @@ public struct AdaptiveRegionProtection: Sendable {
   private var lastSample: Date?
   private var geometry: PanelSpaceTransform?
   private var captureSize: (cols: Int, rows: Int)?
+
+  private var windowRestoration = AdaptiveWindowRestoration()
+  /// Keep the driver fast only while a recently hovered window is returning.
+  public var isRestoringWindows: Bool { windowRestoration.isReturning }
+  /// A fully restored window still needs pointer-exit events to start its grace.
+  public var needsInputTracking: Bool { windowRestoration.needsInputTracking }
 
   public init() {}
 
@@ -78,14 +84,20 @@ public struct AdaptiveRegionProtection: Sendable {
     captureSize = (cols, rows)
   }
 
-  public func nominate(observation: WindowObservation, exposure: ExposureMap,
-                       activity: Activity, at now: Date) -> OverlayMask? {
+  public mutating func nominate(observation: WindowObservation, exposure: ExposureMap,
+                       activity: Activity, windows: [WindowSnapshot], at now: Date) -> OverlayMask? {
     guard Self.valid(observation), observation.fullScreenOwner == nil,
       evidence.count == PanelGrid.cellCount, brightness.count == PanelGrid.cellCount,
       let lastSample, now.timeIntervalSinceReferenceDate.isFinite,
       now >= lastSample, now.timeIntervalSince(lastSample) <= Self.maximumGap,
       activity.isFocusedDisplay != nil, let frontmostPID = activity.frontmostPID
-    else { return nil }
+    else {
+      windowRestoration = AdaptiveWindowRestoration()
+      return nil
+    }
+
+    let windowScales = windowRestoration.update(
+      pointer: activity.pointerPosition, windows: windows, at: now)
 
     // History only adjusts depth after a region qualifies on present evidence.
     // An immature or malformed record earns no extra dimming.
@@ -104,13 +116,13 @@ public struct AdaptiveRegionProtection: Sendable {
         held.windowID == window, held.ownerPID == owner,
         (observation.stationarySecondsByWindowID[window] ?? 0)
           >= WindowObserver.stationaryThresholdSeconds,
-        owner != frontmostPID,
-        !Self.isNearPointer(cell, pointer: activity.pointerCell)
+        owner != frontmostPID
       else { continue }
       // 15% normally, rising to 25% at twice the panel's average exposure.
       // These are conservative policy limits, not calibrated wear estimates.
       let extra = useHistory ? min(1, max(0, exposure.cells[cell] / mean - 1)) * 0.10 : 0
       cells[cell] = min(0.25, StaticRegionDetector.Thresholds.defaultDepth + extra)
+        * (windowScales[window] ?? 1)
     }
     let mask = OverlayMask(cells: cells)
     return mask.peak > 0 ? mask : nil
@@ -120,12 +132,6 @@ public struct AdaptiveRegionProtection: Sendable {
     observation.windowIDByCell.count == PanelGrid.cellCount
       && observation.ownerPIDByCell.count == PanelGrid.cellCount
       && observation.stationaryByCell.count == PanelGrid.cellCount
-  }
-
-  private static func isNearPointer(_ cell: Int, pointer: Int?) -> Bool {
-    guard let pointer, (0..<PanelGrid.cellCount).contains(pointer) else { return false }
-    return abs(cell % PanelGrid.cols - pointer % PanelGrid.cols) <= 1
-      && abs(cell / PanelGrid.cols - pointer / PanelGrid.cols) <= 1
   }
 
   /// Hash the spatial detail before reducing to a mean. Two moving patterns

--- a/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveWindowRestoration.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/AdaptiveWindowRestoration.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+import Foundation
+
+/// Restores a hovered window without changing its content-stability evidence.
+/// Bounds are display-local, independent of the coarse capture grid or rotation.
+struct AdaptiveWindowRestoration: Sendable {
+  private var hovered: UInt32?
+  private var leftAt: [UInt32: Date] = [:]
+  var needsInputTracking: Bool { hovered != nil || !leftAt.isEmpty }
+  var isReturning: Bool { !leftAt.isEmpty }
+
+  mutating func update(pointer: CGPoint?, windows: [WindowSnapshot], at now: Date)
+    -> [UInt32: Double]
+  {
+    let present = Set(windows.map(\.windowID))
+    leftAt = leftAt.filter { present.contains($0.key) }
+    if let hovered, !present.contains(hovered) { self.hovered = nil }
+    // Hit the frontmost rectangle before considering its layer. A menu or
+    // overlay must not grant a hover to the ordinary window behind it.
+    let hit = pointer.flatMap { point in windows.first { $0.bounds.contains(point) } }
+    let current = hit.flatMap { $0.layer == 0 ? $0.windowID : nil }
+    if current != hovered {
+      if let hovered { leftAt[hovered] = now }
+      hovered = current
+    }
+    if let current { leftAt.removeValue(forKey: current) }
+    var scales: [UInt32: Double] = [:]
+    for (window, left) in leftAt {
+      // A backwards wall-clock adjustment restarts the grace, never jumps dark.
+      let elapsed = max(0, now.timeIntervalSince(left))
+      if now < left { leftAt[window] = now }
+      if elapsed >= 3 {
+        leftAt.removeValue(forKey: window)
+      } else {
+        // Two seconds clear, then a one-second fade back to the eligible depth.
+        scales[window] = max(0, elapsed - 2)
+      }
+    }
+    if let current { scales[current] = 0 }
+    return scales
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/OledCareCadence.swift
@@ -42,14 +42,20 @@ public enum OledCareCadence {
   /// be corrected. Only dims `liftsOnInput` covers: detection dimming's mask is
   /// `nominationDisplayed`, which buys the window-follow second, not 10 Hz.
   ///
+  /// A hover restoration temporarily keeps the fast cadence for its grace and
+  /// fade, including when the hovered window was the last visible nomination.
+  ///
   /// `anythingEnrolled` defaults to true so a caller that forgets it cannot idle
   /// the loop by accident. A displayed nomination outranks it: a mask on screen
   /// is work in flight whatever the caller says about enrollment.
   public static func interval(
     anyOverlayUp: Bool, anyLockDimEngaged: Bool, verificationPending: Bool,
+    windowRestorationPending: Bool = false,
     nominationDisplayed: Bool = false, anythingEnrolled: Bool = true
   ) -> Duration {
-    if anyOverlayUp || anyLockDimEngaged || verificationPending { return fast }
+    if anyOverlayUp || anyLockDimEngaged || verificationPending || windowRestorationPending {
+      return fast
+    }
     if nominationDisplayed { return windowFollow }
     return anythingEnrolled ? slow : idle
   }

--- a/CandelaKit/Sources/CandelaKit/OledCare/WindowObservation.swift
+++ b/CandelaKit/Sources/CandelaKit/OledCare/WindowObservation.swift
@@ -47,17 +47,24 @@ public struct WindowObservation: Equatable, Sendable {
   /// True where the covering window has been stationary past the threshold.
   public let stationaryByCell: [Bool]
   public let fullScreenOwner: String?
+  /// Fully covered cells belonging to the first visible window. Mixed cells stay unknown.
+  public let windowIDByCell: [UInt32?]
+  public let ownerPIDByCell: [Int32?]
 
   public init(
     dominantOwnerByCell: [String?],
     stationarySecondsByWindowID: [UInt32: TimeInterval],
     stationaryByCell: [Bool],
-    fullScreenOwner: String?
+    fullScreenOwner: String?,
+    windowIDByCell: [UInt32?] = Array(repeating: nil, count: PanelGrid.cellCount),
+    ownerPIDByCell: [Int32?] = Array(repeating: nil, count: PanelGrid.cellCount)
   ) {
     self.dominantOwnerByCell = dominantOwnerByCell
     self.stationarySecondsByWindowID = stationarySecondsByWindowID
     self.stationaryByCell = stationaryByCell
     self.fullScreenOwner = fullScreenOwner
+    self.windowIDByCell = windowIDByCell
+    self.ownerPIDByCell = ownerPIDByCell
   }
 }
 
@@ -118,10 +125,22 @@ public struct WindowObserver: Sendable {
     var owners = [String?](repeating: nil, count: PanelGrid.cellCount)
     var stationary = [Bool](repeating: false, count: PanelGrid.cellCount)
     var best = [Double](repeating: 0, count: PanelGrid.cellCount)
+    var visibleWindows = [UInt32?](repeating: nil, count: PanelGrid.cellCount)
+    var visibleOwners = [Int32?](repeating: nil, count: PanelGrid.cellCount)
+    var covered = [Bool](repeating: false, count: PanelGrid.cellCount)
 
     for window in windows {
       let coverage = transform.coverage(ofDisplayRect: window.bounds)
       let isStationary = (ages[window.windowID] ?? 0) >= Self.stationaryThresholdSeconds
+      // Front-to-back, unlike dominant area attribution. A partially covered
+      // cell cannot safely inherit the identity or age of a window behind it.
+      for cell in 0..<PanelGrid.cellCount where coverage[cell] > 1e-9 && !covered[cell] {
+        covered[cell] = true
+        if coverage[cell] >= 1 - 1e-9, window.layer == Self.normalWindowLayer {
+          visibleWindows[cell] = window.windowID
+          visibleOwners[cell] = window.ownerPID
+        }
+      }
       for cell in 0..<PanelGrid.cellCount where coverage[cell] > best[cell] {
         best[cell] = coverage[cell]
         owners[cell] = window.ownerName
@@ -133,7 +152,8 @@ public struct WindowObserver: Sendable {
       dominantOwnerByCell: owners,
       stationarySecondsByWindowID: ages,
       stationaryByCell: stationary,
-      fullScreenOwner: fullScreenOwner(among: windows, on: transform.displaySize))
+      fullScreenOwner: fullScreenOwner(among: windows, on: transform.displaySize),
+      windowIDByCell: visibleWindows, ownerPIDByCell: visibleOwners)
   }
 
   private func fullScreenOwner(among windows: [WindowSnapshot], on displaySize: CGSize)

--- a/CandelaKit/Tests/CandelaKitTests/AdaptiveRegionProtectionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AdaptiveRegionProtectionTests.swift
@@ -80,6 +80,49 @@ struct AdaptiveRegionProtectionTests {
     #expect((result?.cells[239] ?? 0) > 0)
   }
 
+  @Test func aStaticRectangleHasATaperedBoundaryAndRoundedCorners() throws {
+    var pixels = Array(repeating: 0.2, count: 240)
+    for row in 2...7 {
+      for col in 4...15 { pixels[row * 24 + col] = 0.8 }
+    }
+    var protection = AdaptiveRegionProtection()
+    for second in stride(from: 0, through: 300, by: 60) {
+      protection.record(displayGrid: pixels, cols: 24, rows: 10,
+        through: transform, observation: observation(),
+        at: start.addingTimeInterval(Double(second)))
+    }
+    let result = try #require(mask(protection))
+    let edge = result.cells[4 * 24 + 4]
+    let shoulder = result.cells[4 * 24 + 5]
+    let interior = result.cells[4 * 24 + 6]
+    #expect(edge > 0 && edge < shoulder)
+    #expect(shoulder < interior)
+    #expect(interior == 38.0 / 255) // Original 15% depth, quantized to 8 bits.
+    #expect(result.cells[2 * 24 + 4] < edge) // Corner fades in both directions.
+    for cell in pixels.indices where pixels[cell] == 0.2 {
+      #expect(result.cells[cell] == 0) // Feathering cannot nominate dark content.
+    }
+  }
+
+  @Test func featheringKeepsAdjacentMovingContentClear() throws {
+    var protection = AdaptiveRegionProtection()
+    for sample in 0...5 {
+      let pixels = (0..<240).map { cell in
+        cell % 24 < 12 ? 0.8 : (sample.isMultiple(of: 2) ? 0.6 : 0.9)
+      }
+      protection.record(displayGrid: pixels, cols: 24, rows: 10,
+        through: transform, observation: observation(),
+        at: start.addingTimeInterval(Double(sample * 60)))
+    }
+    let result = try #require(mask(protection))
+    #expect(result.cells[5 * 24 + 11] < result.cells[5 * 24 + 9])
+    for cell in result.cells.indices where cell % 24 >= 12 {
+      #expect(result.cells[cell] == 0)
+    }
+    // The physical display edge has no adjacent content to protect.
+    #expect(result.cells[0] == 38.0 / 255)
+  }
+
   @Test func focusedAppAndEntireHoveredWindowAreProtected() {
     let protection = warmed()
     #expect(mask(protection, activity: .init(
@@ -110,10 +153,12 @@ struct AdaptiveRegionProtectionTests {
         activity: .init(isFocusedDisplay: false, frontmostPID: 99, pointerPosition: point),
         windows: windows, at: start.addingTimeInterval(second))
     }
+    let beforeHover = nominate(nil, 300)
     let hovered = nominate(CGPoint(x: 1, y: 1), 300)
     #expect(protection.needsInputTracking)
     #expect(hovered?.cells[216] == 0) // Far corner of the hovered window.
     #expect((hovered?.cells[239] ?? 0) > 0) // Same app, different window.
+    #expect(hovered?.cells[5 * 24 + 12] == beforeHover?.cells[5 * 24 + 12])
     #expect(nominate(nil, 301)?.cells[216] == 0)
     #expect(nominate(nil, 303)?.cells[216] == 0) // Grace has just ended.
     let fading = nominate(nil, 303.5)
@@ -203,6 +248,7 @@ struct AdaptiveRegionProtectionTests {
     let baseline = mask(protection)
     let weighted = mask(protection, exposure: accumulator.map)
     #expect((weighted?.cells[0] ?? 0) > (baseline?.cells[0] ?? 0))
+    #expect(weighted?.cells[0] == 64.0 / 255) // Full 25% depth survives away from boundaries.
     #expect(weighted?.cells[239] == baseline?.cells[239])
     #expect((weighted?.peak ?? 1) <= 0.251)
 

--- a/CandelaKit/Tests/CandelaKitTests/AdaptiveRegionProtectionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AdaptiveRegionProtectionTests.swift
@@ -10,7 +10,7 @@ struct AdaptiveRegionProtectionTests {
   private let transform = PanelSpaceTransform(
     displaySize: CGSize(width: 2400, height: 1000), rotation: .standard)
   private let activity = AdaptiveRegionProtection.Activity(
-    isFocusedDisplay: false, frontmostPID: 99, pointerCell: nil)
+    isFocusedDisplay: false, frontmostPID: 99, pointerPosition: nil)
 
   private func observation(window: UInt32 = 1, owner: Int32 = 7,
                            fullScreen: String? = nil) -> WindowObservation {
@@ -23,11 +23,11 @@ struct AdaptiveRegionProtectionTests {
       ownerPIDByCell: Array(repeating: owner, count: 240))
   }
 
-  private func warmed() -> AdaptiveRegionProtection {
+  private func warmed(observation: WindowObservation? = nil) -> AdaptiveRegionProtection {
     var protection = AdaptiveRegionProtection()
     for second in stride(from: 0, through: 300, by: 60) {
       protection.record(displayGrid: Array(repeating: 0.8, count: 960), cols: 48, rows: 20,
-                        through: transform, observation: observation(),
+                        through: transform, observation: observation ?? self.observation(),
                         at: start.addingTimeInterval(Double(second)))
     }
     return protection
@@ -37,8 +37,12 @@ struct AdaptiveRegionProtectionTests {
                     observation: WindowObservation? = nil,
                     exposure: ExposureMap = .empty,
                     activity: AdaptiveRegionProtection.Activity? = nil) -> OverlayMask? {
-    protection.nominate(observation: observation ?? self.observation(), exposure: exposure,
-                        activity: activity ?? self.activity, at: start.addingTimeInterval(second))
+    var protection = protection
+    return protection.nominate(observation: observation ?? self.observation(), exposure: exposure,
+                        activity: activity ?? self.activity, windows: [
+                          WindowSnapshot(windowID: 1, ownerPID: 7, ownerName: "Editor",
+                            bounds: CGRect(x: 0, y: 0, width: 2400, height: 1000), layer: 0)
+                        ], at: start.addingTimeInterval(second))
   }
 
   @Test func oneBrightSampleIsNotEvidenceOfPersistentContent() {
@@ -76,34 +80,115 @@ struct AdaptiveRegionProtectionTests {
     #expect((result?.cells[239] ?? 0) > 0)
   }
 
-  @Test func focusedAppAndRecentPointerAreaAreProtected() {
+  @Test func focusedAppAndEntireHoveredWindowAreProtected() {
     let protection = warmed()
     #expect(mask(protection, activity: .init(
-      isFocusedDisplay: true, frontmostPID: 7, pointerCell: nil)) == nil)
+      isFocusedDisplay: true, frontmostPID: 7, pointerPosition: nil)) == nil)
     let otherApp = mask(protection, activity: .init(
-      isFocusedDisplay: true, frontmostPID: 99, pointerCell: 25))
-    #expect(otherApp?.cells[25] == 0)
-    #expect(otherApp?.cells[0] == 0) // adjacent cell
-    #expect((otherApp?.cells[239] ?? 0) > 0)
+      isFocusedDisplay: true, frontmostPID: 99, pointerPosition: CGPoint(x: 150, y: 150)))
+    #expect(otherApp == nil) // Hover restores even the far end of the same window.
     #expect(mask(protection, activity: .init(
-      isFocusedDisplay: nil, frontmostPID: 7, pointerCell: nil)) == nil)
+      isFocusedDisplay: nil, frontmostPID: 7, pointerPosition: nil)) == nil)
     #expect(mask(protection, activity: .init(
-      isFocusedDisplay: true, frontmostPID: nil, pointerCell: nil)) == nil)
+      isFocusedDisplay: true, frontmostPID: nil, pointerPosition: nil)) == nil)
+  }
+
+
+  @Test func hoveringOneWindowLeavesAnotherWindowOfTheSameAppProtected() {
+    let windows = [
+      WindowSnapshot(windowID: 1, ownerPID: 7, ownerName: "Editor",
+        bounds: CGRect(x: 0, y: 0, width: 1200, height: 1000), layer: 0),
+      WindowSnapshot(windowID: 2, ownerPID: 7, ownerName: "Editor",
+        bounds: CGRect(x: 1200, y: 0, width: 1200, height: 1000), layer: 0),
+    ]
+    var observer = WindowObserver()
+    _ = observer.observe(windows, through: transform, at: start)
+    let observed = observer.observe(windows, through: transform, at: start.addingTimeInterval(300))
+    var protection = warmed(observation: observed)
+    func nominate(_ point: CGPoint?, _ second: Double) -> OverlayMask? {
+      protection.nominate(observation: observed, exposure: .empty,
+        activity: .init(isFocusedDisplay: false, frontmostPID: 99, pointerPosition: point),
+        windows: windows, at: start.addingTimeInterval(second))
+    }
+    let hovered = nominate(CGPoint(x: 1, y: 1), 300)
+    #expect(protection.needsInputTracking)
+    #expect(hovered?.cells[216] == 0) // Far corner of the hovered window.
+    #expect((hovered?.cells[239] ?? 0) > 0) // Same app, different window.
+    #expect(nominate(nil, 301)?.cells[216] == 0)
+    #expect(nominate(nil, 303)?.cells[216] == 0) // Grace has just ended.
+    let fading = nominate(nil, 303.5)
+    #expect((fading?.cells[216] ?? 0) > 0)
+    #expect((fading?.cells[216] ?? 1) < (fading?.cells[239] ?? 0))
+    #expect(nominate(nil, 304)?.cells[216] == hovered?.cells[239])
+    #expect(!protection.needsInputTracking)
+  }
+
+  @Test func clearingTheLastMaskKeepsExitTrackingThroughTheReturn() {
+    let windows = [WindowSnapshot(windowID: 1, ownerPID: 7, ownerName: "Editor",
+      bounds: CGRect(x: 0, y: 0, width: 2400, height: 1000), layer: 0)]
+    var protection = warmed()
+    #expect(protection.nominate(observation: observation(), exposure: .empty,
+      activity: .init(isFocusedDisplay: false, frontmostPID: 99,
+                      pointerPosition: CGPoint(x: 50, y: 50)),
+      windows: windows, at: start.addingTimeInterval(300)) == nil)
+    #expect(protection.needsInputTracking)
+    #expect(!protection.isRestoringWindows) // Listen for exit without fast polling.
+    #expect(protection.nominate(observation: observation(), exposure: .empty,
+      activity: activity, windows: windows, at: start.addingTimeInterval(301)) == nil)
+    #expect(protection.needsInputTracking && protection.isRestoringWindows)
+    #expect(protection.nominate(observation: observation(), exposure: .empty,
+      activity: activity, windows: windows, at: start.addingTimeInterval(304)) != nil)
+    #expect(!protection.needsInputTracking && !protection.isRestoringWindows)
+  }
+
+  @Test func staleEvidenceEndsTheReturnCadenceAndWithholdsTheMask() {
+    let windows = [WindowSnapshot(windowID: 1, ownerPID: 7, ownerName: "Editor",
+      bounds: CGRect(x: 0, y: 0, width: 2400, height: 1000), layer: 0)]
+    var protection = warmed()
+    _ = protection.nominate(observation: observation(), exposure: .empty,
+      activity: .init(isFocusedDisplay: false, frontmostPID: 99,
+                      pointerPosition: CGPoint(x: 50, y: 50)),
+      windows: windows, at: start.addingTimeInterval(389))
+    _ = protection.nominate(observation: observation(), exposure: .empty,
+      activity: activity, windows: windows, at: start.addingTimeInterval(390))
+    #expect(protection.isRestoringWindows)
+    #expect(protection.nominate(observation: observation(), exposure: .empty,
+      activity: activity, windows: windows, at: start.addingTimeInterval(391)) == nil)
+    #expect(!protection.isRestoringWindows)
+    #expect(!protection.needsInputTracking)
+  }
+
+  @Test func rotatedDisplayAndPointerBeyondItsBoundsRestoreTheSpanningWindow() {
+    let rotated = PanelSpaceTransform(
+      displaySize: CGSize(width: 1000, height: 2400), rotation: .ninety)
+    let windows = [WindowSnapshot(windowID: 1, ownerPID: 7, ownerName: "Editor",
+      bounds: CGRect(x: -100, y: 0, width: 1100, height: 2400), layer: 0)]
+    var protection = AdaptiveRegionProtection()
+    for second in stride(from: 0, through: 300, by: 60) {
+      protection.record(displayGrid: Array(repeating: 0.8, count: 960), cols: 20, rows: 48,
+        through: rotated, observation: observation(), at: start.addingTimeInterval(Double(second)))
+    }
+    #expect(protection.nominate(observation: observation(), exposure: .empty,
+      activity: activity, windows: windows, at: start.addingTimeInterval(300)) != nil)
+    #expect(protection.nominate(observation: observation(), exposure: .empty,
+      activity: .init(isFocusedDisplay: false, frontmostPID: 99,
+                      pointerPosition: CGPoint(x: -50, y: 50)),
+      windows: windows, at: start.addingTimeInterval(300)) == nil)
   }
 
   @Test func anExcludedForegroundAppCannotBeDimmedThroughItsBackgroundWindows() {
     let protection = warmed()
     #expect(mask(protection, activity: .init(
-      isFocusedDisplay: true, frontmostPID: 42, pointerCell: nil,
+      isFocusedDisplay: true, frontmostPID: 42, pointerPosition: nil,
       captureExcludedPID: 42)) == nil)
     #expect(mask(protection, activity: .init(
-      isFocusedDisplay: true, frontmostPID: 42, pointerCell: nil,
+      isFocusedDisplay: true, frontmostPID: 42, pointerPosition: nil,
       captureExcludedPID: 99)) != nil)
   }
 
   @Test func aForegroundAppSpanningDisplaysIsProtectedOnBoth() {
     #expect(mask(warmed(), activity: .init(
-      isFocusedDisplay: false, frontmostPID: 7, pointerCell: nil)) == nil)
+      isFocusedDisplay: false, frontmostPID: 7, pointerPosition: nil)) == nil)
   }
 
   @Test func historyStrengthensEligibleHotRegionsButCannotNominateDarkContent() {

--- a/CandelaKit/Tests/CandelaKitTests/AdaptiveRegionProtectionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AdaptiveRegionProtectionTests.swift
@@ -1,0 +1,187 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import CandelaKit
+
+@Suite("Adaptive region protection")
+struct AdaptiveRegionProtectionTests {
+  private let start = Date(timeIntervalSince1970: 1_000)
+  private let transform = PanelSpaceTransform(
+    displaySize: CGSize(width: 2400, height: 1000), rotation: .standard)
+  private let activity = AdaptiveRegionProtection.Activity(
+    isFocusedDisplay: false, frontmostPID: 99, pointerCell: nil)
+
+  private func observation(window: UInt32 = 1, owner: Int32 = 7,
+                           fullScreen: String? = nil) -> WindowObservation {
+    WindowObservation(
+      dominantOwnerByCell: Array(repeating: "Editor", count: 240),
+      stationarySecondsByWindowID: [window: 600],
+      stationaryByCell: Array(repeating: true, count: 240),
+      fullScreenOwner: fullScreen,
+      windowIDByCell: Array(repeating: window, count: 240),
+      ownerPIDByCell: Array(repeating: owner, count: 240))
+  }
+
+  private func warmed() -> AdaptiveRegionProtection {
+    var protection = AdaptiveRegionProtection()
+    for second in stride(from: 0, through: 300, by: 60) {
+      protection.record(displayGrid: Array(repeating: 0.8, count: 960), cols: 48, rows: 20,
+                        through: transform, observation: observation(),
+                        at: start.addingTimeInterval(Double(second)))
+    }
+    return protection
+  }
+
+  private func mask(_ protection: AdaptiveRegionProtection, at second: Double = 300,
+                    observation: WindowObservation? = nil,
+                    exposure: ExposureMap = .empty,
+                    activity: AdaptiveRegionProtection.Activity? = nil) -> OverlayMask? {
+    protection.nominate(observation: observation ?? self.observation(), exposure: exposure,
+                        activity: activity ?? self.activity, at: start.addingTimeInterval(second))
+  }
+
+  @Test func oneBrightSampleIsNotEvidenceOfPersistentContent() {
+    var protection = AdaptiveRegionProtection()
+    protection.record(displayGrid: Array(repeating: 0.8, count: 960), cols: 48, rows: 20,
+                      through: transform, observation: observation(), at: start)
+    #expect(mask(protection, at: 0) == nil)
+    #expect(mask(warmed()) != nil)
+  }
+
+  @Test func movingDetailWithTheSameMeanLuminanceDoesNotBecomeStatic() {
+    var protection = AdaptiveRegionProtection()
+    for second in stride(from: 0, through: 360, by: 60) {
+      // Every cell retains a mean of 0.7, but the detail swaps every sample.
+      let grid = (0..<960).map { pixel in
+        (pixel % 2 == (second / 60) % 2) ? 0.5 : 0.9
+      }
+      protection.record(displayGrid: grid, cols: 48, rows: 20,
+                        through: transform, observation: observation(),
+                        at: start.addingTimeInterval(Double(second)))
+    }
+    #expect(mask(protection, at: 360) == nil)
+    #expect(mask(warmed()) != nil)
+  }
+
+  @Test func changedContentClearsOnlyItsOwnRegion() {
+    var protection = warmed()
+    var pixels = Array(repeating: 0.8, count: 960)
+    pixels[0] = 0.4
+    protection.record(displayGrid: pixels, cols: 48, rows: 20,
+                      through: transform, observation: observation(),
+                      at: start.addingTimeInterval(360))
+    let result = mask(protection, at: 360)
+    #expect(result?.cells[0] == 0)
+    #expect((result?.cells[239] ?? 0) > 0)
+  }
+
+  @Test func focusedAppAndRecentPointerAreaAreProtected() {
+    let protection = warmed()
+    #expect(mask(protection, activity: .init(
+      isFocusedDisplay: true, frontmostPID: 7, pointerCell: nil)) == nil)
+    let otherApp = mask(protection, activity: .init(
+      isFocusedDisplay: true, frontmostPID: 99, pointerCell: 25))
+    #expect(otherApp?.cells[25] == 0)
+    #expect(otherApp?.cells[0] == 0) // adjacent cell
+    #expect((otherApp?.cells[239] ?? 0) > 0)
+    #expect(mask(protection, activity: .init(
+      isFocusedDisplay: nil, frontmostPID: 7, pointerCell: nil)) == nil)
+    #expect(mask(protection, activity: .init(
+      isFocusedDisplay: true, frontmostPID: nil, pointerCell: nil)) == nil)
+  }
+
+  @Test func anExcludedForegroundAppCannotBeDimmedThroughItsBackgroundWindows() {
+    let protection = warmed()
+    #expect(mask(protection, activity: .init(
+      isFocusedDisplay: true, frontmostPID: 42, pointerCell: nil,
+      captureExcludedPID: 42)) == nil)
+    #expect(mask(protection, activity: .init(
+      isFocusedDisplay: true, frontmostPID: 42, pointerCell: nil,
+      captureExcludedPID: 99)) != nil)
+  }
+
+  @Test func aForegroundAppSpanningDisplaysIsProtectedOnBoth() {
+    #expect(mask(warmed(), activity: .init(
+      isFocusedDisplay: false, frontmostPID: 7, pointerCell: nil)) == nil)
+  }
+
+  @Test func historyStrengthensEligibleHotRegionsButCannotNominateDarkContent() {
+    var accumulator = ExposureAccumulator()
+    var past = Array(repeating: 0.1, count: 240)
+    past[0] = 1
+    for second in 0..<30 {
+      accumulator.accumulate(displayGrid: past, cols: 24, rows: 10, through: transform,
+                             elapsed: 60, at: start.addingTimeInterval(Double(second * 60)))
+    }
+    let protection = warmed()
+    let baseline = mask(protection)
+    let weighted = mask(protection, exposure: accumulator.map)
+    #expect((weighted?.cells[0] ?? 0) > (baseline?.cells[0] ?? 0))
+    #expect(weighted?.cells[239] == baseline?.cells[239])
+    #expect((weighted?.peak ?? 1) <= 0.251)
+
+    var dark = AdaptiveRegionProtection()
+    for second in stride(from: 0, through: 300, by: 60) {
+      dark.record(displayGrid: Array(repeating: 0.02, count: 960), cols: 48, rows: 20,
+                  through: transform, observation: observation(),
+                  at: start.addingTimeInterval(Double(second)))
+    }
+    #expect(mask(dark, exposure: accumulator.map) == nil)
+  }
+
+  @Test func windowReplacementAndFullScreenLiftImmediatelyWithoutAnotherCapture() {
+    let protection = warmed()
+    #expect(mask(protection, observation: observation(window: 2)) == nil)
+    #expect(mask(protection, observation: observation(fullScreen: "Player")) == nil)
+    #expect(mask(protection) != nil)
+  }
+
+  @Test func gapsAndInvalidSamplesRequireFreshEvidence() {
+    let original = warmed()
+    #expect(mask(original, at: 500) == nil)
+    for bad in [Double.nan, .infinity, -1] {
+      var protection = original
+      var pixels = Array(repeating: 0.8, count: 960)
+      pixels[0] = bad
+      protection.record(displayGrid: pixels, cols: 48, rows: 20, through: transform,
+                        observation: observation(), at: start.addingTimeInterval(360))
+      #expect(mask(protection, at: 360) == nil)
+    }
+    var resumed = original
+    resumed.record(displayGrid: Array(repeating: 0.8, count: 960), cols: 48, rows: 20,
+                   through: transform, observation: observation(),
+                   at: start.addingTimeInterval(900))
+    #expect(mask(resumed, at: 900) == nil)
+  }
+
+  @Test func clockReversalAndGeometryChangesDiscardStability() {
+    var protection = warmed()
+    protection.record(displayGrid: Array(repeating: 0.8, count: 960), cols: 48, rows: 20,
+                      through: transform, observation: observation(), at: start)
+    #expect(mask(protection, at: 0) == nil)
+    protection = warmed()
+    protection.record(displayGrid: Array(repeating: 0.8, count: 960), cols: 48, rows: 20,
+                      through: .init(displaySize: CGSize(width: 1000, height: 2400),
+                                     rotation: .ninety),
+                      observation: observation(), at: start.addingTimeInterval(360))
+    #expect(mask(protection, at: 360) == nil)
+  }
+
+  @Test func foregroundPartialWindowDoesNotBorrowTheBackgroundWindowsAge() {
+    var observer = WindowObserver()
+    let windows = [
+      WindowSnapshot(windowID: 2, ownerPID: 8, ownerName: "Photo",
+                     bounds: CGRect(x: 0, y: 0, width: 50, height: 100), layer: 0),
+      WindowSnapshot(windowID: 1, ownerPID: 7, ownerName: "Editor",
+                     bounds: CGRect(x: 0, y: 0, width: 2300, height: 1000), layer: 0),
+    ]
+    _ = observer.observe(windows, through: transform, at: start)
+    let observation = observer.observe(windows, through: transform,
+                                       at: start.addingTimeInterval(300))
+    // A mixed cell is uncertain; the fully visible neighboring cell is usable.
+    #expect(observation.windowIDByCell[0] == nil)
+    #expect(observation.windowIDByCell[1] == 1)
+    #expect(observation.ownerPIDByCell[1] == 7)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/AdaptiveWindowRestorationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AdaptiveWindowRestorationTests.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import CandelaKit
+
+@Suite("Adaptive window restoration")
+struct AdaptiveWindowRestorationTests {
+  private let start = Date(timeIntervalSince1970: 1_000)
+  private func window(_ id: UInt32, _ x: Double = 0, layer: Int = 0) -> WindowSnapshot {
+    WindowSnapshot(windowID: id, ownerPID: 7, ownerName: "Editor",
+      bounds: CGRect(x: x, y: 0, width: 100, height: 100), layer: layer)
+  }
+
+  @Test func exactHitTestingRespectsEdgesOcclusionAndChrome() {
+    var restore = AdaptiveWindowRestoration()
+    let windows = [window(2, 50), window(1)]
+    let edge = restore.update(pointer: CGPoint(x: 0.1, y: 0.1), windows: windows, at: start)
+    #expect(edge[1] == 0)
+    #expect(edge[2] == nil)
+    restore = AdaptiveWindowRestoration()
+    let overlap = restore.update(pointer: CGPoint(x: 75, y: 50), windows: windows, at: start)
+    #expect(overlap[2] == 0)
+    #expect(overlap[1] == nil)
+    restore = AdaptiveWindowRestoration()
+    #expect(restore.update(pointer: CGPoint(x: 75, y: 50),
+      windows: [window(3, layer: 10)] + windows, at: start).isEmpty)
+    #expect(restore.update(pointer: CGPoint(x: -1, y: 50), windows: windows, at: start).isEmpty)
+  }
+
+  @Test func parkedPointerStaysClearAndLeavingStartsGraceThenFade() {
+    var restore = AdaptiveWindowRestoration()
+    let windows = [window(1)]
+    let point = CGPoint(x: 50, y: 50)
+    #expect(restore.update(pointer: point, windows: windows, at: start)[1] == 0)
+    #expect(!restore.isReturning)
+    #expect(restore.update(pointer: point, windows: windows, at: start.addingTimeInterval(60))[1] == 0)
+    #expect(restore.update(pointer: nil, windows: windows, at: start.addingTimeInterval(61))[1] == 0)
+    #expect(restore.isReturning)
+    #expect(restore.update(pointer: nil, windows: windows, at: start.addingTimeInterval(63))[1] == 0)
+    #expect(restore.update(pointer: nil, windows: windows, at: start.addingTimeInterval(63.5))[1] == 0.5)
+    #expect(restore.update(pointer: nil, windows: windows, at: start.addingTimeInterval(64))[1] == nil)
+    #expect(!restore.isReturning)
+  }
+
+  @Test func crossingWindowsKeepsSeparateGraceAndReentryClearsImmediately() {
+    var restore = AdaptiveWindowRestoration()
+    let windows = [window(1), window(2, 100)]
+    _ = restore.update(pointer: CGPoint(x: 50, y: 50), windows: windows, at: start)
+    let crossed = restore.update(pointer: CGPoint(x: 150, y: 50), windows: windows,
+      at: start.addingTimeInterval(1))
+    #expect(crossed[1] == 0 && crossed[2] == 0)
+    let returned = restore.update(pointer: CGPoint(x: 50, y: 50), windows: windows,
+      at: start.addingTimeInterval(3.5))
+    #expect(returned[1] == 0 && returned[2] == 0)
+    let fading = restore.update(pointer: CGPoint(x: 50, y: 50), windows: windows,
+      at: start.addingTimeInterval(6))
+    #expect(fading[1] == 0 && fading[2] == 0.5)
+  }
+
+  @Test func closedWindowsAreForgottenAndClockReversalDoesNotJumpToDim() {
+    var restore = AdaptiveWindowRestoration()
+    _ = restore.update(pointer: CGPoint(x: 50, y: 50), windows: [window(1)], at: start)
+    _ = restore.update(pointer: nil, windows: [window(1)], at: start.addingTimeInterval(1))
+    #expect(restore.update(pointer: nil, windows: [window(1)], at: start.addingTimeInterval(-1))[1] == 0)
+    #expect(restore.update(pointer: nil, windows: [], at: start).isEmpty)
+    #expect(!restore.isReturning)
+    #expect(restore.update(pointer: nil, windows: [window(1)], at: start).isEmpty)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/OledCareCadenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/OledCareCadenceTests.swift
@@ -20,6 +20,15 @@ struct OledCareCadenceNominationTests {
     #expect(OledCareCadence.windowFollow == .seconds(1))
   }
 
+  @Test func hoverReturnKeepsAFastTickEvenWhenItsMaskIsCurrentlyClear() {
+    #expect(OledCareCadence.interval(
+      anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+      windowRestorationPending: true, nominationDisplayed: false) == .milliseconds(100))
+    #expect(OledCareCadence.interval(
+      anyOverlayUp: false, anyLockDimEngaged: false, verificationPending: false,
+      windowRestorationPending: false, nominationDisplayed: false) == .seconds(2))
+  }
+
   /// The geometry refresh under the mask is throttled at one second, so the
   /// slow fall-through would double the wait a moved window's dim sheds in.
   @Test func theWindowFollowIntervalSitsBetweenFastAndSlow() {

--- a/docs/guide/oled-care.md
+++ b/docs/guide/oled-care.md
@@ -38,12 +38,42 @@ immediately.
   were using.
 - **Dim while this display has nothing in focus.** For the display you are not
   working on. Only clicking into it brings it back, not typing elsewhere.
-- **Automatic static-region dimming.** Areas that stay bright and unchanged, a
-  toolbar or a sidebar, are dimmed a little while you work. Full-screen video
-  is never dimmed. This is the one dimming setting that is **off by default**
-  and not part of the recommended settings, because it is the only one that
-  changes the screen while you are looking at it. It also needs both
-  measurement settings on the Health pane; without them nothing is dimmed.
+- **Automatic static-region dimming.** Bright, stable regions in background
+  windows can dim a little while you work. Your foreground app stays undimmed across
+  displays, as does the area around the pointer for 30 seconds
+  after input. Full-screen content and anything holding the display awake
+  suspend this protection. Regional dimming is also withheld while Candela
+  itself is foreground, because its windows are excluded from capture. This
+  setting is **off by default** and needs both
+  measurement settings on the Health pane.
+
+### How adaptive regional protection decides
+
+The detector compares spatial fingerprints from the existing once-per-minute
+captures. A region needs six matching samples spanning at least five minutes,
+bright content, and a stationary window fully covering the cell. A changed
+sample or window owner restarts that region's evidence. A cell shared by
+multiple windows is left alone.
+
+An eligible region normally receives a 15% dark overlay. Once at least 30
+exposure samples have accumulated, regions above the panel's average recorded
+exposure receive a proportional increase, capped at 25% at twice the average.
+History alone never makes a dark, changing, or actively used region eligible.
+This is an exposure-based policy, not a calibrated prediction of physical wear.
+
+A gap longer than 90 seconds, a failed capture, sleep, display reconfiguration,
+or disabling the required settings discards temporary detection evidence.
+Protection needs fresh samples before it can resume. Your cumulative exposure
+history is retained and does not automatically decay; it begins when you enable
+measurement and cannot account for earlier use of the display.
+
+The detector retains only coarse brightness values and per-region fingerprints,
+not screenshots. It can miss motion between samples or changes too small to
+alter a fingerprint. A paused video or photograph is still static content;
+focus is a useful signal, not proof of what you are looking at. Keep regional
+dimming off when judging colors or brightness. Other apps' overlays that macOS
+omits from capture cannot be accounted for, and the exposure map is not a
+measurement of the panel's actual light output.
 
 ## Screen chrome
 

--- a/docs/guide/oled-care.md
+++ b/docs/guide/oled-care.md
@@ -40,9 +40,11 @@ immediately.
   working on. Only clicking into it brings it back, not typing elsewhere.
 - **Automatic static-region dimming.** Bright, stable regions in background
   windows can dim a little while you work. Your foreground app stays undimmed across
-  displays, as does the area around the pointer for 30 seconds
-  after input. Full-screen content and anything holding the display awake
-  suspend this protection. Regional dimming is also withheld while Candela
+  displays, as does the entire window under your pointer. After the pointer
+  leaves a window, it stays clear for two seconds, then eligible regions fade
+  back to their dimmed level over one second. Other background windows remain
+  protected, including other windows belonging to the same app. Full-screen
+  content and anything holding the display awake suspend this protection. Regional dimming is also withheld while Candela
   itself is foreground, because its windows are excluded from capture. This
   setting is **off by default** and needs both
   measurement settings on the Health pane.

--- a/docs/guide/oled-care.md
+++ b/docs/guide/oled-care.md
@@ -63,6 +63,11 @@ exposure receive a proportional increase, capped at 25% at twice the average.
 History alone never makes a dark, changing, or actively used region eligible.
 This is an exposure-based policy, not a calibrated prediction of physical wear.
 
+Dimming tapers inward at a region's edges and corners to reduce visible box
+boundaries. The interior retains its eligible depth; narrow or isolated regions
+receive less dimming. This taper does not make additional cells eligible and
+does not change the uniform idle-dimming or exposure-compensation masks.
+
 A gap longer than 90 seconds, a failed capture, sleep, display reconfiguration,
 or disabling the required settings discards temporary detection evidence.
 Protection needs fresh samples before it can resume. Your cumulative exposure


### PR DESCRIPTION
## Changes

Automatic static-region dimming requires six matching spatial fingerprints across at least five minutes. It excludes the foreground app across displays and restores the entire window under the pointer. Other background windows remain eligible. After the pointer leaves, the window stays clear for two seconds, then eligible regions fade back over one second.

Recorded exposure increases eligible regions’ dimming from 15% up to 25%. Eligible boundaries now taper inward to soften the visible rectangle, without extending dimming into moving or ineligible cells. Interior protection is preserved; narrow regions receive less dimming. Feathering precedes window restoration so hovering one window does not weaken its neighbors.

The existing setting remains off by default and reuses once-per-minute captures. Only coarse brightness values and regional fingerprints are retained. Temporary evidence resets after capture failures, long gaps, sleep, display reconfiguration, or disabling required settings. Settings and documentation explain sampling limits and the history-based behavior.

Adds event-tap diagnostic logging for disabled-tap notifications, run-loop exits, and watchdog ping ages. This does **not** change watchdog recovery policy or claim to fix the two earlier unexplained restarts.

## Verification

Latest branch includes main through `36972af9` (#85).

- 2,560 engine tests and 610 app tests passed.
- Debug and Release builds, deep/strict signature verification, six-Mach-O release-marker scan, and diff check passed.
- Final independent branch review found no actionable issues.
- Regression coverage includes fingerprints, history, foreground/hover exclusions, grace/fade, stale evidence, rotation, spanning windows, occlusion, input cancellation, tapered edges/corners, unchanged interior depth, and zero alpha in moving cells.

Hardware testing used an MSI MAG 341C OLED over USB-C through a Thunderbolt dock, with a rotated Dell attached. I confirmed static-versus-moving protection, whole-window hover restoration and smooth return, and less conspicuous boundaries. Earlier checks passed Candela foreground clearing, fullscreen suppression, playback keep-awake suppression, and measurement producer stopping/resuming.

With the feather build, verified sleep/wake, MSI-only reconnect, and whole-dock reconnect retained the same app process, recovered sampling/protection after fresh qualification, and restored physical layout/rotation. No watchdog emergency or disabled-tap notification recurred. The MSI-only unplug removed an active overlay promptly. The overlay had already cleared before the verified sleep and whole-dock unplug, so those are recovery checks rather than direct active-overlay teardown checks. The later unattended switch and performance checks used the signed Release build at `b9e59276`, after the #85 merge.

A subsequent unattended run directly verified all three required switches against active on-screen overlays: brightness measurement, window observation, and automatic static-region dimming each cleared the mask within one second, while another app remained foreground. Measurement stopped captures for a full sampling interval; both producer re-enable paths kept stale masks down and recovered after fresh qualification, preserving history.

A controlled two-minute comparison with the General pane held constant measured 0.44% of one CPU core with protection active versus 0.30% with it off. Active resident memory stayed at 114–115 MiB. The Release-linked engine benchmark averaged about 12 microseconds per nomination. These are smoke measurements, not battery-life estimates. OLED settings-page rendering has a separate pre-existing CPU cost; its drawing code is unchanged here.

The final targeted sleep test began with an active overlay. The mask cleared at 19:09:54.942 CDT, before macOS entered Software Sleep at 19:09:59. After wake, the same app process and enabled keyboard listener remained alive; display arrangement and the Dell’s 270° rotation matched the baseline. Fresh sampling resumed at 19:10:23, with no stale mask or watchdog emergency.

The installed app and original MSI detection/idle settings and Settings-window position have been restored. Measurement settings and recorded history were preserved. Temporary test windows and monitoring helpers were closed.

## Before merge

Automated verification and the planned hardware checks have passed on `b9e59276`.

- Review the documented watchdog risk: the original two ping-loss restarts remain unreproduced and unexplained. The watchdog policy and listener lifecycle predate this PR and are unchanged; repeated clean runs do not establish a root cause or prove a fix. Diagnostic logging is retained for follow-up.
- My final manual review.

Ready for review; I’ll merge after my final manual check.
