### PR TITLE
Stop repeating work the app cannot show: catalog enumeration, care-tick readings, main-thread compute, hidden-window animation

### DIFF
--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -492,16 +492,22 @@ final class DisplayModeCoordinator {
       dropPreviewOnDepartedDisplay()
       return
     }
-    let all = DisplayModeCatalog.full(configurator.modes(for: displayID))
+    // One enumeration for the whole pass: each separate configurator call
+    // re-runs the CoreGraphics mode copy and the per-mode CGS description loop.
+    let snapshot = configurator.modeSnapshot(for: displayID)
+    let all = DisplayModeCatalog.full(snapshot.modes)
     // While a synthesized size is engaged, panel-derived values come from the last
     // pass taken with this display on its own desktop: an engaged panel's
     // readbacks describe the virtual master. See `PanelBaseline`.
     let engagedSize = synthesis?.engagedSize(displayID: displayID)
-    let baseline = baseline(for: display, modes: all, isEngaged: engagedSize != nil)
+    let baseline = baseline(
+      for: display, modes: all, nativePixels: snapshot.nativePixels,
+      isEngaged: engagedSize != nil
+    )
     let native = baseline.nativePixels.map { (width: $0.width, height: $0.height) }
     // Sampled once and handed to both the catalog and the verdict: the size the
     // model calls "current" has to be the one this enumeration saw.
-    let current = configurator.currentMode(for: displayID)
+    let current = snapshot.current
     // Density is a claim about physical pixels, so no native size means no
     // geometry at all rather than geometry over zeros.
     let geometry = native.flatMap { native in
@@ -540,7 +546,7 @@ final class DisplayModeCoordinator {
       current: current,
       distinctLogicalSizes: Set(all.map { LogicalSize(mode: $0) }).count,
       nativePixels: baseline.nativePixels,
-      withheldForWireTiming: configurator.modesWithheldByWireTimingGuard(for: displayID),
+      withheldForWireTiming: snapshot.withheldByWireTimingGuard,
       density: geometry.map {
         PanelDensityModel.evaluate(
           // PUBLISHED rows only: the model ranks whatever it is handed, so the
@@ -562,15 +568,18 @@ final class DisplayModeCoordinator {
   /// The panel-derived values for this pass: freshly measured while the display
   /// shows its own desktop, and the last such measurement while a synthesized
   /// size is engaged.
+  /// - Parameter nativePixels: from the caller's enumeration, not re-read here;
+  ///   a second read is a second enumeration and could describe another instant.
   private func baseline(
-    for display: ConfiguredDisplay, modes: [DisplayMode], isEngaged: Bool
+    for display: ConfiguredDisplay, modes: [DisplayMode],
+    nativePixels: (width: Int, height: Int)?, isEngaged: Bool
   ) -> PanelBaseline {
     let key = display.identity.key
     if isEngaged, let cached = baselines[key] { return cached }
-    let nativePixels = configurator.nativePixels(for: display.id)
-      .map { PixelSize(width: $0.width, height: $0.height) }
-    // The native-flagged mode from the SAME list this catalog is built from,
-    // which is how `nativePixels(for:)` finds it too.
+    let pixels = nativePixels.map { PixelSize(width: $0.width, height: $0.height) }
+    // The native-flagged mode from the SAME list the catalog is built from, so
+    // ladder and rows agree. Only its LOGICAL size is read: this list is sorted
+    // and two modes can carry the flag, so it may not be `nativePixels`' mode.
     let native = modes.first(where: \.isNative)
     let stops: [SyntheticSize] = if let native, !display.isBuiltIn {
       SyntheticSizeCatalog.stops(
@@ -583,7 +592,7 @@ final class DisplayModeCoordinator {
       []
     }
     let baseline = PanelBaseline(
-      nativePixels: nativePixels,
+      nativePixels: pixels,
       nativeLogicalWidth: native?.logicalWidth,
       nativeLogicalHeight: native?.logicalHeight,
       stops: stops
@@ -828,19 +837,22 @@ final class DisplayModeCoordinator {
   private func reapplyStoredMode(for display: ConfiguredDisplay) -> ModeReapplyStep {
     let identity = display.identity
     let stored = persistence.storedMode(for: identity)
-    // Enumerated for every arrival, including displays that never opted in: the
-    // opt-in gate lives inside the tested policy, so asking costs one
-    // `CGDisplayCopyAllDisplayModes` per arrival, the same call `warmModeCatalogs`
-    // makes on every menu close.
+    let isEnabled = persistence.isEnabled(for: identity)
+    // The policy's own first guard, hoisted so a display nobody opted in for
+    // costs no enumeration. `decide` answers `.doNothing` for both, which is this `.done`.
+    guard isEnabled, stored != nil else { return .done }
+    // One pass: the policy checks the current mode against what the stored
+    // descriptor resolves to in the list, so both must describe one instant.
+    let snapshot = configurator.modeSnapshot(for: display.id)
     let decision = ModeReapplyPolicy.decide(
-      isEnabled: persistence.isEnabled(for: identity),
+      isEnabled: isEnabled,
       // From the entry the list handed us, not asked again now: the mirror state
       // has to describe the same instant as the enumeration that claimed this
       // arrival.
       isMirroringAnotherDisplay: display.isMirrorSlave,
       stored: stored,
-      available: configurator.modes(for: display.id),
-      current: configurator.currentMode(for: display.id)
+      available: snapshot.modes,
+      current: snapshot.current
     )
     // "Not now": a mirror slave, or a display that cannot say what mode it is
     // running. The claim goes back, since only an observed ABSENCE re-arms one and
@@ -907,9 +919,11 @@ final class DisplayModeCoordinator {
     // ladder computes from that, and every stop lands under the minor-axis floor.
     // The stored stop then resolves nil and the relaunch restore reports
     // staleDescriptor forever.
-    let modes = DisplayModeCatalog.full(configurator.modes(for: display.id))
+    let snapshot = configurator.modeSnapshot(for: display.id)
+    let modes = DisplayModeCatalog.full(snapshot.modes)
     let baseline = baseline(
-      for: display, modes: modes, isEngaged: synthesis.isEngaged(displayID: display.id)
+      for: display, modes: modes, nativePixels: snapshot.nativePixels,
+      isEngaged: synthesis.isEngaged(displayID: display.id)
     )
     let decision = await synthesis.reapply(
       for: display,

--- a/Candela/OledCare/LuminanceSampler.swift
+++ b/Candela/OledCare/LuminanceSampler.swift
@@ -21,7 +21,7 @@ import os
 ///   luminance values and reads as a legible screenshot, with window layout,
 ///   large text and app identity recoverable from it, where the reduced grid is
 ///   not. It stays transient by the shape of the call graph: the `CGImage` dies
-///   with `sample(displayID:)`, the caller reduces `Sample` to its cells and
+///   with `sample(displayID:content:)`, the caller reduces `Sample` to its cells and
 ///   stores only those. A consumer that started holding a `Sample` is the thing
 ///   to look at.
 /// - Performance. [MEASURED 2026-08-18, 20 captures per leg on this rig] Median
@@ -58,34 +58,46 @@ final class LuminanceSampler {
     CGPreflightScreenCaptureAccess()
   }
 
-  /// Captures `displayID` once and reduces it to a mean-luminance grid.
-  /// Nil on any failure: permission denied, display gone, capture error,
-  /// empty result.
-  func sample(displayID: CGDirectDisplayID) async -> Sample? {
-    guard Self.hasScreenRecordingPermission() else { return nil }
-
+  /// One XPC round trip per sampling wave rather than one per enrolled display.
+  /// Nil when the grant is absent or the enumeration fails; the caller skips the sample.
+  ///
+  /// Fetched per wave, never cached: `displays` goes stale when a panel departs
+  /// or is mirrored, and a stale `applications` loses our own entry, which puts
+  /// our overlays back into the measurement they feed.
+  static func shareableContent() async -> SCShareableContent? {
+    guard hasScreenRecordingPermission() else { return nil }
     // Desktop windows are NOT excluded: wallpaper is emitted light and belongs
     // in the measurement. On-screen only, since an offscreen window emits nothing.
-    let content: SCShareableContent
     do {
-      content = try await SCShareableContent.excludingDesktopWindows(
+      return try await SCShareableContent.excludingDesktopWindows(
         false, onScreenWindowsOnly: true)
     } catch {
-      Self.log.debug("luminance sample: shareable content unavailable (\(error.localizedDescription, privacy: .public))")
+      log.debug("luminance sample: shareable content unavailable (\(error.localizedDescription, privacy: .public))")
       return nil
     }
+  }
 
+  /// Captures `displayID` once against the wave's `shareableContent()` and
+  /// reduces it to a mean-luminance grid. Nil on display gone, capture error or empty result.
+  func sample(displayID: CGDirectDisplayID, content: SCShareableContent) async -> Sample? {
     guard let scDisplay = content.displays.first(where: { $0.displayID == displayID }) else {
       return nil
     }
 
-    // Our own overlays must not be sampled, or detection dimming feeds
-    // back into the measurement it derives from: band dims region, region reads
-    // cooler, band lifts, region reheats. `owningApplication` is nil for some
-    // system windows, which are correctly kept.
+    // Our own overlays must not be sampled, or detection dimming feeds back into
+    // the measurement it derives from: band dims region, region reads cooler,
+    // band lifts, region reheats.
+    //
+    // Excluded by OWNER, not by window list: the list is a snapshot taken before
+    // the capture and shared by the whole wave, so an overlay raised in between
+    // would be in the frame. Naming the application excludes every window this
+    // process owns at CAPTURE time. Windows with no owning application (some
+    // system windows) and the desktop and dock are still kept, as before. An
+    // empty `ourApps` excludes nothing, exactly as an empty window list did.
     let ourPID = ProcessInfo.processInfo.processIdentifier
-    let ownWindows = content.windows.filter { $0.owningApplication?.processID == ourPID }
-    let filter = SCContentFilter(display: scDisplay, excludingWindows: ownWindows)
+    let ourApps = content.applications.filter { $0.processID == ourPID }
+    let filter = SCContentFilter(
+      display: scDisplay, excludingApplications: ourApps, exceptingWindows: [])
 
     let config = SCStreamConfiguration()
     let (requestedWidth, requestedHeight) = LuminanceReduction.requestedSize(
@@ -115,7 +127,14 @@ final class LuminanceSampler {
     let rows = image.height
     guard cols > 0, rows > 0 else { return nil }
 
-    guard let grid = LuminanceReduction.meanLuminance(of: image, cols: cols, rows: rows) else { return nil }
+    // Every captured pixel (83,000 to 96,000 here) walked on the main thread is
+    // a stall the driver loop has to answer input through. Detached so it does
+    // not inherit cancellation: bounded pure compute over an immutable image is
+    // cheaper to let finish than to abandon, and the caller drops the result.
+    let reduced = await Task.detached(priority: .utility) {
+      LuminanceReduction.meanLuminance(of: image, cols: cols, rows: rows)
+    }.value
+    guard let grid = reduced else { return nil }
     // `image` dies with this scope. Nothing retains a CGImage past here.
     return Sample(grid: grid, cols: cols, rows: rows)
   }

--- a/Candela/OledCare/LuminanceSampler.swift
+++ b/Candela/OledCare/LuminanceSampler.swift
@@ -48,6 +48,25 @@ final class LuminanceSampler {
     let rows: Int
   }
 
+  /// A prepared content snapshot. Starting a capture is synchronous; its
+  /// screenshot and reduction complete asynchronously on the returned task.
+  struct Wave {
+    let start: @MainActor (CGDirectDisplayID) -> Task<Sample?, Never>
+  }
+
+  /// One content enumeration shared by independently completing captures.
+  /// The non-Sendable snapshot never leaves MainActor, including the tasks
+  /// that read it. Only the immutable image reduction runs on a worker.
+  static func prepareWave() async -> Wave? {
+    guard let content = await shareableContent() else { return nil }
+    let sampler = LuminanceSampler()
+    return Wave { displayID in
+      Task { @MainActor in
+        await sampler.sample(displayID: displayID, content: content)
+      }
+    }
+  }
+
   private static let log = Logger(subsystem: "com.rydersel.Candela", category: "oledcare")
 
   /// Whether Screen Recording is already granted. Preflight only: this type

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -85,7 +85,8 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// like `synthesisSuspensions`, so the pane cannot disagree about the reason.
   private(set) var checkupSuspensions: Set<String> = []
 
-  private struct PerDisplay {
+  /// Internal so the host-free test bundle can drive one tick's telemetry gate directly.
+  struct PerDisplay {
     var engine: IdleDimmingEngine
     /// Cached from prefs (refreshed by `reconcileEnrollment`) so the tick can
     /// decide whether to run the focus sampler without a per-tick prefs read.
@@ -235,14 +236,20 @@ final class OledCareCoordinator: CheckupCareHolding {
 
   @ObservationIgnored private let windowList: (CGDirectDisplayID) -> [WindowSnapshot]
 
+  /// Injectable so a test can count reads: the IOKit power-source copy belongs
+  /// on the 60 s decision point, never on the tick.
+  @ObservationIgnored private let lowBattery: () -> Bool
+
   init(
     wallpaper: WallpaperLuminanceSource = WallpaperLuminanceSource(),
     windowList: @escaping (CGDirectDisplayID) -> [WindowSnapshot] = {
       CGWindowListSource(displayID: $0).onScreenWindows()
-    }
+    },
+    lowBattery: @escaping () -> Bool = { OledCareSignalSources.onLowBattery() }
   ) {
     self.wallpaper = wallpaper
     self.windowList = windowList
+    self.lowBattery = lowBattery
   }
 
   /// The most recent accepted reading, panel-native, for the hero's live
@@ -276,6 +283,15 @@ final class OledCareCoordinator: CheckupCareHolding {
   @ObservationIgnored private var exposureEpoch = 0
   /// Per enrolled-and-connected display, by persistenceKey.
   @ObservationIgnored private var states: [String: PerDisplay] = [:]
+  /// One display's place in a capture wave. The epoch is stamped when the tick
+  /// queues it, so a delete between the tick and the wave still invalidates
+  /// what comes back. Internal for `PerDisplay`'s reason.
+  struct CaptureRequest {
+    let key: String
+    let target: OledTelemetryTarget
+    let transform: PanelSpaceTransform
+    let epoch: Int
+  }
   /// Displays with a checkup field on them, by persistenceKey. Not enrollment
   /// state, so `reconcileEnrollment` leaves it alone: only the window that
   /// raised a field takes it down, and a display can be un-enrolled and
@@ -407,7 +423,7 @@ final class OledCareCoordinator: CheckupCareHolding {
             self.disarmInputMonitor()
           }
         }
-        try? await Task.sleep(for: interval)
+        try? await Task.sleep(for: interval, tolerance: Self.sleepTolerance(for: interval))
       }
     }
   }
@@ -868,6 +884,9 @@ final class OledCareCoordinator: CheckupCareHolding {
       model.displays.map { ($0.display.persistenceKey, $0) },
       uniquingKeysWith: { first, _ in first }
     )
+    // Tick-local, never a stored property: the wave is issued at the end of the
+    // tick that fills it, so nothing can be left behind.
+    var captures: [CaptureRequest] = []
     var published = dimStates
     // Built empty rather than copied from the published set: a display that
     // stopped being a synthesis slave simply does not get re-added, so a
@@ -964,6 +983,9 @@ final class OledCareCoordinator: CheckupCareHolding {
       // departure and is already handled. macOS exposes no signal that
       // distinguishes a soft-standby panel, and the one signal Candela had, its
       // own 0xD6 write, went with the power-off action that was cut.
+      //
+      // One read per display per tick, shared with the telemetry gate below
+      // (`target.panel` is `id`).
       let awake = CGDisplayIsAsleep(id) == 0
       if state.hoursTracking {
         if state.wasAwake, !awake { hoursTracker(for: key).noteStandby() }
@@ -999,7 +1021,9 @@ final class OledCareCoordinator: CheckupCareHolding {
       // target is built from THIS tick's topology sample, so the surface it
       // resolves and the `isSynthesis` verdict above describe one instant.
       let target = OledTelemetryTarget(panel: id, topology: topology)
-      updateTelemetry(for: key, state: &state, dimState: newState, on: target, at: now)
+      updateTelemetry(
+        for: key, state: &state, dimState: newState, on: target, panelIsAwake: awake, at: now,
+        into: &captures)
       // Mutates the LOCAL copy, deliberately before this tick's render: the
       // sample path's `renominate` writes `states[key]` because it lands
       // between ticks, but a mid-tick write there would be clobbered by the
@@ -1041,6 +1065,33 @@ final class OledCareCoordinator: CheckupCareHolding {
     if published != dimStates { dimStates = published }
     if synthesisPaused != synthesisSuspensions { synthesisSuspensions = synthesisPaused }
     if checkupPaused != checkupSuspensions { checkupSuspensions = checkupPaused }
+    // After the loop, so every display that took this slot shares one wave and
+    // one content enumeration.
+    issueCaptureWave(captures)
+  }
+
+  /// How far a tick may be deferred so the kernel can coalesce the wakeup with
+  /// whatever else the machine is waking for.
+  ///
+  /// Per cadence, never one constant: the fast cadence answers input inside
+  /// 100 ms and cannot spend slack. An unrecognized interval is one nobody has
+  /// reasoned about, so it gets the strict answer too.
+  static func sleepTolerance(for interval: Duration) -> Duration {
+    switch interval {
+    case OledCareCadence.fast: .zero
+    // A displayed nomination sheds within a second of the window moving; a
+    // tenth of that is under the threshold the shed is judged against.
+    case OledCareCadence.windowFollow: .milliseconds(100)
+    // The sampling throttle rides this tick and books a fixed 60 s of exposure
+    // however late the slot lands, so slack here under-books what the panel
+    // emitted. 10% of cadence, as for window follow: under 0.35% of the 60 s
+    // booked, and still enough to coalesce the wakeup.
+    case OledCareCadence.slow: .milliseconds(200)
+    // Nothing rides the idle tick: it waits for an enrollment that restarts the
+    // loop itself, so 33 s reaches the same verdict as 30 s.
+    case OledCareCadence.idle: .seconds(3)
+    default: .zero
+    }
   }
 
   /// A given-up verify drops the fast cadence only when nothing is wanted (the
@@ -1335,9 +1386,10 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// uniform dim and orients the result, so keeping it panel-side means one
   /// orientation per render instead of one here plus a re-orientation whenever
   /// the display rotates under a cached mask.
-  private func renominate(
-    for key: String, grid: [Double], cols: Int, rows: Int, through transform: PanelSpaceTransform
-  ) {
+  ///
+  /// The grid arrives re-binned: the caller already has it for the live view and
+  /// the model pair, and a second derivation is a second chance to disagree.
+  private func renominate(for key: String, panelGrid: [Double]) {
     guard states[key]?.detectionDimmingEnabled == true else {
       states[key]?.nominatedMask = nil
       return
@@ -1352,7 +1404,6 @@ final class OledCareCoordinator: CheckupCareHolding {
       states[key]?.nominatedMask = nil
       return
     }
-    let panelGrid = transform.panelNativeGrid(fromDisplayGrid: grid, cols: cols, rows: rows)
     states[key]?.nominatedMask = StaticRegionDetector.nominate(
       recentGrid: panelGrid, observation: observation, thresholds: .default)
   }
@@ -1438,14 +1489,20 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// [MEASURED 2026-08-06: 0.46 ms]. The luminance capture is not, since it
   /// suspends for ~70 ms across an `SCShareableContent` XPC round trip and the
   /// driver loop has to answer input inside 100 ms when an overlay is up. It
-  /// goes to a ONE-SHOT task; the loop itself stays synchronous.
-  private func updateTelemetry(
+  /// goes to a ONE-SHOT task per wave; the loop itself stays synchronous.
+  func updateTelemetry(
     for key: String, state: inout PerDisplay, dimState: OledDimState,
-    on target: OledTelemetryTarget, at now: SuspendingClock.Instant
+    on target: OledTelemetryTarget, panelIsAwake: Bool, at now: SuspendingClock.Instant,
+    into captures: inout [CaptureRequest]
   ) {
     guard state.telemetryEnabled || state.windowObservationEnabled else { return }
-    guard samplingQualifies(dimState: dimState, on: target) else { return }
+    // Throttle FIRST: qualification ends in an IOKit power-source copy, the
+    // loop's most expensive read, and every tick in the interval but one is
+    // turned away here. `lastSampleAt` is written only when both gates pass, so
+    // the order does not change the schedule.
     if let last = state.lastSampleAt, now - last < Self.samplingInterval { return }
+    guard samplingQualifies(dimState: dimState, on: target, panelIsAwake: panelIsAwake)
+    else { return }
     state.lastSampleAt = now
 
     // A degenerate transform does NOT reject the sample downstream:
@@ -1464,7 +1521,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     }
     if state.telemetryEnabled, !state.sampleInFlight {
       state.sampleInFlight = true
-      captureExposure(for: key, on: target, through: transform)
+      captures.append(queuedCapture(for: key, on: target, through: transform))
     }
     persistExposureHistoryIfDue(at: now)
   }
@@ -1501,8 +1558,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     observers[key] = observer
     latestObservations[key] = observation
     latestWindows[key] = windows
-    // `cells` is already panel-native (re-binned at accept time), matching
-    // what `renominate` derives before calling the same rule.
+    // `cells` is already panel-native: it is the same array `renominate` was
+    // handed at accept time, and the rule below is the same one.
     state.nominatedMask = StaticRegionDetector.nominate(
       recentGrid: cached.cells, observation: observation, thresholds: .default)
   }
@@ -1554,13 +1611,17 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// holds `.suspended` whatever the idle counter says. Do not "fix" this with a
   /// readback or a DPMS probe: a write-only panel answers neither, and the
   /// probe itself can strand the display.
-  private func samplingQualifies(dimState: OledDimState, on target: OledTelemetryTarget) -> Bool {
+  ///
+  /// `panelIsAwake` is passed in so one tick asks the panel once. It is the
+  /// PANEL's sleep, never the surface's: a virtual display has no panel to
+  /// sleep, and the wear being measured is the glass's.
+  private func samplingQualifies(
+    dimState: OledDimState, on target: OledTelemetryTarget, panelIsAwake: Bool
+  ) -> Bool {
     guard !resetting, target.samplingMayRun(dimState: dimState), !lockObserver.isLocked
     else { return false }
-    // The panel's own sleep, never the surface's: a virtual display has no
-    // panel to sleep, and the wear being measured is the glass's.
-    guard CGDisplayIsAsleep(target.panel) == 0 else { return false }
-    return !OledCareSignalSources.onLowBattery()
+    guard panelIsAwake else { return false }
+    return !lowBattery()
   }
 
   /// Display geometry for the transform, from `CGDisplayBounds`: the same source
@@ -1652,21 +1713,60 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// every time the display is recreated. The panel's key is the only stable
   /// identity in the pair, and booking to it once is also what keeps one desktop
   /// from being counted twice.
-  private func captureExposure(
+  private func queuedCapture(
     for key: String, on target: OledTelemetryTarget, through transform: PanelSpaceTransform
-  ) {
-    let epoch = exposureEpoch
+  ) -> CaptureRequest {
     log.debug("""
-    OLED care: exposure capture issued for display \(target.panel, privacy: .public) \
+    OLED care: exposure capture queued for display \(target.panel, privacy: .public) \
     (surface \(target.surface, privacy: .public))
     """)
-    // One shot, not a loop. `self` is deliberately not held across the await,
-    // the driver loop's rule: the sampler is a separate object, so awaiting
-    // through it retains the sampler and not this coordinator.
+    return CaptureRequest(
+      key: key, target: target, transform: transform, epoch: exposureEpoch)
+  }
+
+  /// One `SCShareableContent` enumeration (an XPC round trip) shared by every
+  /// capture this tick queued.
+  ///
+  /// Captures stay sequential on this actor: `SCShareableContent` is not
+  /// `Sendable`. Two accepted consequences. The gap between enumeration and a
+  /// later capture is wider, so everything it can invalidate is re-checked in
+  /// `finishExposureCapture`, and the own-window exclusion is by owning
+  /// APPLICATION at capture time. And a capture that never returns strands the
+  /// whole wave in `sampleInFlight`, not one display. No timeout: the recovery
+  /// is the same either way, and a deadline on a call never seen to hang is a
+  /// second failure mode to reason about.
+  ///
+  /// One shot, not a loop. `self` is not held across the await: awaiting through
+  /// the sampler retains the sampler, not this coordinator.
+  private func issueCaptureWave(_ requests: [CaptureRequest]) {
+    guard !requests.isEmpty else { return }
     Task { @MainActor [weak self] in
-      guard let sampler = self?.sampler else { return }
-      let sample = await sampler.sample(displayID: target.surface)
-      self?.finishExposureCapture(sample, for: key, on: target, through: transform, epoch: epoch)
+      guard let content = await LuminanceSampler.shareableContent() else {
+        // No grant or failed enumeration: every request still goes through the
+        // one door that clears `sampleInFlight`.
+        for request in requests {
+          self?.finishExposureCapture(
+            nil, for: request.key, on: request.target, through: request.transform,
+            epoch: request.epoch)
+        }
+        return
+      }
+      // Resolved above the loop: bailing part-way would strand the rest of the
+      // wave in `sampleInFlight`, so a gone sampler takes the same nil routing.
+      guard let sampler = self?.sampler else {
+        for request in requests {
+          self?.finishExposureCapture(
+            nil, for: request.key, on: request.target, through: request.transform,
+            epoch: request.epoch)
+        }
+        return
+      }
+      for request in requests {
+        let sample = await sampler.sample(displayID: request.target.surface, content: content)
+        self?.finishExposureCapture(
+          sample, for: request.key, on: request.target, through: request.transform,
+          epoch: request.epoch)
+      }
     }
   }
 
@@ -1689,7 +1789,11 @@ final class OledCareCoordinator: CheckupCareHolding {
     guard current == target else { return }
     let id = target.panel
     guard let state = states[key], state.telemetryEnabled, state.lastDisplayID == id,
-      let dimState = dimStates[key], samplingQualifies(dimState: dimState, on: current)
+      let dimState = dimStates[key],
+      // Re-read, not carried: the capture's suspension is long enough for the
+      // panel to sleep under it.
+      samplingQualifies(
+        dimState: dimState, on: current, panelIsAwake: CGDisplayIsAsleep(current.panel) == 0)
     else { return }
     // Geometry can change under a capture without the display departing (a
     // rotation, a mode switch). The grid was reduced through the OLD geometry,
@@ -1715,8 +1819,8 @@ final class OledCareCoordinator: CheckupCareHolding {
     }
     accumulators[key] = accumulator
     unsavedExposureKeys.insert(key)
-    // Re-binned once here for the live view and the pair; `accumulate` does
-    // the same internally and does not expose its result.
+    // Re-binned once for the live view, the model pair and the nomination;
+    // `accumulate` re-bins internally and does not expose its result.
     let panelGrid = transform.panelNativeGrid(
       fromDisplayGrid: sample.grid, cols: sample.cols, rows: sample.rows)
     latestSamples[key] = (panelGrid, Date())
@@ -1724,8 +1828,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     // Detection dimming's luminance half nominates here, off the sampling clock:
     // the grid changes once a minute, so recomputing faster reaches the same
     // answer. The window half does NOT wait for it.
-    renominate(for: key, grid: sample.grid, cols: sample.cols, rows: sample.rows,
-               through: transform)
+    renominate(for: key, panelGrid: panelGrid)
     log.debug("""
     OLED care: exposure sample accepted for display \(id, privacy: .public) \
     (\(accumulator.map.sampleCount, privacy: .public) total)

--- a/Candela/OledCare/OledCareCoordinator.swift
+++ b/Candela/OledCare/OledCareCoordinator.swift
@@ -142,9 +142,6 @@ final class OledCareCoordinator: CheckupCareHolding {
     /// halves, so a display is never sampled and observed on drifting cadences
     /// that each pay their own cost.
     var lastSampleAt: SuspendingClock.Instant?
-    /// A capture is out on the XPC round trip. Nothing else may issue one: two
-    /// in flight would double-book the interval they both stand for.
-    var sampleInFlight = false
     /// USER mirror-set membership as of the last tick, for the mirror-set pause's entry EDGE.
     /// The steady state is already handled (a mirrored display never
     /// qualifies); this exists so the observer's ageing state is dropped
@@ -205,7 +202,8 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// because it measures the same thing about the same glass: how long, and now
   /// also at what level.
   @ObservationIgnored private var wearTrackers: [String: WearSignalTracker] = [:]
-  @ObservationIgnored private let sampler = LuminanceSampler()
+  /// Owns one pending request per panel, including its identity across re-enrollment.
+  @ObservationIgnored private let exposureCapture: OledExposureCapture
   /// Accumulated exposure per panel, by persistenceKey, restored from disk on
   /// first touch and kept for the app's lifetime: wear is a fact about a panel,
   /// not about a connection, exactly like `trackers`.
@@ -245,11 +243,13 @@ final class OledCareCoordinator: CheckupCareHolding {
     windowList: @escaping (CGDirectDisplayID) -> [WindowSnapshot] = {
       CGWindowListSource(displayID: $0).onScreenWindows()
     },
-    lowBattery: @escaping () -> Bool = { OledCareSignalSources.onLowBattery() }
+    lowBattery: @escaping () -> Bool = { OledCareSignalSources.onLowBattery() },
+    exposureCapture: OledExposureCapture = OledExposureCapture(prepare: LuminanceSampler.prepareWave)
   ) {
     self.wallpaper = wallpaper
     self.windowList = windowList
     self.lowBattery = lowBattery
+    self.exposureCapture = exposureCapture
   }
 
   /// The most recent accepted reading, panel-native, for the hero's live
@@ -286,12 +286,7 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// One display's place in a capture wave. The epoch is stamped when the tick
   /// queues it, so a delete between the tick and the wave still invalidates
   /// what comes back. Internal for `PerDisplay`'s reason.
-  struct CaptureRequest {
-    let key: String
-    let target: OledTelemetryTarget
-    let transform: PanelSpaceTransform
-    let epoch: Int
-  }
+  typealias CaptureRequest = OledExposureCapture.Request
   /// Displays with a checkup field on them, by persistenceKey. Not enrollment
   /// state, so `reconcileEnrollment` leaves it alone: only the window that
   /// raised a field takes it down, and a display can be un-enrolled and
@@ -550,6 +545,9 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// let the health view keep naming apps for a history the user just deleted.
   func clearExposureHistory(for persistenceKey: String) {
     exposureEpoch += 1
+    // The epoch is global, so every old request is obsolete. Release their
+    // reservations now, even if a compositor reply never comes back.
+    exposureCapture.invalidateAll()
     accumulators[persistenceKey] = ExposureAccumulator()
     ownerHours[persistenceKey] = OwnerHoursAccumulator()
     forgetWindowObservation(for: persistenceKey)
@@ -622,6 +620,7 @@ final class OledCareCoordinator: CheckupCareHolding {
     // epoch bump does the same for a capture already in flight.
     exposureEpoch += 1
     unsavedExposureKeys.removeAll()
+    exposureCapture.invalidateAll()
     // The wipe removes the stored bytes the quarantine existed to protect, so
     // holding the flag past it would leave a display recording nothing forever
     // over a file that is already gone.
@@ -758,6 +757,7 @@ final class OledCareCoordinator: CheckupCareHolding {
         }
         existing.hoursTracking = tracking
         existing.telemetryEnabled = prefs.oledTelemetry
+        if !existing.telemetryEnabled { exposureCapture.invalidate(key: key) }
         existing.windowObservationEnabled = prefs.oledWindowObservation
         // Turning detection dimming off must drop the nomination, not merely
         // stop consulting it. A retained mask would come straight back on the
@@ -810,6 +810,7 @@ final class OledCareCoordinator: CheckupCareHolding {
   }
 
   private func dropState(for key: String) {
+    exposureCapture.invalidate(key: key)
     guard var state = states.removeValue(forKey: key) else { return }
     // BEFORE the controller lookup, which misses a departed display: the state
     // owning the ramp is being discarded, so nothing else can cancel it.
@@ -1079,13 +1080,13 @@ final class OledCareCoordinator: CheckupCareHolding {
   static func sleepTolerance(for interval: Duration) -> Duration {
     switch interval {
     case OledCareCadence.fast: .zero
-    // A displayed nomination sheds within a second of the window moving; a
-    // tenth of that is under the threshold the shed is judged against.
+    // The one-second follow cadence can be deferred by another 100 ms.
     case OledCareCadence.windowFollow: .milliseconds(100)
     // The sampling throttle rides this tick and books a fixed 60 s of exposure
-    // however late the slot lands, so slack here under-books what the panel
-    // emitted. 10% of cadence, as for window follow: under 0.35% of the 60 s
-    // booked, and still enough to coalesce the wakeup.
+    // however late the slot lands. These are repeated relative sleeps, not a
+    // 60 s deadline: 28 fully deferred 2.2 s ticks reach 61.6 s while booking
+    // 60 s, about 2.6% less. Nominal exposure already ignores scheduling jitter;
+    // this tolerance is a wakeup allowance, not a bound on measurement error.
     case OledCareCadence.slow: .milliseconds(200)
     // Nothing rides the idle tick: it waits for an enrollment that restarts the
     // loop itself, so 33 s reaches the same verdict as 30 s.
@@ -1519,9 +1520,9 @@ final class OledCareCoordinator: CheckupCareHolding {
     if state.windowObservationEnabled {
       observeWindows(for: key, on: target.surface, through: transform)
     }
-    if state.telemetryEnabled, !state.sampleInFlight {
-      state.sampleInFlight = true
-      captures.append(queuedCapture(for: key, on: target, through: transform))
+    if state.telemetryEnabled,
+       let request = queuedCapture(for: key, on: target, through: transform) {
+      captures.append(request)
     }
     persistExposureHistoryIfDue(at: now)
   }
@@ -1715,91 +1716,57 @@ final class OledCareCoordinator: CheckupCareHolding {
   /// from being counted twice.
   private func queuedCapture(
     for key: String, on target: OledTelemetryTarget, through transform: PanelSpaceTransform
-  ) -> CaptureRequest {
+  ) -> CaptureRequest? {
+    guard let request = exposureCapture.reserve(
+      key: key, target: target, transform: transform, epoch: exposureEpoch)
+    else { return nil }
     log.debug("""
     OLED care: exposure capture queued for display \(target.panel, privacy: .public) \
     (surface \(target.surface, privacy: .public))
     """)
-    return CaptureRequest(
-      key: key, target: target, transform: transform, epoch: exposureEpoch)
+    return request
   }
 
   /// One `SCShareableContent` enumeration (an XPC round trip) shared by every
   /// capture this tick queued.
   ///
-  /// Captures stay sequential on this actor: `SCShareableContent` is not
-  /// `Sendable`. Two accepted consequences. The gap between enumeration and a
-  /// later capture is wider, so everything it can invalidate is re-checked in
-  /// `finishExposureCapture`, and the own-window exclusion is by owning
-  /// APPLICATION at capture time. And a capture that never returns strands the
-  /// whole wave in `sampleInFlight`, not one display. No timeout: the recovery
-  /// is the same either way, and a deadline on a call never seen to hang is a
-  /// second failure mode to reason about.
-  ///
-  /// One shot, not a loop. `self` is not held across the await: awaiting through
-  /// the sampler retains the sampler, not this coordinator.
+  /// Each screenshot completes independently, with the content snapshot confined
+  /// to MainActor. Only the pipeline is retained across the await; both callbacks
+  /// capture the coordinator weakly so a delayed screenshot cannot keep it alive.
   private func issueCaptureWave(_ requests: [CaptureRequest]) {
     guard !requests.isEmpty else { return }
+    let pipeline = exposureCapture
     Task { @MainActor [weak self] in
-      guard let content = await LuminanceSampler.shareableContent() else {
-        // No grant or failed enumeration: every request still goes through the
-        // one door that clears `sampleInFlight`.
-        for request in requests {
-          self?.finishExposureCapture(
-            nil, for: request.key, on: request.target, through: request.transform,
-            epoch: request.epoch)
-        }
-        return
-      }
-      // Resolved above the loop: bailing part-way would strand the rest of the
-      // wave in `sampleInFlight`, so a gone sampler takes the same nil routing.
-      guard let sampler = self?.sampler else {
-        for request in requests {
-          self?.finishExposureCapture(
-            nil, for: request.key, on: request.target, through: request.transform,
-            epoch: request.epoch)
-        }
-        return
-      }
-      for request in requests {
-        let sample = await sampler.sample(displayID: request.target.surface, content: content)
-        self?.finishExposureCapture(
-          sample, for: request.key, on: request.target, through: request.transform,
-          epoch: request.epoch)
-      }
+      await pipeline.run(requests,
+        current: { [weak self] request in self?.exposureCaptureContext(for: request) },
+        accept: { [weak self] request, sample in
+          self?.finishExposureCapture(sample, request: request)
+        })
     }
   }
 
-  /// Everything the capture's suspension can invalidate is re-checked here.
-  /// ~70 ms is long enough for the display to lock, mirror, sleep, dim, be
-  /// reconfigured, be un-enrolled, or have its history deleted, and a sample
-  /// taken before any of those is exposure the panel did not emit.
-  private func finishExposureCapture(
-    _ sample: LuminanceSampler.Sample?, for key: String, on target: OledTelemetryTarget,
-    through transform: PanelSpaceTransform, epoch: Int
-  ) {
-    states[key]?.sampleInFlight = false
-    guard let sample, epoch == exposureEpoch else { return }
-    // Re-resolved, never re-used: a synthesized size can be disengaged inside
-    // the suspension, which moves the desktop back onto the panel and changes
-    // both the surface the sample came from and the qualification that let it
-    // run. An unequal target describes a machine the sample was not taken of,
-    // so it is dropped rather than attributed.
-    let current = telemetryTarget(for: target.panel)
-    guard current == target else { return }
-    let id = target.panel
-    guard let state = states[key], state.telemetryEnabled, state.lastDisplayID == id,
-      let dimState = dimStates[key],
-      // Re-read, not carried: the capture's suspension is long enough for the
-      // panel to sleep under it.
-      samplingQualifies(
-        dimState: dimState, on: current, panelIsAwake: CGDisplayIsAsleep(current.panel) == 0)
-    else { return }
-    // Geometry can change under a capture without the display departing (a
-    // rotation, a mode switch). The grid was reduced through the OLD geometry,
-    // so it is binned rather than re-mapped through geometry it never saw.
-    guard Self.transform(current) == transform else { return }
+  /// Re-sample everything that can change across the screenshot's suspension.
+  /// The pipeline rejects old history, enrollment, target, geometry and state
+  /// before invoking the bookkeeping callback, in one non-suspending actor turn.
+  private func exposureCaptureContext(for request: CaptureRequest) -> OledExposureCapture.Context? {
+    guard let state = states[request.key], let id = state.lastDisplayID,
+          let dimState = dimStates[request.key] else { return nil }
+    let current = telemetryTarget(for: request.target.panel)
+    var context = OledExposureCapture.Context(
+      epoch: exposureEpoch, displayID: id, target: current, transform: Self.transform(current),
+      telemetryEnabled: state.telemetryEnabled, dimState: dimState,
+      isResetting: resetting, isLocked: lockObserver.isLocked,
+      panelIsAwake: CGDisplayIsAsleep(current.panel) == 0, isLowBattery: false)
+    // Keep the expensive power-source read behind the other rejection gates.
+    if context.accepts(request) { context.isLowBattery = lowBattery() }
+    return context
+  }
 
+  private func finishExposureCapture(_ sample: LuminanceSampler.Sample, request: CaptureRequest) {
+    let key = request.key
+    let current = request.target
+    let id = current.panel
+    let transform = request.transform
     var accumulator = exposureAccumulator(for: key)
     let before = accumulator.map.sampleCount
     // Handed over whole: `accumulate` is all-or-nothing and refuses a malformed

--- a/Candela/OledCare/OledCareSignals.swift
+++ b/Candela/OledCare/OledCareSignals.swift
@@ -12,8 +12,8 @@ import IOKit.pwr_mgt
 /// nonisolated: the platform calls are thread-safe and none touches stored
 /// state, so the two on the 10 Hz tick path must not be forced through a
 /// main-actor hop [MEASURED 2026-08-06: sub-microsecond and 0.07 ms per call].
-/// Only `displaySleepMinutes()` is `@MainActor`, because it owns a cache, and it
-/// costs 1000x the tick reads.
+/// Only `displaySleepMinutes()` is `@MainActor`, for its cache; the spawn it
+/// waits on costs 1000x a tick read and runs off the actor.
 enum OledCareSignalSources {
   /// Seconds since the last user input, system-wide.
   ///
@@ -86,38 +86,61 @@ enum OledCareSignalSources {
 
   @MainActor private static var cachedDisplaySleep: (minutes: Int?, at: ContinuousClock.Instant)?
 
+  /// The spawn in flight: a second caller during those 79 ms waits on it rather
+  /// than starting a second `pmset`.
+  @MainActor private static var displaySleepProbe: Task<Int?, Never>?
+
   /// The system `displaysleep` setting in minutes (0 = never), for the pane's
   /// "your dim never fires" warning. Read via `pmset -g`, since no public API
   /// reports it.
   ///
-  /// **79 ms process spawn** [MEASURED 2026-08-06], on the main actor. Call it
-  /// once per pane appearance, NEVER from a timer: the 60 s cache is a backstop
-  /// against a re-render loop, not a licence to poll.
+  /// **79 ms process spawn** [MEASURED 2026-08-06], so the wait happens off the
+  /// main actor and only the cache is main-actor state. Call it once per pane
+  /// appearance, NEVER from a timer: the 60 s cache is a backstop against a
+  /// re-render loop, not a licence to poll.
   @MainActor
-  static func displaySleepMinutes() -> Int? {
+  static func displaySleepMinutes() async -> Int? {
     if let cached = cachedDisplaySleep, cached.at.duration(to: .now) < .seconds(60) {
       return cached.minutes
     }
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
-    process.arguments = ["-g"]
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    var minutes: Int?
-    if (try? process.run()) != nil {
-      // Drain BEFORE waiting: a child that fills the pipe buffer blocks on write
-      // while we block on its exit. `pmset -g` is far under 64 KB today.
-      let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-      process.waitUntilExit()
-      for line in output.split(separator: "\n") {
-        let parts = line.split(separator: " ", omittingEmptySubsequences: true)
-        if parts.count >= 2, parts[0] == "displaysleep" { minutes = Int(parts[1]) }
-      }
+    if let probe = displaySleepProbe { return await probe.value }
+    let probe = Task { @MainActor in
+      let minutes = await readDisplaySleepMinutes()
+      // The failure is cached too: a pmset that cannot run will not start
+      // working within the next 60 s, and re-spawning per poll would be worse
+      // than nil.
+      cachedDisplaySleep = (minutes, .now)
+      displaySleepProbe = nil
+      return minutes
     }
-    // The failure is cached too: a pmset that cannot run will not start working
-    // within the next 60 s, and re-spawning per poll would be worse than nil.
-    cachedDisplaySleep = (minutes, .now)
-    return minutes
+    displaySleepProbe = probe
+    return await probe.value
+  }
+
+  /// Detached, not merely `nonisolated async`: the hop off the main actor is a
+  /// language-mode property and vanishes under `NonisolatedNonsendingByDefault`.
+  /// Touches no stored state, so it can run anywhere.
+  private nonisolated static func readDisplaySleepMinutes() async -> Int? {
+    await Task.detached(priority: .utility) { () -> Int? in
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+      process.arguments = ["-g"]
+      let pipe = Pipe()
+      process.standardOutput = pipe
+      var minutes: Int?
+      if (try? process.run()) != nil {
+        // Drain BEFORE waiting: a child that fills the pipe buffer blocks on
+        // write while we block on its exit. `pmset -g` is far under 64 KB today.
+        let output =
+          String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        process.waitUntilExit()
+        for line in output.split(separator: "\n") {
+          let parts = line.split(separator: " ", omittingEmptySubsequences: true)
+          if parts.count >= 2, parts[0] == "displaysleep" { minutes = Int(parts[1]) }
+        }
+      }
+      return minutes
+    }.value
   }
 }
 

--- a/Candela/OledCare/OledExposureCapture.swift
+++ b/Candela/OledCare/OledExposureCapture.swift
@@ -1,0 +1,93 @@
+import CandelaKit
+import CoreGraphics
+import Foundation
+
+/// Owns pending capture slots and the validation between asynchronous capture
+/// and exposure bookkeeping. ScreenCaptureKit stays behind the wave factory.
+@MainActor
+final class OledExposureCapture {
+  struct Request: Equatable {
+    let id = UUID()
+    let key: String
+    let target: OledTelemetryTarget
+    let transform: PanelSpaceTransform
+    let epoch: Int
+  }
+
+  /// Re-read after capture, never carried over from the tick that queued it.
+  struct Context {
+    var epoch: Int
+    var displayID: CGDirectDisplayID
+    var target: OledTelemetryTarget
+    var transform: PanelSpaceTransform?
+    var telemetryEnabled: Bool
+    var dimState: OledDimState
+    var isResetting: Bool
+    var isLocked: Bool
+    var panelIsAwake: Bool
+    var isLowBattery: Bool
+
+    func accepts(_ request: Request) -> Bool {
+      epoch == request.epoch && displayID == request.target.panel
+        && target == request.target && transform == request.transform
+        && telemetryEnabled && !isResetting && !isLocked && panelIsAwake && !isLowBattery
+        && target.samplingMayRun(dimState: dimState)
+    }
+  }
+
+  private let prepare: @MainActor () async -> LuminanceSampler.Wave?
+  private var pending: [String: UUID] = [:]
+
+  init(prepare: @escaping @MainActor () async -> LuminanceSampler.Wave?) {
+    self.prepare = prepare
+  }
+
+  func reserve(
+    key: String, target: OledTelemetryTarget, transform: PanelSpaceTransform, epoch: Int
+  ) -> Request? {
+    guard pending[key] == nil else { return nil }
+    let request = Request(key: key, target: target, transform: transform, epoch: epoch)
+    pending[key] = request.id
+    return request
+  }
+
+  func invalidate(key: String) { pending.removeValue(forKey: key) }
+  func invalidateAll() { pending.removeAll() }
+
+  func run(
+    _ requests: [Request], current: @escaping @MainActor (Request) -> Context?,
+    accept: @escaping @MainActor (Request, LuminanceSampler.Sample) -> Void
+  ) async {
+    let requests = requests.filter { pending[$0.key] == $0.id }
+    guard !requests.isEmpty else { return }
+    guard let wave = await prepare() else {
+      for request in requests { finish(nil, request: request, current: current, accept: accept) }
+      return
+    }
+    // Launch every capture before waiting for any of them. The snapshot stays
+    // on MainActor, but one compositor reply must not hold up another panel.
+    // Each completion books independently, even if an earlier task stays out.
+    let completions = requests.compactMap { request -> Task<Void, Never>? in
+      guard pending[request.key] == request.id else { return nil }
+      let capture = wave.start(request.target.surface)
+      return Task { @MainActor [weak self] in
+        let sample = await capture.value
+        self?.finish(sample, request: request, current: current, accept: accept)
+      }
+    }
+    for completion in completions { await completion.value }
+  }
+
+  private func finish(
+    _ sample: LuminanceSampler.Sample?, request: Request,
+    current: @MainActor (Request) -> Context?,
+    accept: @MainActor (Request, LuminanceSampler.Sample) -> Void
+  ) {
+    // A departure, opt-out or reset can replace this key's reservation while
+    // the old screenshot is still out. It owns neither the new slot nor its data.
+    guard pending[request.key] == request.id else { return }
+    pending.removeValue(forKey: request.key)
+    guard let sample, let context = current(request), context.accepts(request) else { return }
+    accept(request, sample)
+  }
+}

--- a/Candela/Onboarding/AnimatedCheckmark.swift
+++ b/Candela/Onboarding/AnimatedCheckmark.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// `DisplayGlyph`; no assets. Reduce Motion shows it complete.
 struct AnimatedCheckmark: View {
   var accent: Color
+  var floatActive = true
 
   @State private var ring: CGFloat = 0
   @State private var check: CGFloat = 0
@@ -30,6 +31,9 @@ struct AnimatedCheckmark: View {
         )
     }
     .shadow(color: accent.opacity(0.45), radius: 12)
+    // The float replaces its content when motion stops. Keep that branch
+    // below this view's drawing state and its once-per-appearance draw-in.
+    .onboardingFloat(active: floatActive)
     .onAppear {
       guard !reduceMotion else {
         ring = 1

--- a/Candela/Onboarding/OnboardingPagesCore.swift
+++ b/Candela/Onboarding/OnboardingPagesCore.swift
@@ -187,7 +187,6 @@ struct OnboardingFinishPage: View {
       VStack(spacing: 14) {
         AnimatedCheckmark(accent: accent)
           .frame(width: 68, height: 68)
-          .onboardingFloat(active: true)
         OnboardingHeading(title: "You're all set")
       }
       Spacer(minLength: 18)

--- a/Candela/Onboarding/OnboardingStyle.swift
+++ b/Candela/Onboarding/OnboardingStyle.swift
@@ -147,32 +147,39 @@ struct OnboardingSkipLink: View {
 }
 
 /// A slow idle bob for hero objects, so a resting page keeps a pulse.
-/// Reduce Motion stills it.
+/// Reduce Motion stills it, and so does `active` going false.
+///
+/// The still state is a separate branch, not a stopped animation. A
+/// `repeatForever` animation never completes, so nothing detaches it while
+/// the animated offset stays in the tree. [MEASURED 2026-09-09], stop path
+/// confirmed running in the log: writing `up` back under
+/// `Transaction.disablesAnimations` left the covered window at about 28% CPU;
+/// `.animation(_:value:)` on the value, about 18%. Dropping the branch tears
+/// the offset and its animation down with it, and the covered window then
+/// reads 0.0 to 0.1%, the same as a pane with no animation. Never collapse
+/// the two branches into one with a conditional modifier.
 struct OnboardingFloatModifier: ViewModifier {
   var active: Bool
 
   @State private var up = false
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-  func body(content: Content) -> some View {
-    content
-      .offset(y: up ? -4 : 3)
-      .onAppear { updateFloat() }
-      .onChange(of: active) { updateFloat() }
-      // Reduce Motion turned on while the page is open stops the float now,
-      // not at the next rebuild.
-      .onChange(of: reduceMotion) { updateFloat() }
-  }
+  private var floats: Bool { active && !reduceMotion }
 
-  private func updateFloat() {
-    guard active, !reduceMotion else {
-      var stop = Transaction()
-      stop.disablesAnimations = true
-      withTransaction(stop) { up = false }
-      return
-    }
-    withAnimation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true)) {
-      up = true
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if floats {
+      content
+        .offset(y: up ? -4 : 3)
+        .animation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true), value: up)
+        // Reset on removal so the next insertion's `up = true` is a real
+        // change and re-arms the animation.
+        .onAppear { up = true }
+        .onDisappear { up = false }
+    } else {
+      // Matches the moving branch's first frame (`up` false), so nothing
+      // jumps on the edge.
+      content.offset(y: 3)
     }
   }
 }

--- a/Candela/Settings/AboutPane.swift
+++ b/Candela/Settings/AboutPane.swift
@@ -16,6 +16,7 @@ struct AboutPane: View {
   @Environment(SettingsActions.self) private var actions
   @Environment(UpdaterModel.self) private var updater
   @Environment(\.settingsAccent) private var lighting
+  @Environment(\.settingsWindowIsVisible) private var windowIsVisible
 
   var body: some View {
     @Bindable var updater = updater
@@ -101,8 +102,8 @@ struct AboutPane: View {
 
   // MARK: - Hero
 
-  /// The window's only float; `onboardingFloat` stills it under Reduce
-  /// Motion.
+  /// The window's only float; stilled while the window is covered so a
+  /// hidden About pane costs no CPU.
   private var hero: some View {
     VStack(spacing: 10) {
       ZStack {
@@ -122,7 +123,7 @@ struct AboutPane: View {
           .shadow(color: .black.opacity(0.35), radius: 10, y: 4)
       }
       .frame(height: 176)
-      .onboardingFloat(active: true)
+      .onboardingFloat(active: windowIsVisible)
       .accessibilityHidden(true)
 
       Text(verbatim: AppInfo.productName)

--- a/Candela/Settings/GeneralPane.swift
+++ b/Candela/Settings/GeneralPane.swift
@@ -39,14 +39,19 @@ struct GeneralPane: View {
     // this body after a write. Without it the switches below keep drawing the
     // value they were built with after a reset or an outside write.
     let _ = model.prefsRevision
+    // One live read per render pass, not a mirror: handed to the badge and the
+    // toggle so they cannot disagree and the service is asked once. Safe to hold
+    // for the pass because `LoginItem.setEnabled` calls `refresh()` on every
+    // path, failure included, so each write re-evaluates this body.
+    let openAtLogin = loginItem.isEnabled
     SettingsPageScaffold {
       SettingsPageHeader(
         title: "General",
         subtitle:
           "How \(AppInfo.productName) opens, how far it dims, and whether your other displays follow the built-in one."
       )
-      statusStrip
-      applicationSection
+      statusStrip(openAtLogin: openAtLogin)
+      applicationSection(openAtLogin: openAtLogin)
       brightnessSection
       syncSection
     }
@@ -81,7 +86,7 @@ struct GeneralPane: View {
   /// The page's one standing object: the app itself, with its login state read
   /// off the same live `SMAppService` status the row below writes. No
   /// float; the About icon is the window's only one.
-  private var statusStrip: some View {
+  private func statusStrip(openAtLogin: Bool) -> some View {
     SettingsCard {
       HStack(spacing: 16) {
         Image(nsImage: NSApp.applicationIconImage)
@@ -105,7 +110,7 @@ struct GeneralPane: View {
         Spacer(minLength: 12)
 
         VStack(alignment: .trailing, spacing: 6) {
-          SettingsBadge(text: loginItem.isEnabled ? "Opens at Login" : "Manual start")
+          SettingsBadge(text: openAtLogin ? "Opens at Login" : "Manual start")
           Text(verbatim: connectedLine)
             .font(.caption2)
             .foregroundStyle(SettingsTheme.faintColor)
@@ -127,13 +132,14 @@ struct GeneralPane: View {
 
   // MARK: - Application
 
-  private var applicationSection: some View {
+  private func applicationSection(openAtLogin: Bool) -> some View {
     SettingsCardSection(title: "Application") {
       SettingRow {
         // The system's own wording in System Settings, and Setup uses the
         // identical string (familiarity beats novelty).
         Toggle("Open at Login", isOn: Binding(
-          get: { loginItem.isEnabled },
+          // The pass's own live read; `setEnabled` re-evaluates the body.
+          get: { openAtLogin },
           set: { loginItem.setEnabled($0) } // the live-status rule: the readback happens inside
         ))
         .themedSwitch()

--- a/Candela/Settings/OledCareDisplayPage.swift
+++ b/Candela/Settings/OledCareDisplayPage.swift
@@ -152,7 +152,9 @@ struct OledCareDisplayPage: View {
       }
     }
     // Two tasks: keyed together, every dim transition would re-spawn pmset.
-    .task { displaySleepMinutes = OledCareSignalSources.displaySleepMinutes() }
+    // The `pmset` spawn behind the await waits off the main actor, so opening
+    // this page does not stall the window; nil draws nothing.
+    .task { displaySleepMinutes = await OledCareSignalSources.displaySleepMinutes() }
     .task(id: model.oledCare.dimStates[persistenceKey]) {
       displaySleepAssertionHeld = OledCareSignalSources.displaySleepAssertionHeld()
     }

--- a/Candela/Settings/OledCarePane.swift
+++ b/Candela/Settings/OledCarePane.swift
@@ -33,6 +33,7 @@ extension EnvironmentValues {
 @MainActor
 struct OledCarePane: View {
   @Environment(AppModel.self) private var model
+  @Environment(\.settingsWindowIsVisible) private var windowIsVisible
 
   /// The last chrome value asked for and not granted, per control.
   /// `ChromeAutoHideController` records what the SYSTEM reports, so a write that
@@ -68,7 +69,13 @@ struct OledCarePane: View {
     // `com.apple.dock autohide` change is only visible on a re-read. Cancelled
     // with the pane, or it would be a permanent timer for a hidden window. The
     // same poll covers the menu bar, which needs no observer of its own.
-    .task {
+    //
+    // Keyed on visibility so a covered or closed window polls nothing. Becoming
+    // visible restarts the task, and the loop refreshes before its first sleep,
+    // so the switches catch up on the way back in rather than up to two seconds
+    // later (the first frame can still show the pre-cover value).
+    .task(id: windowIsVisible) {
+      guard windowIsVisible else { return }
       while !Task.isCancelled {
         // Resolved inside the loop, never captured before it: the coordinator
         // builds `chrome` during launch wiring, so a `guard else { return }`

--- a/Candela/Settings/OledCareSummary.swift
+++ b/Candela/Settings/OledCareSummary.swift
@@ -548,10 +548,15 @@ struct OledTelemetryTicker: View {
 /// The breathing measurement indicator. It may only breathe while readings
 /// genuinely land (`lastSample` within `OledCareCadence.livenessWindowSeconds`),
 /// so the motion IS the telemetry: a dead grant stills it within a few minutes.
+///
+/// A covered window stills it too; nobody is reading it then. `isActive`
+/// re-arms the effect on uncover, and the colour, the words beside it and the
+/// ticker are unchanged while it is stopped.
 struct OledMeasuringDot: View {
   let live: Bool
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.settingsWindowIsVisible) private var windowIsVisible
 
   var body: some View {
     // A symbol effect, not a custom repeatForever animation: a repeating
@@ -562,7 +567,8 @@ struct OledMeasuringDot: View {
       // Green stays: it is the ticker's "grant OK" in a colour, and the words
       // beside it carry the same fact anyway.
       .foregroundStyle(live ? Color.green : SettingsTheme.faintColor)
-      .symbolEffect(.pulse, options: .repeating, isActive: live && !reduceMotion)
+      .symbolEffect(
+        .pulse, options: .repeating, isActive: live && !reduceMotion && windowIsVisible)
       .accessibilityHidden(true)
   }
 }

--- a/Candela/Settings/SettingsRootView.swift
+++ b/Candela/Settings/SettingsRootView.swift
@@ -3,6 +3,22 @@ import CandelaKit
 import Observation
 import SwiftUI
 
+/// Whether the settings window is on screen and not fully covered. Published by
+/// the shell so a pane can stop work whose only output is on that window.
+///
+/// Defaults to `true`: views outside this window (onboarding, the Heat Map
+/// window, render tests) have no shell to answer for them and must not go still.
+private struct SettingsWindowIsVisibleKey: EnvironmentKey {
+  static let defaultValue = true
+}
+
+extension EnvironmentValues {
+  var settingsWindowIsVisible: Bool {
+    get { self[SettingsWindowIsVisibleKey.self] }
+    set { self[SettingsWindowIsVisibleKey.self] = newValue }
+  }
+}
+
 /// Sidebar navigation over a pane registry.
 ///
 /// The shell is hand-built: a canvas, a fixed-width sidebar, a hairline,
@@ -126,6 +142,8 @@ struct SettingsRootView: View {
     // Published once for the whole shell, so the wordmark and every themed
     // component read one destination's lighting.
     .environment(\.settingsAccent, currentAccent)
+    // The same signal the poll consumer flag rides, handed to the panes.
+    .environment(\.settingsWindowIsVisible, isOnScreen)
     // Dark-only: every colour comes from the theme layer and none of
     // them has a light-appearance answer.
     .preferredColorScheme(.dark)

--- a/CandelaAppTests/DisplayModeEnumerationTests.swift
+++ b/CandelaAppTests/DisplayModeEnumerationTests.swift
@@ -1,0 +1,126 @@
+import CandelaKit
+import CoreGraphics
+import Foundation
+import Testing
+
+/// What one catalog refresh and one arrival cost in enumerations, and that the
+/// values they produce are unchanged by the counting.
+///
+/// Enumeration is the expensive call on real hardware: `CGDisplayCopyAllDisplayModes`
+/// plus the CGS revelation pass, per display. Measured 2026-09-09, one Dell mode
+/// apply and its revert produced 16 catalog refreshes and 64 full enumerations.
+@MainActor
+@Suite("Display mode enumeration cost")
+struct DisplayModeEnumerationTests {
+  private static let panelID: CGDirectDisplayID = 12
+  private static let native = DisplayMode(
+    ioModeID: 1, logicalWidth: 3440, logicalHeight: 1440,
+    pixelWidth: 3440, pixelHeight: 1440, refreshHz: 175, isNative: true
+  )
+  private static let smaller = DisplayMode(
+    ioModeID: 2, logicalWidth: 2560, logicalHeight: 1080,
+    pixelWidth: 2560, pixelHeight: 1080, refreshHz: 175, isNative: false
+  )
+
+  /// A coordinator with no `SynthesisCoordinator` and its own defaults suite, so
+  /// the stored-mode half of a reapply can be counted alone. Not the shape the
+  /// app runs: `AppModel` attaches synthesis to every coordinator, and that
+  /// shape is counted over `SynthesisFixture` below.
+  private struct Rig {
+    let world: FakeDisplayWorld
+    let configurator: FakeSynthesisDisplayConfigurator
+    let modes: DisplayModeCoordinator
+    let persistence: ModePersistence
+    let identity: DisplayConfigIdentity
+    let suiteName: String
+
+    func forgetPrefs() {
+      UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+  }
+
+  private static func rig() -> Rig {
+    let world = FakeDisplayWorld()
+    let identity = DisplayConfigIdentity(vendor: 0x3669, model: 9, serial: 9, isBuiltIn: false)
+    world.attach(
+      ConfiguredDisplay(id: panelID, identity: identity, name: "MAG341C", isBuiltIn: false),
+      modes: [native, smaller], current: native,
+      nativePixels: (width: 3440, height: 1440)
+    )
+    let configurator = FakeSynthesisDisplayConfigurator(world)
+    let suiteName = "app-tests-enumeration-\(UUID().uuidString)"
+    let persistence = ModePersistence(defaults: UserDefaults(suiteName: suiteName)!)
+    let modes = DisplayModeCoordinator(
+      gate: DisplayReconfigurationGate(),
+      configurator: configurator,
+      persistence: persistence
+    )
+    return Rig(
+      world: world, configurator: configurator, modes: modes,
+      persistence: persistence, identity: identity, suiteName: suiteName
+    )
+  }
+
+  @Test("One catalog refresh enumerates the display once")
+  func refreshEnumeratesOnce() throws {
+    let rig = Self.rig()
+    defer { rig.forgetPrefs() }
+
+    rig.world.forgetEnumerations()
+    rig.modes.refreshCatalog(for: Self.panelID)
+
+    #expect(rig.world.enumerations == [.snapshot])
+
+    // The saving is only worth anything if the catalog is the same catalog.
+    let catalog = try #require(rig.modes.catalogs[Self.panelID])
+    #expect(catalog.current == Self.native)
+    #expect(catalog.nativePixels?.width == 3440)
+    #expect(catalog.nativePixels?.height == 1440)
+    #expect(catalog.all == DisplayModeCatalog.full([Self.native, Self.smaller]))
+    #expect(catalog.withheldForWireTiming == 0)
+  }
+
+  /// The stored-mode half alone, with no synthesis attached: nothing stored
+  /// means nothing to ask the display about, so it is asked nothing.
+  @Test("The stored-mode reapply enumerates not at all when nothing is stored")
+  func storedModeReapplyWithNothingStoredDoesNotEnumerate() async {
+    let rig = Self.rig()
+    defer { rig.forgetPrefs() }
+
+    rig.world.forgetEnumerations()
+    await rig.modes.reapplyStoredModes()
+
+    #expect(rig.world.enumerations.isEmpty)
+    #expect(rig.world.applies.isEmpty)
+  }
+
+  /// The stored descriptor is the mode the display already runs, so no apply and
+  /// no refresh follow: what is left is the one enumeration the decision needs.
+  @Test("The stored-mode reapply enumerates once when a mode is stored")
+  func storedModeReapplyEnumeratesOnce() async {
+    let rig = Self.rig()
+    defer { rig.forgetPrefs() }
+    rig.persistence.setEnabled(true, for: rig.identity)
+    rig.persistence.store(Self.native.descriptor, for: rig.identity)
+
+    rig.world.forgetEnumerations()
+    await rig.modes.reapplyStoredModes()
+
+    #expect(rig.world.enumerations == [.snapshot])
+    #expect(rig.world.applies.isEmpty)
+  }
+
+  /// The shape the app runs: synthesis attached, so an arrival pays the
+  /// synthesis half's enumeration even with nothing stored. Still one pass.
+  @Test("An arrival with synthesis attached and nothing stored enumerates once")
+  func arrivalWithSynthesisAttachedEnumeratesOnce() async {
+    let fixture = SynthesisFixture()
+    defer { fixture.forgetPrefs() }
+
+    fixture.world.forgetEnumerations()
+    await fixture.modes.reapplyStoredModes()
+
+    #expect(fixture.world.enumerations == [.snapshot])
+    #expect(fixture.world.applies.isEmpty)
+  }
+}

--- a/CandelaAppTests/Fakes/SynthesisFakes.swift
+++ b/CandelaAppTests/Fakes/SynthesisFakes.swift
@@ -36,6 +36,40 @@ final class FakeDisplayWorld: @unchecked Sendable {
   }
   private(set) var mirrorChanges: [[MirrorChange]] = []
   private var _applies: [(mode: DisplayMode, displayID: CGDirectDisplayID)] = []
+  private var _enumerations: [EnumerationCall] = []
+
+  /// Each of these is one full CoreGraphics enumeration on the real configurator.
+  /// A fake answers from a dictionary, so this count is the only place a
+  /// hardware-free test sees that cost.
+  enum EnumerationCall: Equatable, Sendable {
+    case modes
+    case currentMode
+    case nativePixels
+    case withheldByWireTimingGuard
+    case snapshot
+  }
+
+  /// Every enumerating call the configurator was asked for, in order.
+  var enumerations: [EnumerationCall] { lock.withLock { _enumerations } }
+
+  private var _withheldByWireTimingGuard = 0
+
+  /// Zero by default: this world runs no revelation pass. One stored value so
+  /// the count and the snapshot cannot disagree; settable so a test can stage a
+  /// withholding guard; lock-backed because the configurator reads it from the
+  /// engine's executor.
+  var withheldByWireTimingGuard: Int {
+    get { lock.withLock { _withheldByWireTimingGuard } }
+    set { lock.withLock { _withheldByWireTimingGuard = newValue } }
+  }
+
+  func recordEnumeration(_ call: EnumerationCall) {
+    lock.withLock { _enumerations.append(call) }
+  }
+
+  func forgetEnumerations() {
+    lock.withLock { _enumerations.removeAll() }
+  }
 
   /// Every mode apply the configurator was asked for, in order. The engage
   /// tail's re-time is one of these, and it is the only evidence of it a fake
@@ -183,13 +217,32 @@ final class FakeSynthesisDisplayConfigurator: DisplayConfiguring, @unchecked Sen
   var applies: [(mode: DisplayMode, displayID: CGDirectDisplayID)] { world.applies }
 
   func displays() -> [ConfiguredDisplay] { world.displays() }
-  func modes(for displayID: CGDirectDisplayID) -> [DisplayMode] { world.modes(for: displayID) }
+
+  func modes(for displayID: CGDirectDisplayID) -> [DisplayMode] {
+    world.recordEnumeration(.modes)
+    return world.modes(for: displayID)
+  }
+
   func currentMode(for displayID: CGDirectDisplayID) -> DisplayMode? {
-    world.currentMode(for: displayID)
+    world.recordEnumeration(.currentMode)
+    return world.currentMode(for: displayID)
   }
 
   func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)? {
-    world.nativePixels(for: displayID)
+    world.recordEnumeration(.nativePixels)
+    return world.nativePixels(for: displayID)
+  }
+
+  /// Read from the world directly, not through the four methods above, so the
+  /// recorded count is one call, as on the real configurator.
+  func modeSnapshot(for displayID: CGDirectDisplayID) -> DisplayModeSnapshot {
+    world.recordEnumeration(.snapshot)
+    return DisplayModeSnapshot(
+      modes: world.modes(for: displayID),
+      current: world.currentMode(for: displayID),
+      nativePixels: world.nativePixels(for: displayID),
+      withheldByWireTimingGuard: world.withheldByWireTimingGuard
+    )
   }
 
   /// Recorded, and the world is deliberately NOT moved. The engage tail's
@@ -221,7 +274,12 @@ final class FakeSynthesisDisplayConfigurator: DisplayConfiguring, @unchecked Sen
 
   var revealsHiddenModes: Bool { false }
   var guardsWireTiming: Bool { true }
-  func modesWithheldByWireTimingGuard(for _: CGDirectDisplayID) -> Int { 0 }
+
+  func modesWithheldByWireTimingGuard(for _: CGDirectDisplayID) -> Int {
+    world.recordEnumeration(.withheldByWireTimingGuard)
+    return world.withheldByWireTimingGuard
+  }
+
   var canRotate: Bool { false }
   func rotation(of _: CGDirectDisplayID) -> DisplayRotation? { .standard }
   func applyRotation(_: DisplayRotation, to _: CGDirectDisplayID) throws {}

--- a/CandelaAppTests/OledCareTickCostTests.swift
+++ b/CandelaAppTests/OledCareTickCostTests.swift
@@ -93,9 +93,8 @@ struct OledCareTickCostTests {
     #expect(captures.isEmpty)
   }
 
-  /// Pinned exactly, not as a floor: the slow tick carries the sampling
-  /// throttle, which books a fixed 60 s however late the slot ran, so slack
-  /// there under-books exposure. 10% of cadence keeps that under 0.35%.
+  /// The fast input-response gate receives no added slack; the slower cadences
+  /// explicitly allow coalescing. These values do not bound sampling drift.
   @Test("Tolerance is zero on the fast cadence and a tenth of the slower ones")
   func toleranceFollowsTheCadence() {
     #expect(OledCareCoordinator.sleepTolerance(for: OledCareCadence.fast) == .zero)
@@ -105,6 +104,38 @@ struct OledCareTickCostTests {
     #expect(
       OledCareCoordinator.sleepTolerance(for: OledCareCadence.slow) == .milliseconds(200))
     #expect(OledCareCoordinator.sleepTolerance(for: OledCareCadence.idle) == .seconds(3))
+  }
+
+  @Test("Repeated slow-tick deferrals are accumulated before the sampling slot")
+  func repeatedDeferralsDoNotPretendToBeOneSixtySecondDeadline() {
+    let counter = ReadCount()
+    let coordinator = OledCareCoordinator(windowList: { _ in [] }, lowBattery: {
+      counter.reads += 1
+      return false
+    })
+    let target = OledTelemetryTarget(panel: Self.absentDisplay, topology: MirrorTopology([]))
+    let start = SuspendingClock.now
+    var now = start
+    var state = enrolled()
+    state.lastSampleAt = start
+    var captures: [OledCareCoordinator.CaptureRequest] = []
+    let deferredInterval = OledCareCadence.slow
+      + OledCareCoordinator.sleepTolerance(for: OledCareCadence.slow)
+
+    // Drive the real throttle with an allowed sequence of fully deferred ticks.
+    // No wall-clock wait or assumption about what the kernel normally chooses.
+    for _ in 0..<27 {
+      now += deferredInterval
+      coordinator.updateTelemetry(for: "panel", state: &state, dimState: .active,
+        on: target, panelIsAwake: true, at: now, into: &captures)
+    }
+    #expect(counter.reads == 0)
+    #expect(state.lastSampleAt == start)
+    now += deferredInterval
+    coordinator.updateTelemetry(for: "panel", state: &state, dimState: .active,
+      on: target, panelIsAwake: true, at: now, into: &captures)
+    #expect(counter.reads == 1)
+    #expect(state.lastSampleAt == start + .milliseconds(61_600))
   }
 
   /// A cadence the enum does not name is a cadence nobody has reasoned about,

--- a/CandelaAppTests/OledCareTickCostTests.swift
+++ b/CandelaAppTests/OledCareTickCostTests.swift
@@ -1,0 +1,142 @@
+import CandelaKit
+import CoreGraphics
+import Foundation
+import Testing
+
+/// What one care tick is allowed to cost. The driver runs at up to 10 Hz while
+/// a dim is up, with the telemetry gate riding it at its own 60 s cadence.
+/// Everything pinned here is about WHERE a reading happens, never what it answers.
+@Suite("Care tick cost") @MainActor
+struct OledCareTickCostTests {
+  /// Not a real display: the transform resolves to nil, which ends the pass
+  /// before any capture is issued.
+  private static let absentDisplay: CGDirectDisplayID = 0xFFFF_FFFE
+
+  @MainActor private final class ReadCount {
+    var reads = 0
+  }
+
+  private func enrolled() -> OledCareCoordinator.PerDisplay {
+    OledCareCoordinator.PerDisplay(
+      engine: IdleDimmingEngine(config: OledDimConfig(
+        idleDimSeconds: 600, idleDimBrightness: 0.5, lockDim: false,
+        blackoutEnabled: false, blackoutSeconds: 900, unfocusedDimEnabled: false,
+        unfocusedDimSeconds: 300, unfocusedDimBrightness: 0.5)),
+      unfocusedDimEnabled: false, hoursTracking: true, telemetryEnabled: true,
+      windowObservationEnabled: false)
+  }
+
+  /// The IOKit power-source copy is read at the 60 s decision point, never on
+  /// the tick, which holds only while the throttle runs BEFORE the qualification.
+  @Test("The battery read happens once a sampling slot, not once a tick")
+  func batteryIsReadOnlyAtTheSamplingSlot() {
+    let counter = ReadCount()
+    let coordinator = OledCareCoordinator(
+      windowList: { _ in [] },
+      lowBattery: {
+        counter.reads += 1
+        return false
+      })
+    let target = OledTelemetryTarget(panel: Self.absentDisplay, topology: MirrorTopology([]))
+    let now = SuspendingClock.now
+    var state = enrolled()
+    var captures: [OledCareCoordinator.CaptureRequest] = []
+
+    state.lastSampleAt = now - .seconds(5)
+    coordinator.updateTelemetry(
+      for: "panel", state: &state, dimState: .active, on: target, panelIsAwake: true, at: now,
+      into: &captures)
+    #expect(counter.reads == 0)
+    // The throttle turned the tick away, so the slot it belongs to is untouched.
+    #expect(state.lastSampleAt == now - .seconds(5))
+
+    state.lastSampleAt = now - .seconds(61)
+    coordinator.updateTelemetry(
+      for: "panel", state: &state, dimState: .active, on: target, panelIsAwake: true, at: now,
+      into: &captures)
+    #expect(counter.reads == 1)
+    #expect(state.lastSampleAt == now)
+    // The transform gate ends the pass before a capture is queued.
+    #expect(captures.isEmpty)
+  }
+
+  /// A slot is taken only when both gates pass, so an unqualified display keeps
+  /// waiting from its last accepted sample rather than resetting its clock.
+  @Test("An unqualified display takes no sampling slot")
+  func unqualifiedDisplayKeepsItsSlot() {
+    let counter = ReadCount()
+    let coordinator = OledCareCoordinator(
+      windowList: { _ in [] },
+      lowBattery: {
+        counter.reads += 1
+        return false
+      })
+    let target = OledTelemetryTarget(panel: Self.absentDisplay, topology: MirrorTopology([]))
+    let now = SuspendingClock.now
+    var state = enrolled()
+    var captures: [OledCareCoordinator.CaptureRequest] = []
+    state.lastSampleAt = now - .seconds(61)
+
+    // Asleep: the qualification refuses it after the throttle has let it by.
+    coordinator.updateTelemetry(
+      for: "panel", state: &state, dimState: .active, on: target, panelIsAwake: false, at: now,
+      into: &captures)
+    #expect(state.lastSampleAt == now - .seconds(61))
+    #expect(counter.reads == 0)
+
+    // Dimmed: refused before the battery is ever consulted.
+    coordinator.updateTelemetry(
+      for: "panel", state: &state, dimState: .idleDim, on: target, panelIsAwake: true, at: now,
+      into: &captures)
+    #expect(state.lastSampleAt == now - .seconds(61))
+    #expect(counter.reads == 0)
+    #expect(captures.isEmpty)
+  }
+
+  /// Pinned exactly, not as a floor: the slow tick carries the sampling
+  /// throttle, which books a fixed 60 s however late the slot ran, so slack
+  /// there under-books exposure. 10% of cadence keeps that under 0.35%.
+  @Test("Tolerance is zero on the fast cadence and a tenth of the slower ones")
+  func toleranceFollowsTheCadence() {
+    #expect(OledCareCoordinator.sleepTolerance(for: OledCareCadence.fast) == .zero)
+    #expect(
+      OledCareCoordinator.sleepTolerance(for: OledCareCadence.windowFollow)
+        == .milliseconds(100))
+    #expect(
+      OledCareCoordinator.sleepTolerance(for: OledCareCadence.slow) == .milliseconds(200))
+    #expect(OledCareCoordinator.sleepTolerance(for: OledCareCadence.idle) == .seconds(3))
+  }
+
+  /// A cadence the enum does not name is a cadence nobody has reasoned about,
+  /// so it gets the strict answer rather than the nearest neighbour's.
+  @Test("An unrecognized interval gets no tolerance")
+  func unknownIntervalHasNoTolerance() {
+    #expect(OledCareCoordinator.sleepTolerance(for: .milliseconds(250)) == .zero)
+    #expect(OledCareCoordinator.sleepTolerance(for: .seconds(7)) == .zero)
+  }
+
+  /// Neither half enabled is the cheapest tick there is, and it stays that way.
+  @Test("A display with telemetry off reads nothing")
+  func telemetryOffReadsNothing() {
+    let counter = ReadCount()
+    let coordinator = OledCareCoordinator(
+      windowList: { _ in [] },
+      lowBattery: {
+        counter.reads += 1
+        return false
+      })
+    let target = OledTelemetryTarget(panel: Self.absentDisplay, topology: MirrorTopology([]))
+    let now = SuspendingClock.now
+    var state = enrolled()
+    var captures: [OledCareCoordinator.CaptureRequest] = []
+    state.telemetryEnabled = false
+    state.lastSampleAt = now - .seconds(61)
+
+    coordinator.updateTelemetry(
+      for: "panel", state: &state, dimState: .active, on: target, panelIsAwake: true, at: now,
+      into: &captures)
+    #expect(counter.reads == 0)
+    #expect(state.lastSampleAt == now - .seconds(61))
+    #expect(captures.isEmpty)
+  }
+}

--- a/CandelaAppTests/OledExposureCaptureTests.swift
+++ b/CandelaAppTests/OledExposureCaptureTests.swift
@@ -1,0 +1,358 @@
+import CandelaKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@Suite("Exposure capture lifecycle") @MainActor
+struct OledExposureCaptureTests {
+  private static let sample = LuminanceSampler.Sample(grid: [0.5], cols: 1, rows: 1)
+
+  @Test func twoDuePanelsShareOneEnumerationAndBookTheirOwnSamples() async throws {
+    let rig = CaptureRig()
+    let first = try #require(rig.reserve("first", panel: 11))
+    let second = try #require(rig.reserve("second", panel: 22))
+    rig.resolve(0, Self.sample)
+    rig.resolve(1, Self.sample)
+
+    await rig.run([first, second])
+
+    #expect(rig.enumerations == 1)
+    #expect(rig.startedDisplays == [11, 22])
+    #expect(rig.maps["first"]?.map.sampleCount == 1)
+    #expect(rig.maps["second"]?.map.sampleCount == 1)
+    #expect(rig.maps["first"]?.map.cells.allSatisfy { $0 == 30 } == true)
+    #expect(rig.pipeline.reserve(key: "first", target: first.target,
+      transform: first.transform, epoch: 0) != nil)
+  }
+
+  @Test func aDelayedPanelDoesNotHoldUpTheOtherPanelsCapture() async throws {
+    let rig = CaptureRig()
+    let first = try #require(rig.reserve("first", panel: 11))
+    let second = try #require(rig.reserve("second", panel: 22))
+    let work = Task { await rig.run([first, second]) }
+    await rig.waitForCaptureStart()
+
+    // start() is synchronous. All captures must be launched before the first
+    // capture task gets the actor, so this assertion needs no scheduling delay.
+    #expect(rig.startedDisplays == [11, 22])
+    if rig.startedDisplays.count == 2 {
+      rig.resolve(1, Self.sample)
+      await rig.waitForAcceptance()
+      #expect(rig.maps["second"]?.map.sampleCount == 1)
+      #expect(rig.maps["first"] == nil)
+    }
+    // Resolve both even on the failing sequential implementation so the test
+    // reports the failed assertion instead of leaving a suspended task behind.
+    rig.resolve(0, Self.sample)
+    rig.resolve(1, Self.sample)
+    await work.value
+  }
+
+  @Test func failedCaptureSkipsItsSampleAndDoesNotPreventTheNextPanel() async throws {
+    let rig = CaptureRig()
+    let first = try #require(rig.reserve("first", panel: 11))
+    let second = try #require(rig.reserve("second", panel: 22))
+    rig.resolve(0, nil)
+    rig.resolve(1, Self.sample)
+    await rig.run([first, second])
+
+    #expect(rig.maps["first"] == nil)
+    #expect(rig.maps["second"]?.map.sampleCount == 1)
+    #expect(rig.pipeline.reserve(key: "first", target: first.target,
+      transform: first.transform, epoch: 0) != nil)
+  }
+
+  @Test func failedEnumerationReleasesEveryReservationWithoutBookingBlackSamples() async throws {
+    let rig = CaptureRig()
+    let first = try #require(rig.reserve("first", panel: 11))
+    let second = try #require(rig.reserve("second", panel: 22))
+    rig.enumerationSucceeds = false
+    await rig.run([first, second])
+
+    #expect(rig.enumerations == 1)
+    #expect(rig.startedDisplays.isEmpty)
+    #expect(rig.maps.isEmpty)
+    #expect(rig.pipeline.reserve(key: "first", target: first.target,
+      transform: first.transform, epoch: 0) != nil)
+    #expect(rig.pipeline.reserve(key: "second", target: second.target,
+      transform: second.transform, epoch: 0) != nil)
+  }
+
+  @Test func anEmptyWaveDoesNotEnumerate() async {
+    let rig = CaptureRig()
+    await rig.run([])
+    #expect(rig.enumerations == 0)
+  }
+
+  enum Invalidation: CaseIterable {
+    case historyDeleted, telemetryOff, displayIDChanged, asleep, locked, resetting
+    case dimmed, userMirrored, rotated, resized, departed, lowBattery, missingGeometry
+  }
+
+  @Test(arguments: Invalidation.allCases)
+  func aChangeDuringCaptureRejectsTheSample(_ change: Invalidation) async throws {
+    let rig = CaptureRig()
+    let request = try #require(rig.reserve("panel", panel: 11))
+    let work = Task { await rig.run([request]) }
+    await rig.waitForCaptureStart()
+    switch change {
+    case .historyDeleted: rig.contexts["panel"]?.epoch += 1
+    case .telemetryOff: rig.contexts["panel"]?.telemetryEnabled = false
+    case .displayIDChanged: rig.contexts["panel"]?.displayID = 33
+    case .asleep: rig.contexts["panel"]?.panelIsAwake = false
+    case .locked: rig.contexts["panel"]?.isLocked = true
+    case .resetting: rig.contexts["panel"]?.isResetting = true
+    case .lowBattery: rig.contexts["panel"]?.isLowBattery = true
+    case .missingGeometry: rig.contexts["panel"]?.transform = nil
+    case .dimmed: rig.contexts["panel"]?.dimState = .idleDim
+    case .userMirrored: rig.contexts["panel"]?.dimState = .suspended
+    case .rotated:
+      rig.contexts["panel"]?.transform = PanelSpaceTransform(
+        displaySize: CGSize(width: 120, height: 240), rotation: .ninety)
+    case .resized:
+      rig.contexts["panel"]?.transform = PanelSpaceTransform(
+        displaySize: CGSize(width: 480, height: 240), rotation: .standard)
+    case .departed: rig.contexts["panel"] = nil
+    }
+    rig.resolve(0, Self.sample)
+    await work.value
+
+    #expect(rig.maps.isEmpty)
+    #expect(rig.pipeline.reserve(key: request.key, target: request.target,
+      transform: request.transform, epoch: 1) != nil)
+  }
+
+  @Test func aSynthesizedSurfaceIsCapturedButItsPanelReceivesTheSample() async throws {
+    let rig = CaptureRig()
+    let target = Self.synthesisTarget()
+    let request = try #require(rig.reserve("physical", target: target))
+    rig.contexts["physical"]?.dimState = .suspended
+    rig.resolve(0, Self.sample)
+    await rig.run([request])
+    #expect(rig.startedDisplays == [79])
+    #expect(rig.maps["physical"]?.map.sampleCount == 1)
+    #expect(rig.maps.count == 1)
+  }
+
+  @Test func endingSynthesisDuringCaptureRejectsTheOldSurface() async throws {
+    let rig = CaptureRig()
+    let request = try #require(rig.reserve("physical", target: Self.synthesisTarget()))
+    let work = Task { await rig.run([request]) }
+    await rig.waitForCaptureStart()
+    rig.contexts["physical"]?.target = OledTelemetryTarget(panel: 11, topology: MirrorTopology([]))
+    rig.resolve(0, Self.sample)
+    await work.value
+    #expect(rig.maps.isEmpty)
+  }
+
+  @Test func aPendingPanelCannotReserveASecondCapture() throws {
+    let rig = CaptureRig()
+    let request = try #require(rig.reserve("panel", panel: 11))
+    #expect(rig.pipeline.reserve(key: request.key, target: request.target,
+      transform: request.transform, epoch: 0) == nil)
+  }
+
+  @Test func anOldEnrollmentCannotBookOrReleaseItsReplacementsCapture() async throws {
+    let rig = CaptureRig()
+    let old = try #require(rig.reserve("panel", panel: 11))
+    let oldWork = Task { await rig.run([old]) }
+    await rig.waitForCaptureStart()
+    rig.pipeline.invalidate(key: "panel")
+    let replacement = try #require(rig.reserve("panel", panel: 11))
+    let newWork = Task { await rig.run([replacement]) }
+    await rig.waitForCaptureStart()
+
+    rig.resolve(0, Self.sample)
+    await oldWork.value
+    #expect(rig.maps.isEmpty)
+    #expect(rig.pipeline.reserve(key: replacement.key, target: replacement.target,
+      transform: replacement.transform, epoch: 0) == nil)
+
+    rig.resolve(1, Self.sample)
+    await newWork.value
+    #expect(rig.maps["panel"]?.map.sampleCount == 1)
+  }
+
+  @Test func invalidationBeforeEnumerationCompletesDoesNotStartACapture() async throws {
+    let rig = CaptureRig()
+    let request = try #require(rig.reserve("panel", panel: 11))
+    rig.beforeEnumerationReturns = { rig.pipeline.invalidate(key: "panel") }
+    rig.resolve(0, Self.sample)
+    await rig.run([request])
+    #expect(rig.startedDisplays.isEmpty)
+    #expect(rig.maps.isEmpty)
+  }
+
+  enum HistoryReset: CaseIterable { case deleteHistory, resetSettings }
+
+  @Test(arguments: HistoryReset.allCases)
+  func clearingHistoryDuringEnumerationReleasesTheOldWave(_ action: HistoryReset) async throws {
+    let rig = CaptureRig()
+    let key = "capture-delete-fixture-\(UUID().uuidString)"
+    let request = try #require(rig.reserve(key, panel: 11))
+    let coordinator = OledCareCoordinator(exposureCapture: rig.pipeline)
+    // No model is started, so reset has no overlays, controllers or real
+    // displays to touch. History deletion uses only this unique fixture key.
+    rig.beforeEnumerationReturns = {
+      switch action {
+      case .deleteHistory: coordinator.clearExposureHistory(for: key)
+      case .resetSettings: coordinator.prepareForReset()
+      }
+    }
+    rig.resolve(0, Self.sample)
+    await rig.run([request])
+
+    #expect(rig.startedDisplays.isEmpty)
+    #expect(rig.maps.isEmpty)
+    #expect(rig.pipeline.reserve(key: key, target: request.target,
+      transform: request.transform, epoch: 1) != nil)
+  }
+
+  @Test(arguments: HistoryReset.allCases)
+  func clearingHistoryReleasesACaptureThatHasNotReturned(_ action: HistoryReset) async throws {
+    let rig = CaptureRig()
+    let key = "capture-delete-fixture-\(UUID().uuidString)"
+    let old = try #require(rig.reserve(key, panel: 11))
+    let coordinator = OledCareCoordinator(exposureCapture: rig.pipeline)
+    let oldWork = Task { await rig.run([old]) }
+    await rig.waitForCaptureStart()
+    switch action {
+    case .deleteHistory: coordinator.clearExposureHistory(for: key)
+    case .resetSettings: coordinator.prepareForReset()
+    }
+    let replacement = rig.pipeline.reserve(key: key, target: old.target,
+      transform: old.transform, epoch: 1)
+    #expect(replacement != nil)
+
+    // Release the obsolete work even if the slot assertion fails.
+    rig.resolve(0, Self.sample)
+    await oldWork.value
+    #expect(rig.maps.isEmpty)
+    if let replacement {
+      #expect(rig.pipeline.reserve(key: key, target: replacement.target,
+        transform: replacement.transform, epoch: 1) == nil)
+    }
+  }
+
+  @Test func aFailedOldEnumerationCannotReleaseAReplacementReservation() async throws {
+    let rig = CaptureRig()
+    let request = try #require(rig.reserve("panel", panel: 11))
+    rig.beforeEnumerationReturns = {
+      rig.pipeline.invalidate(key: "panel")
+      #expect(rig.reserve("panel", panel: 11) != nil)
+    }
+    rig.enumerationSucceeds = false
+    await rig.run([request])
+
+    #expect(rig.startedDisplays.isEmpty)
+    #expect(rig.maps.isEmpty)
+    #expect(rig.pipeline.reserve(key: request.key, target: request.target,
+      transform: request.transform, epoch: 0) == nil)
+  }
+
+  private static func synthesisTarget() -> OledTelemetryTarget {
+    func display(_ id: CGDirectDisplayID, mirror: CGDirectDisplayID = 0) -> ConfiguredDisplay {
+      ConfiguredDisplay(id: id,
+        identity: DisplayConfigIdentity(vendor: 1, model: id, serial: id, isBuiltIn: false),
+        name: "Fixture", isBuiltIn: false, mirrorsDisplay: mirror)
+    }
+    return OledTelemetryTarget(panel: 11,
+      topology: MirrorTopology([display(11, mirror: 79), display(79)], synthesisMasters: [79]))
+  }
+}
+
+/// Capture preparation and live context reads are controlled. Reservation,
+/// ownership, validation and dispatch run through the production pipeline;
+/// accepted samples go through the real exposure accumulator. The history
+/// tests also call the coordinator's production deletion and reset entry points.
+@MainActor private final class CaptureRig {
+  typealias Request = OledExposureCapture.Request
+  var enumerations = 0
+  var enumerationSucceeds = true
+  var beforeEnumerationReturns: (() -> Void)?
+  var startedDisplays: [CGDirectDisplayID] = []
+  var contexts: [String: OledExposureCapture.Context] = [:]
+  var maps: [String: ExposureAccumulator] = [:]
+  private var results: [Int: Resolution] = [:]
+  private var waiting: [Int: CheckedContinuation<LuminanceSampler.Sample?, Never>] = [:]
+  private let starts = CaptureEvent()
+  private let accepts = CaptureEvent()
+
+  private enum Resolution { case sample(LuminanceSampler.Sample?) }
+
+  lazy var pipeline = OledExposureCapture { [unowned self] in
+    enumerations += 1
+    let beforeReturn = beforeEnumerationReturns
+    beforeEnumerationReturns = nil
+    beforeReturn?()
+    guard enumerationSucceeds else { return nil }
+    return LuminanceSampler.Wave { [unowned self] displayID in
+      let index = startedDisplays.count
+      startedDisplays.append(displayID)
+      return Task { @MainActor in
+        self.starts.signal()
+        return await withCheckedContinuation { continuation in
+          if case let .sample(sample) = self.results[index] {
+            continuation.resume(returning: sample)
+          } else {
+            self.waiting[index] = continuation
+          }
+        }
+      }
+    }
+  }
+
+  func reserve(_ key: String, panel: CGDirectDisplayID) -> Request? {
+    reserve(key, target: OledTelemetryTarget(panel: panel, topology: MirrorTopology([])))
+  }
+
+  func reserve(_ key: String, target: OledTelemetryTarget) -> Request? {
+    let transform = PanelSpaceTransform(displaySize: CGSize(width: 240, height: 120), rotation: .standard)
+    contexts[key] = OledExposureCapture.Context(
+      epoch: 0, displayID: target.panel, target: target, transform: transform,
+      telemetryEnabled: true, dimState: .active, isResetting: false,
+      isLocked: false, panelIsAwake: true, isLowBattery: false)
+    return pipeline.reserve(key: key, target: target, transform: transform, epoch: 0)
+  }
+
+  func run(_ requests: [Request]) async {
+    await pipeline.run(requests, current: { [unowned self] request in contexts[request.key] },
+      accept: { [unowned self] request, sample in
+        var map = maps[request.key] ?? ExposureAccumulator()
+        map.accumulate(displayGrid: sample.grid, cols: sample.cols, rows: sample.rows,
+          through: request.transform, elapsed: 60, at: Date(timeIntervalSince1970: 0))
+        maps[request.key] = map
+        accepts.signal()
+      })
+  }
+
+  func resolve(_ index: Int, _ sample: LuminanceSampler.Sample?) {
+    results[index] = .sample(sample)
+    waiting.removeValue(forKey: index)?.resume(returning: sample)
+  }
+
+  func waitForCaptureStart() async { await starts.next() }
+  func waitForAcceptance() async { await accepts.next() }
+}
+
+@MainActor private final class CaptureEvent {
+  private var available = 0
+  private var waiting: CheckedContinuation<Void, Never>?
+
+  func signal() {
+    if let continuation = waiting {
+      waiting = nil
+      continuation.resume()
+    } else {
+      available += 1
+    }
+  }
+
+  func next() async {
+    if available > 0 {
+      available -= 1
+      return
+    }
+    await withCheckedContinuation { waiting = $0 }
+  }
+}

--- a/CandelaAppTests/OnboardingFloatLifecycleTests.swift
+++ b/CandelaAppTests/OnboardingFloatLifecycleTests.swift
@@ -1,0 +1,84 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@Suite("Onboarding float lifecycle") @MainActor
+struct OnboardingFloatLifecycleTests {
+  // Reduce Motion is read-only in SwiftUI's environment. Exercise the same
+  // float gate through `active`, without changing the machine's preferences.
+  @Test(.enabled("The float transition requires Reduce Motion to be off") {
+    await MainActor.run { !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
+  })
+  func stoppingAndResumingFloatKeepsTheCompletedCheckmarkVisible() async throws {
+    let update = RenderUpdate()
+    let host = NSHostingView(rootView: Content(active: true, update: update))
+    let window = NSWindow(
+      contentRect: NSRect(x: -10000, y: -10000, width: 100, height: 100),
+      styleMask: [.borderless], backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    window.contentView = host
+    defer {
+      window.contentView = nil
+      window.close()
+    }
+
+    // Never order the window on screen. The reference is the real completed
+    // stroke; a new child whose drawing restarts has no white stroke yet.
+    var completedWhitePixels: Int?
+    for active in [true, false, true] {
+      host.rootView = Content(active: active, update: update)
+      for _ in 0..<100 {
+        host.layoutSubtreeIfNeeded()
+        if update.appliedActive == active { break }
+        try await Task.sleep(for: .milliseconds(10))
+      }
+      try #require(update.appliedActive == active)
+      if let completedWhitePixels {
+        let pixels = try whitePixels(in: host)
+        // Count coverage, not positions: floating shifts the stroke and its
+        // antialiasing, but must not erase it or replay the draw-in.
+        #expect(pixels >= completedWhitePixels * 4 / 5)
+      } else {
+        try await Task.sleep(for: .milliseconds(1100))
+        let pixels = try whitePixels(in: host)
+        try #require(pixels > 50, "The offscreen host must render a completed white stroke")
+        completedWhitePixels = pixels
+      }
+    }
+  }
+
+  private func whitePixels(in host: NSView) throws -> Int {
+    host.layoutSubtreeIfNeeded()
+    let bitmap = try #require(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+    host.cacheDisplay(in: host.bounds, to: bitmap)
+    var count = 0
+    for y in 0..<bitmap.pixelsHigh {
+      for x in 0..<bitmap.pixelsWide {
+        guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
+        if color.alphaComponent > 0.5, color.redComponent > 0.7,
+          color.greenComponent > 0.7, color.blueComponent > 0.7
+        {
+          count += 1
+        }
+      }
+    }
+    return count
+  }
+
+  private final class RenderUpdate {
+    var appliedActive: Bool?
+  }
+
+  private struct Content: View {
+    let active: Bool
+    let update: RenderUpdate
+
+    var body: some View {
+      AnimatedCheckmark(accent: Color(red: 0, green: 1, blue: 0), floatActive: active)
+        .frame(width: 68, height: 68)
+        .frame(width: 100, height: 100)
+        .background(.black)
+        .onChange(of: active, initial: true) { update.appliedActive = active }
+    }
+  }
+}

--- a/CandelaAppTests/SettingsVisibilitySignalTests.swift
+++ b/CandelaAppTests/SettingsVisibilitySignalTests.swift
@@ -38,4 +38,11 @@ struct SettingsVisibilitySignalTests {
     #expect(onScreen(nil, .active))
     #expect(onScreen(nil, .inactive) == false)
   }
+
+  /// Every reader stops something while this is false, so the default must be
+  /// `true`: onboarding, the Heat Map window and the render tests draw outside
+  /// the shell and must not go still.
+  @Test func theEnvironmentValueDefaultsToVisibleOutsideTheShell() {
+    #expect(EnvironmentValues().settingsWindowIsVisible)
+  }
 }

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -2,9 +2,19 @@ import CoreGraphics
 import Observation
 import os
 
-/// Drag-perf diagnostics: one line per post-coalescing stage (target adoption, DDC
-/// write start/end). Cheap at ~30 Hz during a drag, and the fastest way to localize
-/// a "slider moves but hardware doesn't" report.
+/// Drag-perf diagnostics: one line per post-coalescing stage (target adoption,
+/// DDC write start/end), the fastest way to localize a "slider moves but
+/// hardware doesn't" report.
+///
+/// Split by level on purpose. `ddc.write.end` stays `.info`: it is the persisted
+/// evidence a write reached the wire, and the regression suite's post-wake write
+/// count is built on it. One line per bus transaction at about 20 ms each, so a
+/// sustained drag persists roughly 50 lines a second.
+///
+/// Target adoption and `ddc.write.start` are `.debug`: drag rate (about 30 Hz)
+/// and neither proves anything landed. Debug records are not persisted until
+/// `log config --mode "level:debug" --subsystem com.rydersel.Candela` runs
+/// before the drag; read them back with `log show --info --debug`.
 let dragPerfLog = Logger(subsystem: "com.rydersel.Candela", category: "dragperf")
 
 /// Path-selection/HDR diagnostics (mode changes, settle completion, cache
@@ -2622,7 +2632,7 @@ actor BrightnessWriteCoalescer {
 
   private func drain() async {
     while let write = await nextTarget() {
-      dragPerfLog.info(
+      dragPerfLog.debug(
         "coalescer.target \(String(describing: write.target), privacy: .public) gen=\(write.generation)"
       )
       // Epoch gate: a target stamped before a display reconfiguration must not land

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -112,8 +112,10 @@ public class Arm64DDC: NSObject {
     var matchedDisplayServices: [Arm64Service] = []
     var scoredCandidateDisplayServices: [Int: [Arm64Service]] = [:]
     for displayID in displayIDs {
+      // Once per display: every candidate in the walk scores against this record.
+      let displayInfo = self.displayInfoDictionary(displayID: displayID)
       for ioregServiceForMatching in ioregServicesForMatching {
-        let score = self.ioregMatchScore(displayID: displayID, ioregEdidUUID: ioregServiceForMatching.edidUUID, ioDisplayLocation: ioregServiceForMatching.ioDisplayLocation, ioregProductName: ioregServiceForMatching.productName, ioregSerialNumber: ioregServiceForMatching.serialNumber)
+        let score = self.ioregMatchScore(displayInfo: displayInfo, ioregEdidUUID: ioregServiceForMatching.edidUUID, ioDisplayLocation: ioregServiceForMatching.ioDisplayLocation, ioregProductName: ioregServiceForMatching.productName, ioregSerialNumber: ioregServiceForMatching.serialNumber)
         let dummy = self.checkIfDummy(ioregService: ioregServiceForMatching)
         let displayService = Arm64Service(displayID: displayID, service: ioregServiceForMatching.service, serviceLocation: ioregServiceForMatching.serviceLocation, dummy: dummy, serviceDetails: ioregServiceForMatching, matchScore: score)
         if scoredCandidateDisplayServices[score] == nil {
@@ -409,9 +411,17 @@ public class Arm64DDC: NSObject {
     return chkd
   }
 
-  static func ioregMatchScore(displayID: CGDirectDisplayID, ioregEdidUUID: String, ioDisplayLocation: String = "", ioregProductName: String = "", ioregSerialNumber: Int64 = 0) -> Int {
+  /// What macOS parsed from this display's EDID at connection; nil when the
+  /// private call declines. Built once per display and scored against every candidate.
+  static func displayInfoDictionary(displayID: CGDirectDisplayID) -> NSDictionary? {
+    CoreDisplay_DisplayCreateInfoDictionary(displayID)?.takeRetainedValue() as NSDictionary?
+  }
+
+  /// Scores one IOReg service's identity fields against `displayInfo`. Nil
+  /// scores 0: nothing to compare against.
+  static func ioregMatchScore(displayInfo: NSDictionary?, ioregEdidUUID: String, ioDisplayLocation: String = "", ioregProductName: String = "", ioregSerialNumber: Int64 = 0) -> Int {
     var matchScore = 0
-    if let dictionary = CoreDisplay_DisplayCreateInfoDictionary(displayID)?.takeRetainedValue() as NSDictionary? {
+    if let dictionary = displayInfo {
       if let kDisplayYearOfManufacture = dictionary[kDisplayYearOfManufacture] as? Int64, let kDisplayWeekOfManufacture = dictionary[kDisplayWeekOfManufacture] as? Int64, let kDisplayVendorID = dictionary[kDisplayVendorID] as? Int64, let kDisplayProductID = dictionary[kDisplayProductID] as? Int64, let kDisplayVerticalImageSize = dictionary[kDisplayVerticalImageSize] as? Int64, let kDisplayHorizontalImageSize = dictionary[kDisplayHorizontalImageSize] as? Int64 {
         struct KeyLoc {
           var key: String
@@ -488,9 +498,10 @@ public class Arm64DDC: NSObject {
     defer { IOObjectRelease(iterator) }
     var candidates: [(score: Int, entry: io_service_t)] = []
     defer { for candidate in candidates { IOObjectRelease(candidate.entry) } }
+    let displayInfo = self.displayInfoDictionary(displayID: displayID)
     while let objectOfInterest = self.ioregIterateToNextObjectOfInterest(interests: ["AppleCLCD2", "IOMobileFramebufferShim"], iterator: &iterator) {
       let details = self.getIORegServiceAppleCDC2Properties(entry: objectOfInterest.entry)
-      let score = self.ioregMatchScore(displayID: displayID, ioregEdidUUID: details.edidUUID, ioDisplayLocation: details.ioDisplayLocation, ioregProductName: details.productName, ioregSerialNumber: details.serialNumber)
+      let score = self.ioregMatchScore(displayInfo: displayInfo, ioregEdidUUID: details.edidUUID, ioDisplayLocation: details.ioDisplayLocation, ioregProductName: details.productName, ioregSerialNumber: details.serialNumber)
       candidates.append((score, objectOfInterest.entry))
     }
     return self.bestMatchingRecord(among: candidates.map { candidate in

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -41,11 +41,10 @@ public actor Arm64DDCService: DDCWriting {
   }
 
   public func write(command: UInt8, value: UInt16) async -> Bool {
-    // start/end pair also exposes the per-transaction duration: ~14 ms, from
-    // the MAG's nine-write ramp measured at 0.129 s.
-    // `.info`: the default level persists every one of these to disk at drag
-    // rate, and `.debug` is invisible to the `log show` the regression rig parses.
-    dragPerfLog.info("ddc.write.start value=\(value)")
+    // End line `.info`, start line `.debug`: see `dragPerfLog`. With debug
+    // persistence on, the pair gives the per-transaction duration (~14 ms, from
+    // the MAG's nine-write ramp at 0.129 s).
+    dragPerfLog.debug("ddc.write.start value=\(value)")
     let ok = Arm64DDC.write(service: box.service, command: command, value: value, pacer: pacer)
     dragPerfLog.info("ddc.write.end value=\(value) ok=\(ok)")
     return ok

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
@@ -66,17 +66,36 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
   /// two computed nothing but `!isHiDPI`, which `DisplayMode` already derives.
   /// Neither list corresponds to what Displays settings shows.
   public func modes(for displayID: CGDirectDisplayID) -> [DisplayMode] {
-    let (published, revealed) = enumerate(displayID)
-    // Collapse AFTER the merge, not inside `copyModes`. Revelation dedupes
-    // against the published IDs, so a twin removed before it ran would free its
-    // ID and come back wearing the revealed badge. Its own gates would reject it
-    // today, but that is a fact about this hardware, not about the ordering.
-    return DisplayModeList.deduplicated(published + (revealed?.modes ?? []))
+    Self.merged(enumerate(displayID))
   }
 
   public func modesWithheldByWireTimingGuard(for displayID: CGDirectDisplayID) -> Int {
-    enumerate(displayID).revealed?.dropped.noNativeParentTiming ?? 0
+    Self.withheld(enumerate(displayID))
   }
+
+  /// The mode list one enumeration answers with. One expression for every
+  /// reader, `modeSnapshot` included: a hand-copied twin could diverge with
+  /// nothing to catch it, since no hardware-free test reaches this configurator.
+  ///
+  /// Collapse AFTER the merge, not inside `copyModes`. Revelation dedupes
+  /// against the published IDs, so a twin removed before it ran would free its
+  /// ID and come back wearing the revealed badge. Its own gates would reject it
+  /// today, but that is a fact about this hardware, not about the ordering.
+  private static func merged(_ pass: EnumerationPass) -> [DisplayMode] {
+    DisplayModeList.deduplicated(pass.published + (pass.revealed?.modes ?? []))
+  }
+
+  /// How many revealed modes that pass's guard withheld. One expression, for
+  /// `merged`'s reason.
+  private static func withheld(_ pass: EnumerationPass) -> Int {
+    pass.revealed?.dropped.noNativeParentTiming ?? 0
+  }
+
+  /// What `enumerate` hands back: the CoreGraphics list and the revelation pass
+  /// over it.
+  typealias EnumerationPass = (
+    published: [DisplayMode], revealed: CGSModeRevelation.RevelationResult?
+  )
 
   /// The CoreGraphics list, and the revelation pass over it when one ran.
   ///
@@ -86,9 +105,7 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
   // published list and the revelation result SEPARATELY. The subset cross-check
   // is only meaningful against modes CoreGraphics computed on its own; a
   // revealed mode agreeing with the CGS entry it was built from proves nothing.
-  func enumerate(
-    _ displayID: CGDirectDisplayID
-  ) -> (published: [DisplayMode], revealed: CGSModeRevelation.RevelationResult?) {
+  func enumerate(_ displayID: CGDirectDisplayID) -> EnumerationPass {
     let published = copyModes(displayID).map { ioID, mode in
       Self.displayMode(ioModeID: ioID, mode: mode)
     }
@@ -130,18 +147,41 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
   /// `kCGDisplayShowDuplicateLowResolutionModes`, measured on hardware at
   /// 132/132, 332/332 and 120/120 across three panels.
   public func currentMode(for displayID: CGDirectDisplayID) -> DisplayMode? {
+    Self.resolveCurrent(displayID, in: modes(for: displayID))
+  }
+
+  /// Resolved rather than looked up: the display can be running a duplicate the
+  /// enumeration collapsed, and `CGDisplayCopyDisplayMode` answers with the live
+  /// id either way. See `DisplayModeList.resolve`.
+  ///
+  /// The list is the caller's: the snapshot has already paid for one.
+  private static func resolveCurrent(
+    _ displayID: CGDirectDisplayID, in modes: [DisplayMode]
+  ) -> DisplayMode? {
     guard let mode = CGDisplayCopyDisplayMode(displayID) else { return nil }
-    // Resolved rather than looked up: the display can be running a duplicate the
-    // enumeration collapsed, and this call answers with the live id either way.
-    // See `DisplayModeList.resolve`.
     return DisplayModeList.resolve(
-      Self.displayMode(ioModeID: mode.ioDisplayModeID, mode: mode),
-      in: modes(for: displayID))
+      Self.displayMode(ioModeID: mode.ioDisplayModeID, mode: mode), in: modes)
   }
 
   public func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)? {
-    guard let native = modes(for: displayID).first(where: \.isNative) else { return nil }
-    return (native.pixelWidth, native.pixelHeight)
+    DisplayModeSnapshot.nativePixels(in: modes(for: displayID))
+  }
+
+  /// One `enumerate` for all four answers where the default costs four.
+  /// Measured 2026-09-09: one mode apply and its revert produced 16 catalog
+  /// refreshes and 64 full enumerations of the same displays.
+  ///
+  /// The current mode is a live `CGDisplayCopyDisplayMode` read resolved into
+  /// THIS list, not a call to `currentMode(for:)`, which would enumerate again.
+  public func modeSnapshot(for displayID: CGDirectDisplayID) -> DisplayModeSnapshot {
+    let pass = enumerate(displayID)
+    let modes = Self.merged(pass)
+    return DisplayModeSnapshot(
+      modes: modes,
+      current: Self.resolveCurrent(displayID, in: modes),
+      nativePixels: DisplayModeSnapshot.nativePixels(in: modes),
+      withheldByWireTimingGuard: Self.withheld(pass)
+    )
   }
 
   public func apply(

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/CoreGraphicsDisplayConfigurator.swift
@@ -74,8 +74,7 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
   }
 
   /// The mode list one enumeration answers with. One expression for every
-  /// reader, `modeSnapshot` included: a hand-copied twin could diverge with
-  /// nothing to catch it, since no hardware-free test reaches this configurator.
+  /// reader, `modeSnapshot` included, so merge and collapse cannot diverge.
   ///
   /// Collapse AFTER the merge, not inside `copyModes`. Revelation dedupes
   /// against the published IDs, so a twin removed before it ran would free its
@@ -147,20 +146,23 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
   /// `kCGDisplayShowDuplicateLowResolutionModes`, measured on hardware at
   /// 132/132, 332/332 and 120/120 across three panels.
   public func currentMode(for displayID: CGDirectDisplayID) -> DisplayMode? {
-    Self.resolveCurrent(displayID, in: modes(for: displayID))
+    Self.resolveCurrent(read: { achievedMode(displayID) }, in: modes(for: displayID))
   }
 
   /// Resolved rather than looked up: the display can be running a duplicate the
   /// enumeration collapsed, and `CGDisplayCopyDisplayMode` answers with the live
   /// id either way. See `DisplayModeList.resolve`.
   ///
-  /// The list is the caller's: the snapshot has already paid for one.
-  private static func resolveCurrent(
-    _ displayID: CGDirectDisplayID, in modes: [DisplayMode]
+  /// Delay the caller's list until the live read succeeds. An unreadable current
+  /// mode must not trigger enumeration, and resolution must use that captured
+  /// reading even if the display changes during enumeration. The snapshot hands
+  /// back its existing list, so it still pays for only one enumeration.
+  /// The read is injected at the hardware boundary for tests without displays.
+  static func resolveCurrent(
+    read: () -> DisplayMode?, in modes: @autoclosure () -> [DisplayMode]
   ) -> DisplayMode? {
-    guard let mode = CGDisplayCopyDisplayMode(displayID) else { return nil }
-    return DisplayModeList.resolve(
-      Self.displayMode(ioModeID: mode.ioDisplayModeID, mode: mode), in: modes)
+    guard let mode = read() else { return nil }
+    return DisplayModeList.resolve(mode, in: modes())
   }
 
   public func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)? {
@@ -178,7 +180,7 @@ public struct CoreGraphicsDisplayConfigurator: DisplayConfiguring {
     let modes = Self.merged(pass)
     return DisplayModeSnapshot(
       modes: modes,
-      current: Self.resolveCurrent(displayID, in: modes),
+      current: Self.resolveCurrent(read: { achievedMode(displayID) }, in: modes),
       nativePixels: DisplayModeSnapshot.nativePixels(in: modes),
       withheldByWireTimingGuard: Self.withheld(pass)
     )

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
@@ -217,6 +217,43 @@ enum MirrorVerification {
   }
 }
 
+/// Everything one enumeration of a display can answer, taken at one instant.
+///
+/// Asked separately, each answer re-runs `CGDisplayCopyAllDisplayModes` plus
+/// the CGS revelation pass on the real configurator, and the four need not
+/// describe the same instant.
+public struct DisplayModeSnapshot: Sendable {
+  public let modes: [DisplayMode]
+  public let current: DisplayMode?
+  public let nativePixels: (width: Int, height: Int)?
+  public let withheldByWireTimingGuard: Int
+
+  public init(
+    modes: [DisplayMode],
+    current: DisplayMode?,
+    nativePixels: (width: Int, height: Int)?,
+    withheldByWireTimingGuard: Int
+  ) {
+    self.modes = modes
+    self.current = current
+    self.nativePixels = nativePixels
+    self.withheldByWireTimingGuard = withheldByWireTimingGuard
+  }
+
+  /// The panel's own pixel count, from the FIRST native-flagged mode in
+  /// ENUMERATION order.
+  ///
+  /// Order is load-bearing. A Retina panel flags two modes (measured: the
+  /// built-in flags both 1512x982@2x and 3024x1964@1x, since the flag means
+  /// framebuffer == panel pixels) and `DisplayModeCatalog.full` sorts the other
+  /// one first. Both report the same pixel count on the panels measured, so a
+  /// read off the sorted list would look right here and diverge on the first
+  /// panel where they differ.
+  public static func nativePixels(in modes: [DisplayMode]) -> (width: Int, height: Int)? {
+    modes.first(where: \.isNative).map { (width: $0.pixelWidth, height: $0.pixelHeight) }
+  }
+}
+
 /// The seam between display-configuration policy and CoreGraphics. Everything
 /// decidable is tested against a fake conformance; the real one is a thin
 /// adapter with no judgement in it.
@@ -231,6 +268,9 @@ public protocol DisplayConfiguring: Sendable {
   /// The panel's own pixel count, from the mode flagged native. Needed to tell
   /// scaled modes from native ones.
   func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)?
+  /// The four answers above from ONE enumeration. The default asks the four
+  /// methods; the real configurator overrides it with a single pass.
+  func modeSnapshot(for displayID: CGDirectDisplayID) -> DisplayModeSnapshot
   /// Stages one mode change, commits it, then reads back what the display runs.
   ///
   /// Throws `DisplayConfigError` if the mode cannot be resolved, staging or the
@@ -305,4 +345,17 @@ public protocol DisplayConfiguring: Sendable {
   /// **Blocks.** Measured at 0.4 to 1.1s: the call does not return until
   /// the rotation has taken effect. Never call it on the main actor.
   func applyRotation(_ rotation: DisplayRotation, to displayID: CGDirectDisplayID) throws
+}
+
+extension DisplayConfiguring {
+  /// Correct for any conformance and cheap for a fake; the real configurator
+  /// overrides it.
+  public func modeSnapshot(for displayID: CGDirectDisplayID) -> DisplayModeSnapshot {
+    DisplayModeSnapshot(
+      modes: modes(for: displayID),
+      current: currentMode(for: displayID),
+      nativePixels: nativePixels(for: displayID),
+      withheldByWireTimingGuard: modesWithheldByWireTimingGuard(for: displayID)
+    )
+  }
 }

--- a/CandelaKit/Tests/CandelaKitTests/AppRegressionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/AppRegressionTests.swift
@@ -122,9 +122,9 @@ struct AppRegressionTests {
     "Timestamp               Ty Process[PID:TID]",
     "2026-08-11 17:15:22.031 Df Candela[80328:9875ec] [com.rydersel.Candela:path] sync fan-out delta=-0.0306 from=1 to=3",
     "2026-08-11 17:15:22.033 Df Candela[80328:998b3a] [com.rydersel.Candela:dragperf] ddc.write.start value=89",
-    "2026-08-11 17:15:22.055 Df Candela[80328:998b3a] [com.rydersel.Candela:dragperf] ddc.write.end value=0 ok=true",
-    "2026-08-11 17:15:22.057 Df Candela[80328:99dfc5] [com.rydersel.Candela:dragperf] ddc.write.end value=37 ok=true",
-    "2026-08-11 17:15:22.061 Df Candela[80328:99dfc5] [com.rydersel.Candela:dragperf] ddc.write.end value=93 ok=false",
+    "2026-08-11 17:15:22.055 I  Candela[80328:998b3a] [com.rydersel.Candela:dragperf] ddc.write.end value=0 ok=true",
+    "2026-08-11 17:15:22.057 I  Candela[80328:99dfc5] [com.rydersel.Candela:dragperf] ddc.write.end value=37 ok=true",
+    "2026-08-11 17:15:22.061 I  Candela[80328:99dfc5] [com.rydersel.Candela:dragperf] ddc.write.end value=93 ok=false",
   ]
 
   @Test func onlyAcknowledgedWriteEndLinesYieldValues() {
@@ -140,7 +140,7 @@ struct AppRegressionTests {
   }
 
   @Test func multiDigitValuesSurviveTheParse() {
-    let line = "2026-08-11 17:15:22.055 Df Candela[1:2] [com.rydersel.Candela:dragperf] ddc.write.end value=100 ok=true"
+    let line = "2026-08-11 17:15:22.055 I  Candela[1:2] [com.rydersel.Candela:dragperf] ddc.write.end value=100 ok=true"
     #expect(AppRegression.ddcWriteValues(fromLogLines: [line]) == [100])
   }
 
@@ -429,7 +429,7 @@ struct AppRegressionTests {
     "2026-08-11 17:15:22.031 Df Candela[80328:9875ec] [com.rydersel.Candela:path] sync fan-out delta=-0.0306 from=1 to=3",
     "2026-08-11 17:15:22.032 Df Candela[80328:9875ec] [com.rydersel.Candela:path] sync fan-out delta=-0.0306 from=1 to=5",
     "2026-08-11 17:15:22.033 Df Candela[80328:9875ec] [com.rydersel.Candela:path] sync fan-out delta=0.0400 from=10 to=3",
-    "2026-08-11 17:15:22.055 Df Candela[80328:998b3a] [com.rydersel.Candela:dragperf] ddc.write.end value=0 ok=true",
+    "2026-08-11 17:15:22.055 I  Candela[80328:998b3a] [com.rydersel.Candela:dragperf] ddc.write.end value=0 ok=true",
   ]
 
   @Test func everyFanOutLineYieldsItsSourceAndNothingElseDoes() {
@@ -645,7 +645,7 @@ struct AppRegressionTests {
   private static let quietLine =
     "2026-08-18 09:12:12.010 Df Candela[80328:3] [com.rydersel.Candela:topology] topology quiet window elapsed, signaling refresh"
   private static func writeLine(_ value: Int, ok: Bool = true) -> String {
-    "2026-08-18 09:12:13.000 Df Candela[80328:4] [com.rydersel.Candela:dragperf] ddc.write.end value=\(value) ok=\(ok)"
+    "2026-08-18 09:12:13.000 I  Candela[80328:4] [com.rydersel.Candela:dragperf] ddc.write.end value=\(value) ok=\(ok)"
   }
 
   @Test func aQuietWakeReadsAsTheWholeTripleAndNoWrites() {

--- a/CandelaKit/Tests/CandelaKitTests/CoreGraphicsCurrentModeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CoreGraphicsCurrentModeTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import CandelaKit
+
+@Suite("CoreGraphics current mode reads")
+struct CoreGraphicsCurrentModeTests {
+  @Test("An unreadable current mode returns without enumerating modes")
+  func unreadableCurrentSkipsEnumeration() {
+    var reads = 0
+    var enumerations = 0
+    func enumerate() -> [DisplayMode] {
+      enumerations += 1
+      return []
+    }
+
+    let current = CoreGraphicsDisplayConfigurator.resolveCurrent(
+      read: {
+        reads += 1
+        return nil
+      },
+      in: enumerate()
+    )
+
+    #expect(current == nil)
+    #expect(reads == 1)
+    #expect(enumerations == 0)
+  }
+
+  @Test("The captured live mode resolves to its surviving row", arguments: [178, 181])
+  func capturedCurrentResolvesToSurvivor(currentID: Int32) {
+    let survivor = DisplayMode(
+      ioModeID: 178, logicalWidth: 1440, logicalHeight: 2560,
+      pixelWidth: 2880, pixelHeight: 5120, refreshHz: 120, isNative: true
+    )
+    let duplicate = DisplayMode(
+      ioModeID: 181, logicalWidth: 1440, logicalHeight: 2560,
+      pixelWidth: 2880, pixelHeight: 5120, refreshHz: 120, isNative: false
+    )
+    var live = DisplayMode(
+      ioModeID: currentID, logicalWidth: 1440, logicalHeight: 2560,
+      pixelWidth: 2880, pixelHeight: 5120, refreshHz: 120, isNative: false
+    )
+    var events: [String] = []
+    func enumerate() -> [DisplayMode] {
+      events.append("enumerate")
+      // A display can change while enumeration is in progress. Resolution must
+      // use the reading already captured, without a second live read.
+      live = DisplayMode(
+        ioModeID: 999, logicalWidth: 800, logicalHeight: 600,
+        pixelWidth: 800, pixelHeight: 600, refreshHz: 60, isNative: false
+      )
+      return DisplayModeList.deduplicated([survivor, duplicate])
+    }
+
+    let current = CoreGraphicsDisplayConfigurator.resolveCurrent(
+      read: {
+        events.append("read")
+        return live
+      },
+      in: enumerate()
+    )
+
+    #expect(events == ["read", "enumerate"])
+    #expect(current?.ioModeID == 178)
+    #expect(current?.isNative == true)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/DisplayDiscoveryTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayDiscoveryTests.swift
@@ -1,3 +1,5 @@
+import Foundation
+import IOKit
 import Testing
 @testable import CandelaKit
 
@@ -10,4 +12,75 @@ import Testing
 @Test func displayNameFallsBackToDisplayID() {
   let service = Arm64DDC.IOregService()  // productName == ""
   #expect(DisplayDiscovery.displayName(from: service, displayID: 5) == "Display 5")
+}
+
+/// Stands in for `CoreDisplay_DisplayCreateInfoDictionary` so the scoring
+/// arithmetic can be pinned.
+private enum MatchScoreFixture {
+  /// EDID UUID whose four scored windows (offsets 0, 4, 19 and 30) carry the
+  /// vendor, product, manufacture-date and image-size keys the fixture declares.
+  static let edidUUID = "1234" + "7856" + "0000-0000-0" + "141F" + "-000000" + "4628"
+  static let location = "IOService:/AppleARMPE/dcp@1/AppleCLCD2"
+  static let productName = "MAG 341C OLED"
+  static let serialNumber: Int64 = 1_234_567
+
+  /// A function, not a stored constant: `NSDictionary` is not `Sendable`.
+  static func dictionary() -> NSDictionary {
+    [
+      kDisplayVendorID: NSNumber(value: Int64(0x1234)),
+      kDisplayProductID: NSNumber(value: Int64(0x5678)),
+      kDisplayWeekOfManufacture: NSNumber(value: Int64(20)),
+      kDisplayYearOfManufacture: NSNumber(value: Int64(2021)),
+      kDisplayHorizontalImageSize: NSNumber(value: Int64(700)),
+      kDisplayVerticalImageSize: NSNumber(value: Int64(400)),
+      kIODisplayLocationKey: location,
+      "DisplayProductName": ["en_US": productName],
+      kDisplaySerialNumber: NSNumber(value: serialNumber),
+    ] as NSDictionary
+  }
+}
+
+@Test func matchScoreSumsEveryAgreement() {
+  let score = Arm64DDC.ioregMatchScore(
+    displayInfo: MatchScoreFixture.dictionary(),
+    ioregEdidUUID: MatchScoreFixture.edidUUID,
+    ioDisplayLocation: MatchScoreFixture.location,
+    ioregProductName: MatchScoreFixture.productName.lowercased(),
+    ioregSerialNumber: MatchScoreFixture.serialNumber
+  )
+  // Four EDID windows, the location worth ten on its own, name and serial.
+  #expect(score == 16)
+}
+
+@Test func matchScoreCountsOnlyTheEdidWindowsWhenTheServiceDiffers() {
+  let score = Arm64DDC.ioregMatchScore(
+    displayInfo: MatchScoreFixture.dictionary(),
+    ioregEdidUUID: MatchScoreFixture.edidUUID,
+    ioDisplayLocation: "IOService:/AppleARMPE/dcp@0/AppleCLCD2",
+    ioregProductName: "U2725QE",
+    ioregSerialNumber: 7
+  )
+  #expect(score == 4)
+}
+
+@Test func matchScoreDropsTheEdidWindowsThatDisagree() {
+  let score = Arm64DDC.ioregMatchScore(
+    displayInfo: MatchScoreFixture.dictionary(),
+    ioregEdidUUID: "0000" + "7856" + "0000-0000-0" + "141F" + "-000000" + "0000",
+    ioDisplayLocation: "",
+    ioregProductName: "",
+    ioregSerialNumber: 0
+  )
+  #expect(score == 2)
+}
+
+@Test func matchScoreIsZeroWithoutADisplayInfoDictionary() {
+  let score = Arm64DDC.ioregMatchScore(
+    displayInfo: nil,
+    ioregEdidUUID: MatchScoreFixture.edidUUID,
+    ioDisplayLocation: MatchScoreFixture.location,
+    ioregProductName: MatchScoreFixture.productName,
+    ioregSerialNumber: MatchScoreFixture.serialNumber
+  )
+  #expect(score == 0)
 }

--- a/CandelaKit/Tests/CandelaKitTests/DisplayModeSnapshotTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DisplayModeSnapshotTests.swift
@@ -1,0 +1,90 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import CandelaKit
+
+/// Shaped like the real configurator: `nativePixels(for:)` looks into its own
+/// mode list, so a snapshot answering from a sorted view would disagree with it.
+private struct TwoNativeConfigurator: DisplayConfiguring {
+  let list: [DisplayMode]
+
+  func displays() -> [ConfiguredDisplay] { [] }
+  func modes(for _: CGDirectDisplayID) -> [DisplayMode] { list }
+  func currentMode(for _: CGDirectDisplayID) -> DisplayMode? { list.first }
+  func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)? {
+    DisplayModeSnapshot.nativePixels(in: modes(for: displayID))
+  }
+
+  func apply(_: DisplayMode, to _: CGDirectDisplayID, scope _: DisplayConfigScope) throws {}
+  func applyMirroring(_: [MirrorChange], scope _: DisplayConfigScope) throws {}
+  var revealsHiddenModes: Bool { false }
+  var guardsWireTiming: Bool { true }
+  func modesWithheldByWireTimingGuard(for _: CGDirectDisplayID) -> Int { 0 }
+  var canRotate: Bool { false }
+  func rotation(of _: CGDirectDisplayID) -> DisplayRotation? { .standard }
+  func applyRotation(_: DisplayRotation, to _: CGDirectDisplayID) throws {}
+}
+
+@Suite("Display mode snapshot")
+struct DisplayModeSnapshotTests {
+  /// The HiDPI half of a Retina pair, listed FIRST, with a smaller framebuffer
+  /// than its 1x sibling so enumeration order and sorted order answer
+  /// differently (on real hardware both share the panel's pixel count).
+  private static let flaggedHiDPI = DisplayMode(
+    ioModeID: 3, logicalWidth: 1512, logicalHeight: 982,
+    pixelWidth: 3024, pixelHeight: 1964, refreshHz: 60, isNative: true
+  )
+  private static let flaggedOneToOne = DisplayMode(
+    ioModeID: 1, logicalWidth: 3840, logicalHeight: 2160,
+    pixelWidth: 3840, pixelHeight: 2160, refreshHz: 60, isNative: true
+  )
+  private static let scaled = DisplayMode(
+    ioModeID: 2, logicalWidth: 1280, logicalHeight: 800,
+    pixelWidth: 1280, pixelHeight: 800, refreshHz: 60, isNative: false
+  )
+
+  private static let raw = [flaggedHiDPI, flaggedOneToOne, scaled]
+
+  @Test("Native pixels come from the first flagged mode in enumeration order")
+  func nativePixelsFollowEnumerationOrder() throws {
+    // The trap this pins: the catalog's sorted view puts the OTHER flagged mode
+    // first, so anything reading native pixels off `full` answers differently.
+    let sorted = DisplayModeCatalog.full(Self.raw)
+    #expect(sorted.first(where: \.isNative)?.ioModeID == Self.flaggedOneToOne.ioModeID)
+
+    let native = try #require(DisplayModeSnapshot.nativePixels(in: Self.raw))
+    #expect(native.width == Self.flaggedHiDPI.pixelWidth)
+    #expect(native.height == Self.flaggedHiDPI.pixelHeight)
+  }
+
+  /// The DEFAULT implementation only; `TwoNativeConfigurator` does not override
+  /// `modeSnapshot`. The real configurator's single-pass override is covered by
+  /// the tests over the expressions it shares with the four methods, and by the
+  /// hardware pass.
+  @Test("The protocol default answers by asking the four separate calls")
+  func protocolDefaultAsksTheFourSeparateCalls() throws {
+    let configurator = TwoNativeConfigurator(list: Self.raw)
+    let displayID: CGDirectDisplayID = 4
+
+    let snapshot = configurator.modeSnapshot(for: displayID)
+
+    #expect(snapshot.modes == configurator.modes(for: displayID))
+    #expect(snapshot.current == configurator.currentMode(for: displayID))
+    #expect(
+      snapshot.withheldByWireTimingGuard
+        == configurator.modesWithheldByWireTimingGuard(for: displayID))
+    let native = try #require(snapshot.nativePixels)
+    let separate = try #require(configurator.nativePixels(for: displayID))
+    #expect(native.width == separate.width)
+    #expect(native.height == separate.height)
+  }
+
+  @Test("No native-flagged mode means no native pixels, not zeros")
+  func noNativeFlagAnswersNil() {
+    #expect(DisplayModeSnapshot.nativePixels(in: [Self.scaled]) == nil)
+    #expect(DisplayModeSnapshot(
+      modes: [Self.scaled], current: Self.scaled, nativePixels: nil,
+      withheldByWireTimingGuard: 0
+    ).nativePixels == nil)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/PanelSpaceTransformTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PanelSpaceTransformTests.swift
@@ -313,6 +313,41 @@ struct PanelSpaceTransformTests {
         == [Double](repeating: 0, count: PanelGrid.cellCount))
   }
 
+  /// One re-bin per accepted capture is shared by the accumulator, the live view
+  /// and the nomination. Sound only while the re-bin is a pure function of grid
+  /// and transform and the accumulator books exactly what it returns; both are
+  /// pinned so a path-dependent re-bin fails here, not as a drifting exposure map.
+  @Test func theRebinIsOneValueEveryConsumerCanShare() {
+    let transform = PanelSpaceTransform(
+      displaySize: CGSize(width: 2160, height: 3840), rotation: .twoSeventy)
+    let cols = 48
+    let rows = 27
+    var display = [Double](repeating: 0, count: cols * rows)
+    for row in 0..<rows {
+      for col in 0..<cols {
+        // Structured, not uniform: a constant field re-bins to itself and would
+        // hide an orientation or weighting difference between two calls.
+        display[row * cols + col] = Double((row * 7 + col * 3) % 11) / 10
+      }
+    }
+
+    let first = transform.panelNativeGrid(fromDisplayGrid: display, cols: cols, rows: rows)
+    let second = transform.panelNativeGrid(fromDisplayGrid: display, cols: cols, rows: rows)
+    #expect(first == second)
+    #expect(first.count == PanelGrid.cellCount)
+    #expect(first.contains { $0 > 0 })
+
+    var accumulator = ExposureAccumulator()
+    let elapsed: TimeInterval = 60
+    accumulator.accumulate(
+      displayGrid: display, cols: cols, rows: rows, through: transform,
+      elapsed: elapsed, at: Date(timeIntervalSince1970: 0))
+    #expect(accumulator.map.sampleCount == 1)
+    for cell in first.indices {
+      #expect(abs(accumulator.map.cells[cell] - first[cell] * elapsed) < 1e-12)
+    }
+  }
+
   @Test func theGridIsTwentyFourByTen() {
     #expect(PanelGrid.cols == 24)
     #expect(PanelGrid.rows == 10)

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -875,9 +875,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
-      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -894,13 +894,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
-      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -917,13 +917,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.1"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
-      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -931,7 +931,7 @@
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.2"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -941,9 +941,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
-      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
-      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
-      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
-      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
-      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -1035,9 +1035,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
-      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1055,9 +1055,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
-      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -1075,9 +1075,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
-      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
-      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -1115,9 +1115,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
-      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -1135,9 +1135,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
-      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -1157,13 +1157,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.1"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
-      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1183,13 +1183,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.1"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
-      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1209,13 +1209,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
-      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -1235,13 +1235,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
-      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -1261,13 +1261,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.1"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
-      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -1287,13 +1287,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.1"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
-      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -1313,13 +1313,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
-      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -1339,18 +1339,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
-      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1360,9 +1360,9 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
-      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
@@ -1370,7 +1370,7 @@
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.2"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1380,9 +1380,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
-      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1400,9 +1400,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
-      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
-      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -3433,15 +3433,15 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
-      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.8.4"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -3450,31 +3450,36 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.2",
-        "@img/sharp-darwin-x64": "0.35.2",
-        "@img/sharp-freebsd-wasm32": "0.35.2",
-        "@img/sharp-libvips-darwin-arm64": "1.3.1",
-        "@img/sharp-libvips-darwin-x64": "1.3.1",
-        "@img/sharp-libvips-linux-arm": "1.3.1",
-        "@img/sharp-libvips-linux-arm64": "1.3.1",
-        "@img/sharp-libvips-linux-ppc64": "1.3.1",
-        "@img/sharp-libvips-linux-riscv64": "1.3.1",
-        "@img/sharp-libvips-linux-s390x": "1.3.1",
-        "@img/sharp-libvips-linux-x64": "1.3.1",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
-        "@img/sharp-linux-arm": "0.35.2",
-        "@img/sharp-linux-arm64": "0.35.2",
-        "@img/sharp-linux-ppc64": "0.35.2",
-        "@img/sharp-linux-riscv64": "0.35.2",
-        "@img/sharp-linux-s390x": "0.35.2",
-        "@img/sharp-linux-x64": "0.35.2",
-        "@img/sharp-linuxmusl-arm64": "0.35.2",
-        "@img/sharp-linuxmusl-x64": "0.35.2",
-        "@img/sharp-webcontainers-wasm32": "0.35.2",
-        "@img/sharp-win32-arm64": "0.35.2",
-        "@img/sharp-win32-ia32": "0.35.2",
-        "@img/sharp-win32-x64": "0.35.2"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/siginfo": {

--- a/site/package.json
+++ b/site/package.json
@@ -34,5 +34,10 @@
     "vite": "^8.2.0",
     "vitest": "^4.1.11",
     "wrangler": "^4.127.1"
+  },
+  "overrides": {
+    "miniflare": {
+      "sharp@0.35.2": "0.35.4"
+    }
   }
 }


### PR DESCRIPTION
Addresses #76 and the enumeration and stored-mode clauses of #54.

Every change here produces the same result as before; what changes is how many times a value is computed, which thread computes it, or whether work continues while nobody can see its surface.

## What changed

- **OLED care tick.** The 60 second sampling throttle now runs ahead of the qualification check, so the battery-state read stays at the decision point its comment always claimed. The display-asleep query is asked once per display per tick. The panel-space grid is re-binned once per accepted sample and shared with the nomination rule. The slow tick carries a small sleep tolerance so the kernel can coalesce it (200 ms on the 2 second cadence; the 100 ms restore gate keeps zero). ScreenCaptureKit content is enumerated once per sampling pass instead of once per enrolled display, our own windows are excluded by owner at capture time (which also closes a pre-existing gap where an overlay created between enumeration and capture entered the sample), and the luminance reduction runs off the main actor.
- **Mode catalog.** One snapshot on the configuring protocol answers the mode list, the current mode, the native pixel size and the wire-timing withheld count from a single enumeration, where each refresh previously enumerated four times. The stored-mode reapply returns before enumerating when nothing is stored. Tests pin the enumeration counts and the ordering trap on displays that carry two native-flagged modes.
- **DDC discovery and diagnostics.** The CoreDisplay info record is built once per display rather than once per display-and-service pair, with the scoring arithmetic pinned by tests. The drag-rate diagnostic's start and coalescer lines move to the debug level; the write-end line stays at info as the persisted evidence that a write happened.
- **Settings surfaces.** The settings shell publishes its window visibility, and the About float, the measuring dot and the OLED Care chrome poll stop while the window is occluded and resume when it is visible again. The float's moving and still states are two different views, because a repeating animation attached to a view attribute could not be stopped on macOS 26 by writing the value with animations disabled (which is also how the Reduce Motion path tried to stop it) nor by replacing the animation on the value; only removing the attribute stops it. The display-sleep probe spawns `pmset` in a detached task instead of blocking the main actor for about 79 ms, and the General pane resolves the launch-at-login status once per render pass, still read live every time.

## Verified on hardware (2026-09-09, two externals, OLED enrolled)

- About pane visible: 27 to 30% CPU. About pane fully covered by another app's window: 0.0 to 0.1%, resuming on uncover. General pane covered: 0.0 to 0.3% (control).
- Luminance reduction on a utility worker thread, never on main (65 s sample at 1 ms). The capture filter's inclusion semantics A/B'd in one process on the same desktop: old and new forms agree on mean luminance to five decimals on all three displays; excluding the wallpaper windows moves the mean by a large margin (control).
- One resolution change plus revert: catalog rows identical before and after; a held change to 2160x3840 at 60 Hz shows in the rows while applied and the original mode after put-back.
- Two posted brightness keys: persisted write-end count rises 0 to 2 at info on both builds; start and coalescer lines 2 each on 1.0.3, 0 here.
- Idle, window closed: 0.0 to 0.2% on both builds.

Full record, controls and the legs that still need a hand are on #76. Suites: CandelaKit 2520 tests, app bundle 596 tests.