### PR TITLE
Make contributor builds and CI verification reproducible

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,15 +18,6 @@
 name: Build and test
 
 on:
-  # push is restricted to main while pull_request carries everything else, and
-  # the split is deliberate rather than copied. A workflow triggered by an
-  # unrestricted push AND by pull_request runs twice on every commit to an open
-  # PR's branch. macOS runner minutes are the expensive ones here, so a
-  # duplicate run would be the costliest thing in the pipeline and would buy no
-  # signal at all.
-  #
-  # paths-ignore holds only what no job below reads. Keep the push and
-  # pull_request lists identical.
   push:
     branches: [main]
     paths-ignore:
@@ -38,21 +29,10 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - '.github/workflows/site.yml'
+  # Every PR gets a result. Suite selection below avoids macOS work for docs and site changes.
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'site/**'
-      - 'LICENSE'
-      - '.github/assets/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
-      - '.github/workflows/site.yml'
   workflow_dispatch:
-
-# `paths-ignore:`, never `paths:`. A stale allow-list hides a real break as
-# green; a stale ignore-list only costs one extra run.
 
 permissions:
   contents: read
@@ -72,7 +52,24 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      app: ${{ steps.scope.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Test suite selection and result handling
+        run: python3 tools/ci/test_verification.py
+      - name: Select suites
+        id: scope
+        run: python3 tools/ci/verification.py scope >> "$GITHUB_OUTPUT"
+
   test:
+    needs: scope
+    if: needs.scope.outputs.app == 'true'
     # Pinned to macos-26, not macos-latest, and matched to the dev machine's
     # major version on purpose. The label decides which Swift compiler runs, and
     # a compiler older than the one the code is written against produces reds
@@ -202,6 +199,8 @@ jobs:
   # window presentation, reset ordering, `SMAppService` registration, TCC
   # grants. Those need a launched app in front of a person and stay manual.
   app-build:
+    needs: scope
+    if: needs.scope.outputs.app == 'true'
     # Not `needs: test`. They are independent questions and running them in
     # parallel answers both on every push, where chaining would hide a build
     # break behind an unrelated test failure and cost a second round trip to
@@ -245,6 +244,9 @@ jobs:
 
       # project.yml is the source of truth and Candela.xcodeproj is gitignored,
       # so CI has to generate it exactly as a developer does.
+      - name: Test contributor build and Release verification tools
+        run: python3 -m unittest discover -s tools/build -p 'test_*.py'
+
       - name: Generate the project
         run: xcodegen generate
 
@@ -386,6 +388,8 @@ jobs:
   # certificate, so it builds with the same signing override app-build uses.
   # Signing, the hardened runtime and notarisation stay verified at deploy time.
   release-build:
+    needs: scope
+    if: needs.scope.outputs.app == 'true'
     runs-on: macos-26
     timeout-minutes: 30
     steps:
@@ -428,52 +432,18 @@ jobs:
             -configuration Release -derivedDataPath "$RUNNER_TEMP/dd-release" build \
             CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM=""
 
-      # The debug-marker grep, plus a positive control, because as usually
-      # written this check cannot fail: a grep pointed at the wrong path returns
-      # zero and reads exactly like a clean build.
-      #
-      # Two measured traps. `strings` without -a misses sections; it once found
-      # the bundle identifier and missed a SwiftUI literal in the same binary.
-      # And Swift stores literals of 15 UTF-8 bytes or fewer inline in the code
-      # rather than in a string section, out of reach, so keep the control
-      # literal and every marker longer than that.
       - name: Debug markers are absent from the Release build
-        shell: bash
-        run: |
-          set -euo pipefail
-          app="$RUNNER_TEMP/dd-release/Build/Products/Release/Candela.app"
-          bin="$app/Contents/MacOS/Candela"
+        run: tools/build/check-release-markers.sh "$RUNNER_TEMP/dd-release/Build/Products/Release/Candela.app"
 
-          if [ ! -x "$bin" ]; then
-            echo "::error::Release build reported success but produced no executable at $bin. Nothing below would be measuring the shipped product."
-            exit 1
-          fi
-          echo "Scanning: $(file -b "$bin")"
-          echo "  sha256: $(shasum -a 256 "$bin" | cut -d' ' -f1)"
-
-          # grep -c exits 1 on no match, which pipefail would turn into a job
-          # failure before the count could be read. It still prints the 0.
-          control="$(strings -a "$bin" | grep -c 'Where this display has been lit' || true)"
-          if [ "$control" -eq 0 ]; then
-            echo "::error::Positive control found none of a literal that is definitely in the app. strings is not reading this binary, so a zero marker count below would mean nothing. Fix the method, not the build."
-            exit 1
-          fi
-          echo "Positive control OK: the control literal is visible to strings ($control hit(s))."
-
-          # Every Mach-O in the bundle, not just the main executable: a marker
-          # compiled into an embedded framework ships just as surely.
-          found=0
-          while IFS= read -r macho; do
-            hits="$(strings -a "$macho" | grep -c 'CANDELA_DEBUG' || true)"
-            if [ "$hits" -ne 0 ]; then
-              echo "::error::${macho#"$app/"} carries $hits CANDELA_DEBUG marker reference(s) in a Release build."
-              strings -a "$macho" | grep 'CANDELA_DEBUG' | sort -u | sed 's/^/    /'
-              found=$(( found + hits ))
-            fi
-          done < <(find "$app" -type f -exec sh -c 'file -b "$1" | grep -q "Mach-O" && printf "%s\n" "$1"' _ {} \;)
-
-          if [ "$found" -ne 0 ]; then
-            echo "::error::$found debug-marker reference(s) reached the Release build. An env-var switch or diagnostic added while iterating has not come back out."
-            exit 1
-          fi
-          echo "No CANDELA_DEBUG markers in any Mach-O in the bundle."
+  verification:
+    name: App verification
+    if: ${{ always() }}
+    needs: [scope, test, app-build, release-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require every selected app job to pass
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: python3 tools/ci/verification.py gate app

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,9 +10,6 @@ on:
       - '.github/workflows/site.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'site/**'
-      - '.github/workflows/site.yml'
   workflow_dispatch:
 
 permissions:
@@ -23,7 +20,24 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      site: ${{ steps.scope.outputs.site }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Test suite selection and result handling
+        run: python3 tools/ci/test_verification.py
+      - name: Select suites
+        id: scope
+        run: python3 tools/ci/verification.py scope >> "$GITHUB_OUTPUT"
+
   site:
+    needs: scope
+    if: needs.scope.outputs.site == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -51,3 +65,16 @@ jobs:
       # build time and is where a broken import or a bad asset path surfaces.
       - name: Build
         run: npm run build
+
+  verification:
+    name: Site verification
+    if: ${{ always() }}
+    needs: [scope, site]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require the selected site job to pass
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: python3 tools/ci/verification.py gate site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,19 +19,35 @@ security problem, do not open an issue: see [SECURITY.md](SECURITY.md).
 
 ## Building
 
+Install Xcode 26 or later, including its macOS 26 SDK and command-line tools.
+The app runs on macOS 14 or later, but compiling it requires the newer SDK.
+Select that Xcode installation in Xcode > Settings > Locations > Command Line
+Tools before building.
+
 The Xcode project is generated and not checked in. Edit `project.yml`, never
-the `.xcodeproj`.
+the `.xcodeproj`. App builds and tests regenerate it automatically so added,
+renamed, and removed source files stay in sync.
 
 ```sh
 brew install xcodegen
-make            # lists the targets
-make build      # Debug build of the app
-make check      # both test suites: the engine (swift test) and the app bundle
+make                       # lists the targets
+make build SIGNING=adhoc    # Debug build without a Developer ID certificate
+make check                 # both test suites: the engine and the app bundle
 ```
 
+Use `make release SIGNING=adhoc` for a Release build, or `make markers
+SIGNING=adhoc` to also check it for debug markers. Build products and the
+incremental build cache stay in `DerivedData/` within each checkout.
+
+Ad-hoc builds are for local testing only. Rebuilding can require granting
+Accessibility permission again. These commands only build the app; they do
+not install or launch it. The default, `SIGNING=developer-id`, preserves the
+project's maintainer Developer ID certificate and team settings.
+
 `make test-app` runs the app suite without launching the app, so it is safe
-with monitors attached. The engine suite is fast whole; do not filter it. Both
-suites and a Release build run in CI on every pull request.
+with monitors attached. The engine suite is fast whole; do not filter it.
+App changes run both suites and a Release build in CI. Documentation and site
+changes receive explicit gate results for the checks relevant to their scope.
 
 For a hardware smoke test with no UI, `cd CandelaKit && swift run
 candela-probe` prints the usage. It covers brightness, volume, contrast, DDC

--- a/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/BrightnessPollerTests.swift
@@ -297,32 +297,33 @@ private func makePoller(
   task.cancel()
   #expect(started)
   // The idle interval here is the FAST one, so a poller that ignored the slow
-  // cadence would be at ~50 reads. The control below proves this window can carry
-  // them.
+  // cadence would be at ~50 reads.
   #expect(probe.reads.count <= 4)
 }
 
 @Test func aSurfaceAppearingShortensTheNextIntervalWithNoRestart() async {
   let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
-  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .milliseconds(200))
-  let task = Task { await poller.run() }
-  _ = await waitUntil { !probe.reads.isEmpty }
-  // Flipped mid-run, on the SAME poll job: the cadence is re-read every tick, so
-  // nothing restarts it.
+  let poller = makePoller(probe, idle: .milliseconds(5), slowIdle: .seconds(30))
+  #expect(await poller.pollOnce() == .seconds(30))
+  // Change the signal on the same job so a cached launch-time answer cannot pass.
   probe.setSurfaceVisible(true)
-  let sped = await waitUntil { probe.reads.count >= 20 }
-  task.cancel()
-  #expect(sped)
+  #expect(await poller.pollOnce() == .milliseconds(5))
+  probe.setSurfaceVisible(false)
+  #expect(await poller.pollOnce() == .seconds(30))
+  #expect(probe.reads.count == 3)
+  #expect(probe.adoptions.isEmpty)
 }
 
 @Test func syncOnKeepsTheShortIntervalWithNoExternalNative() async {
   let probe = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false)
+  let poller = makePoller(probe, idle: .milliseconds(5), slowIdle: .seconds(30))
   probe.setSyncEnabled(true)
-  let poller = makePoller(probe, fast: .milliseconds(5), idle: .milliseconds(5), slowIdle: .seconds(30))
-  let task = Task { await poller.run() }
-  let sped = await waitUntil { probe.reads.count >= 20 }
-  task.cancel()
-  #expect(sped)
+  #expect(await poller.pollOnce() == .milliseconds(5))
+  #expect(await poller.pollOnce() == .milliseconds(5))
+  probe.setSyncEnabled(false)
+  #expect(await poller.pollOnce() == .seconds(30))
+  #expect(probe.reads.count == 3)
+  #expect(probe.adoptions.isEmpty)
 }
 
 @Test func batteryLengthensTheSlowIntervalFurther() async {
@@ -407,13 +408,15 @@ private func makePoller(
 @Test func aNativeExternalDoesHoldTheShortInterval() async {
   let external = Probe(expected: 0.5, generation: 1, hardware: 0.5, displayID: 8)
   let builtIn = Probe(expected: 0.5, generation: 1, hardware: 0.5, isExternal: false, displayID: 9)
-  let poller = makePoller(
-    [builtIn, external], fast: .milliseconds(5), idle: .milliseconds(5),
-    slowIdle: .seconds(30))
-  let task = Task { await poller.run() }
-  let sped = await waitUntil { builtIn.reads.count >= 20 }
-  task.cancel()
-  #expect(sped)
+  let poller = makePoller([builtIn, external], idle: .milliseconds(5), slowIdle: .seconds(30))
+  #expect(await poller.pollOnce() == .milliseconds(5))
+  #expect(await poller.pollOnce() == .milliseconds(5))
+  external.setNativeActive(false)
+  #expect(await poller.pollOnce() == .seconds(30))
+  #expect(builtIn.reads.count == 3)
+  #expect(external.reads.count == 2)
+  #expect(builtIn.adoptions.isEmpty)
+  #expect(external.adoptions.isEmpty)
 }
 
 /// The poll job must survive every idle state: an external entering HDR reaches

--- a/Makefile
+++ b/Makefile
@@ -17,61 +17,54 @@ SHELL := /bin/bash
 
 DD       ?= DerivedData
 PROJ     := Candela.xcodeproj
-PBXPROJ  := $(PROJ)/project.pbxproj
 SCHEME   := Candela
 APPTESTS := CandelaAppTests
 XCB      := xcodebuild -project $(PROJ) -quiet
 REL_APP  := $(DD)/Build/Products/Release/Candela.app
 REL_BIN  := $(REL_APP)/Contents/MacOS/Candela
 
-# The Release debug-marker gate. The control MUST be found or the method is
-# broken and a zero marker count means nothing: a check whose failure mode is
-# silence is not a check. The control string is 31 bytes, clearing the 16-byte
-# floor below which `strings` cannot see a Swift literal at all.
-# The marker is a PREFIX. CANDELA_DEBUG alone is 13 bytes, inline-stored, and
-# `strings` can never emit it, so that grep could not fail; and the one switch
-# that ever reached a Release build was CANDELA_TOOLBAR_STYLE, which no
-# CANDELA_DEBUG grep would match. Every Mach-O in the bundle is scanned, not
-# just the main binary. All real switches are #if DEBUG-gated, so any hit in a
-# Release Mach-O is a defect.
-CONTROL := Where this display has been lit
-MARKER  := CANDELA_
+# Keep the project's Developer ID settings unless local ad-hoc signing is
+# explicitly requested. Clearing Release's timestamp flag also avoids needing
+# Apple's timestamp service for a contributor build.
+SIGNING ?= developer-id
+ifeq ($(SIGNING),developer-id)
+APP_SIGNING :=
+else ifeq ($(SIGNING),adhoc)
+APP_SIGNING := CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= OTHER_CODE_SIGN_FLAGS=
+else
+$(error Invalid SIGNING '$(SIGNING)'; use SIGNING=developer-id or SIGNING=adhoc)
+endif
 
 .PHONY: help build release test test-app check markers regen probe conform clean
 
 help:
 	@echo "Candela targets            (DD=$(DD))"
 	@echo ""
-	@echo "  make build       Debug build of the app"
-	@echo "  make release     Release build of the app"
+	@echo "  make build       Debug build of the app       (SIGNING=$(SIGNING))"
+	@echo "  make release     Release build of the app     (SIGNING=$(SIGNING))"
 	@echo "  make test        CandelaKit engine suite      (hardware-free)"
 	@echo "  make test-app    CandelaAppTests bundle       (host-free, safe with panels attached)"
 	@echo "  make check       Both suites"
 	@echo "  make markers     Release build + debug-marker gate with its positive control"
 	@echo "  make probe A='list'      candela-probe (run with no A= for its usage)"
 	@echo "  make conform     Platform-conformance suite; the exit code is the verdict"
-	@echo "  make regen       Force xcodegen generate"
+	@echo "  make regen       Run xcodegen generate"
 	@echo "  make clean       Remove $(DD)/ and CandelaKit/.build"
 	@echo ""
-	@echo "The xcodeproj regenerates automatically when project.yml is newer."
+	@echo "Contributors: make build SIGNING=adhoc (also works with release and markers)."
+	@echo "The xcodeproj regenerates before each app build or test to track source changes."
 
 # Generated and gitignored: never edit the xcodeproj by hand, edit project.yml.
-# Making it a real dependency is what stops a stale project from failing a build
-# for a reason that looks like a code error. It did exactly that on 2026-08-19:
-# project.yml carried the Sparkle merge, the generated project did not, and the
-# build failed with "cannot find 'UpdaterModel' in scope".
-$(PBXPROJ): project.yml
-	@echo "==> project.yml is newer than the generated project, regenerating"
-	@xcodegen generate
-
+# Directory membership can change without project.yml changing. Regenerate on
+# every app operation so additions, renames, and deletions reach both targets.
 regen:
 	@xcodegen generate
 
-build: $(PBXPROJ)
-	$(XCB) -scheme $(SCHEME) -configuration Debug -derivedDataPath $(DD) build
+build: regen
+	$(XCB) -scheme $(SCHEME) -configuration Debug -derivedDataPath $(DD) $(APP_SIGNING) build
 
-release: $(PBXPROJ)
-	$(XCB) -scheme $(SCHEME) -configuration Release -derivedDataPath $(DD) build
+release: regen
+	$(XCB) -scheme $(SCHEME) -configuration Release -derivedDataPath $(DD) $(APP_SIGNING) build
 
 # The engine suite is hardware-free and fast whole, so it is never worth
 # filtering: the saving is negligible and a filter can hide a regression
@@ -86,7 +79,7 @@ test:
 # prints "** TEST SUCCEEDED **" and exits 0 having executed zero tests
 # [MEASURED 2026-08-19, the same positive control the app-test-target work used].
 # The only honest evidence is the "Test run with N tests" line with N > 0.
-test-app: $(PBXPROJ)
+test-app: regen
 	@out=$$(xcodebuild -project $(PROJ) -scheme $(APPTESTS) -destination 'platform=macOS' \
 	          -derivedDataPath $(DD) test 2>&1); rc=$$?; \
 	summary=$$(echo "$$out" | grep -E "Test run with [0-9]+ test" | tail -1); \
@@ -104,37 +97,7 @@ test-app: $(PBXPROJ)
 check: test test-app
 
 markers: release
-	@set -euo pipefail; \
-	if [ ! -x "$(REL_BIN)" ]; then \
-	  echo "FAIL: no Release binary at $(REL_BIN)"; exit 1; \
-	fi; \
-	ctl=$$(strings -a "$(REL_BIN)" | grep -c "$(CONTROL)" || true); \
-	if [ "$$ctl" -eq 0 ]; then \
-	  echo "FAIL: positive control found nothing in $(REL_BIN)."; \
-	  echo "      The grep method or the path is wrong, so a clean marker"; \
-	  echo "      result would mean nothing. Fix the method, do not ship it."; \
-	  exit 1; \
-	fi; \
-	machos=$$(find "$(REL_APP)" -type f -print0 | xargs -0 file \
-	          | grep "Mach-O" | cut -d: -f1 \
-	          | sed 's/ (for architecture.*$$//' | sort -u); \
-	if [ -z "$$machos" ]; then \
-	  echo "FAIL: no Mach-O files found under $(REL_APP); the scan is broken."; exit 1; \
-	fi; \
-	nbin=0; hits=0; \
-	while IFS= read -r b; do \
-	  nbin=$$((nbin + 1)); \
-	  n=$$(strings -a "$$b" | grep -c "$(MARKER)" || true); \
-	  if [ "$$n" -ne 0 ]; then \
-	    hits=$$((hits + n)); \
-	    echo "FAIL: $$n debug marker(s) matching '$(MARKER)*' in $$b:"; \
-	    strings -a "$$b" | grep "$(MARKER)" | sort -u | sed 's/^/        /'; \
-	  fi; \
-	done <<< "$$machos"; \
-	[ "$$hits" -eq 0 ] || exit 1; \
-	echo "markers: control found ($$ctl hits), no '$(MARKER)*' in any of $$nbin Mach-Os. OK"; \
-	echo "         NOTE: strings cannot see a Swift literal of 15 bytes or fewer;"; \
-	echo "         name debug switches CANDELA_DEBUG_<thing> so they clear 16."
+	@tools/build/check-release-markers.sh "$(REL_APP)"
 
 A ?=
 probe:

--- a/tools/build/check-release-markers.sh
+++ b/tools/build/check-release-markers.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Scan every Mach-O in a Release app, including embedded frameworks.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 path/to/Candela.app" >&2
+  exit 2
+fi
+
+app=$1
+binary="$app/Contents/MacOS/Candela"
+# This positive control clears the 16-byte floor below which strings cannot
+# see a Swift literal. Without it, a clean marker count proves nothing.
+control='Where this display has been lit'
+# Scan the whole prefix: CANDELA_TOOLBAR_STYLE once reached a Release build
+# and would not have matched CANDELA_DEBUG. Real switches are DEBUG-gated.
+marker='CANDELA_'
+
+if [ ! -x "$binary" ]; then
+  echo "FAIL: no Release binary at $binary"
+  exit 1
+fi
+if ! contents=$(strings -a "$binary"); then
+  echo "FAIL: could not inspect strings in $binary"
+  exit 1
+fi
+ctl=$(grep -c "$control" <<< "$contents") || [ "$?" -eq 1 ]
+if [ "$ctl" -eq 0 ]; then
+  echo "FAIL: positive control found nothing in $binary."
+  echo "      The grep method or the path is wrong, so a clean marker"
+  echo "      result would mean nothing. Fix the method, do not ship it."
+  exit 1
+fi
+
+nbin=0
+hits=0
+# Complete discovery first so a traversal error cannot produce a clean scan.
+file_list=$(mktemp)
+trap 'rm -f "$file_list"' EXIT
+if ! find "$app" -type f -print0 > "$file_list"; then
+  echo "FAIL: could not enumerate files under $app"
+  exit 1
+fi
+while IFS= read -r -d '' b; do
+  if ! description=$(file -E -b "$b"); then
+    echo "FAIL: could not identify file type for $b"
+    exit 1
+  fi
+  if [[ "$description" != *Mach-O* ]]; then
+    continue
+  fi
+  nbin=$((nbin + 1))
+  if ! contents=$(strings -a "$b"); then
+    echo "FAIL: could not inspect strings in $b"
+    exit 1
+  fi
+  n=$(grep -c "$marker" <<< "$contents") || [ "$?" -eq 1 ]
+  if [ "$n" -ne 0 ]; then
+    hits=$((hits + n))
+    echo "FAIL: $n debug marker(s) matching '$marker*' in $b:"
+    grep "$marker" <<< "$contents" | sort -u | sed 's/^/        /'
+  fi
+done < "$file_list"
+if [ "$nbin" -eq 0 ]; then
+  echo "FAIL: no Mach-O files found under $app; the scan is broken."
+  exit 1
+fi
+[ "$hits" -eq 0 ] || exit 1
+echo "markers: control found ($ctl hits), no '$marker*' in any of $nbin Mach-Os. OK"
+echo "         NOTE: strings cannot see a Swift literal of 15 bytes or fewer;"
+echo "         name debug switches CANDELA_DEBUG_<thing> so they clear 16."

--- a/tools/build/test_makefile.py
+++ b/tools/build/test_makefile.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Build command regressions using disposable projects and real Mach-O files.
+
+Requires Xcode command-line tools and XcodeGen. The xcodebuild process is
+replaced with an argument recorder; no app is built, installed, or launched.
+"""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class MakefileTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="candela-build-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        for name in ("Makefile", "project.yml"):
+            shutil.copy2(ROOT / name, self.root / name)
+        checker = ROOT / "tools/build/check-release-markers.sh"
+        if checker.exists():
+            (self.root / "tools/build").mkdir(parents=True)
+            shutil.copy2(checker, self.root / "tools/build")
+        for name in ("Candela", "CandelaAppTests", "CandelaKit", "bin"):
+            (self.root / name).mkdir()
+        (self.root / "Candela/App.swift").write_text("struct App {}\n")
+        (self.root / "CandelaAppTests/AppTests.swift").write_text("struct AppTests {}\n")
+        self.calls = self.root / "calls.jsonl"
+        recorder = self.root / "bin/xcodebuild"
+        recorder.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys\n"
+            "with open(os.environ['BUILD_TEST_CALLS'], 'a') as output:\n"
+            "    output.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+            "if 'test' in sys.argv:\n"
+            "    print('Test run with 1 test passed after 0.001 seconds.')\n"
+        )
+        recorder.chmod(0o755)
+        self.env = os.environ.copy()
+        self.env["PATH"] = str(self.root / "bin") + os.pathsep + self.env["PATH"]
+        self.env["BUILD_TEST_CALLS"] = str(self.calls)
+        self.run_command(["xcodegen", "generate"])
+
+    def run_command(self, command, *, succeeds=True):
+        result = subprocess.run(
+            command, cwd=self.root, env=self.env,
+            text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        if succeeds:
+            self.assertEqual(result.returncode, 0, result.stdout)
+        else:
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def make(self, *arguments, succeeds=True):
+        return self.run_command(["make", "-f", "Makefile", *arguments], succeeds=succeeds)
+
+    def last_build(self):
+        return json.loads(self.calls.read_text().splitlines()[-1])
+
+    def sources(self, target_name):
+        project = self.run_command([
+            "plutil", "-convert", "json", "-o", "-",
+            "Candela.xcodeproj/project.pbxproj",
+        ])
+        objects = json.loads(project.stdout)["objects"]
+        target = next(obj for obj in objects.values()
+                      if obj.get("isa") == "PBXNativeTarget" and obj["name"] == target_name)
+        result = set()
+        for phase_id in target["buildPhases"]:
+            phase = objects[phase_id]
+            if phase["isa"] == "PBXSourcesBuildPhase":
+                for file_id in phase["files"]:
+                    result.add(objects[objects[file_id]["fileRef"]]["path"])
+        return result
+
+    def test_default_signing_preserves_project_settings(self):
+        for target in ("build", "release"):
+            for options in ([], ["SIGNING=developer-id"]):
+                with self.subTest(target=target, options=options):
+                    self.make(target, *options)
+                    args = self.last_build()
+                    self.assertEqual(args[args.index("-derivedDataPath") + 1], "DerivedData")
+                    self.assertFalse(any(arg.startswith(("CODE_SIGN", "DEVELOPMENT_TEAM=",
+                                                          "OTHER_CODE_SIGN_FLAGS="))
+                                         for arg in args), args)
+
+    def test_adhoc_signing_removes_certificate_team_and_timestamp_requirements(self):
+        for target, configuration in (("build", "Debug"), ("release", "Release")):
+            with self.subTest(target=target):
+                self.make(target, "SIGNING=adhoc")
+                args = self.last_build()
+                for setting in ("CODE_SIGN_IDENTITY=-", "CODE_SIGN_STYLE=Manual",
+                                "DEVELOPMENT_TEAM=", "OTHER_CODE_SIGN_FLAGS="):
+                    self.assertIn(setting, args)
+                self.assertEqual(args[args.index("-configuration") + 1], configuration)
+                self.assertEqual(args[args.index("-derivedDataPath") + 1], "DerivedData")
+
+    def test_invalid_signing_fails_before_building(self):
+        for value in ("", "ad-hoc", "adhoc developer-id"):
+            with self.subTest(value=value):
+                result = self.make("build", f"SIGNING={value}", succeeds=False)
+                self.assertIn("SIGNING", result.stdout)
+                self.assertIn("adhoc", result.stdout)
+                self.assertIn("developer-id", result.stdout)
+                self.assertFalse(self.calls.exists())
+
+    def test_test_app_uses_only_the_host_free_scheme_without_signing_overrides(self):
+        for signing in ("developer-id", "adhoc"):
+            with self.subTest(signing=signing):
+                self.make("test-app", f"SIGNING={signing}")
+                args = self.last_build()
+                self.assertEqual(args[args.index("-scheme") + 1], "CandelaAppTests")
+                self.assertEqual(args[-1], "test")
+                self.assertFalse(any(arg.startswith(("CODE_SIGN", "DEVELOPMENT_TEAM=",
+                                                      "OTHER_CODE_SIGN_FLAGS="))
+                                     for arg in args), args)
+
+    def test_source_membership_tracks_additions_renames_and_deletions(self):
+        original_mtime = (self.root / "project.yml").stat().st_mtime_ns
+        app_file = self.root / "Candela/AddedApp.swift"
+        test_file = self.root / "CandelaAppTests/AddedTest.swift"
+        app_file.write_text("struct AddedApp {}\n")
+        test_file.write_text("struct AddedTest {}\n")
+        self.make("build")
+        self.assertIn("AddedApp.swift", self.sources("Candela"))
+        self.assertIn("AddedApp.swift", self.sources("CandelaAppTests"))
+        self.assertIn("AddedTest.swift", self.sources("CandelaAppTests"))
+        self.assertNotIn("AddedTest.swift", self.sources("Candela"))
+
+        renamed_app = app_file.with_name("RenamedApp.swift")
+        renamed_test = test_file.with_name("RenamedTest.swift")
+        app_file.rename(renamed_app)
+        test_file.rename(renamed_test)
+        self.make("release")
+        self.assertIn("RenamedApp.swift", self.sources("Candela"))
+        self.assertIn("RenamedTest.swift", self.sources("CandelaAppTests"))
+        self.assertNotIn("AddedApp.swift", self.sources("Candela"))
+        self.assertNotIn("AddedTest.swift", self.sources("CandelaAppTests"))
+
+        renamed_app.unlink()
+        renamed_test.unlink()
+        self.make("test-app")
+        self.assertNotIn("RenamedApp.swift", self.sources("Candela"))
+        self.assertNotIn("RenamedApp.swift", self.sources("CandelaAppTests"))
+        self.assertNotIn("RenamedTest.swift", self.sources("CandelaAppTests"))
+        self.assertEqual((self.root / "project.yml").stat().st_mtime_ns, original_mtime)
+
+    def compile_binary(self, relative_path, message):
+        binary = self.root / "DerivedData/Build/Products/Release/Candela.app" / relative_path
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        source = self.root / "fixture.c"
+        source.write_text(f"#include <stdio.h>\nint main(void) {{ puts({json.dumps(message)}); }}\n")
+        self.run_command(["clang", str(source), "-o", str(binary)])
+
+    def test_markers_accept_clean_release_and_forward_adhoc_signing(self):
+        self.compile_binary("Contents/MacOS/Candela", "Where this display has been lit")
+        self.make("markers", "SIGNING=adhoc")
+        args = self.last_build()
+        self.assertEqual(args[args.index("-configuration") + 1], "Release")
+        self.assertIn("CODE_SIGN_IDENTITY=-", args)
+
+    def test_markers_reject_marker_in_nested_macho(self):
+        self.compile_binary("Contents/MacOS/Candela", "Where this display has been lit")
+        self.compile_binary("Contents/Frameworks/Nested Framework.framework/Nested",
+                            "CANDELA_TOOLBAR_STYLE")
+        result = self.make("markers", succeeds=False)
+        self.assertIn("CANDELA_TOOLBAR_STYLE", result.stdout)
+        self.assertIn("Nested Framework.framework/Nested", result.stdout)
+
+    def test_markers_reject_missing_control(self):
+        self.compile_binary("Contents/MacOS/Candela", "A clean binary without the control")
+        result = self.make("markers", succeeds=False)
+        self.assertIn("positive control", result.stdout)
+
+    def test_markers_reject_missing_product(self):
+        result = self.make("markers", succeeds=False)
+        self.assertIn("no Release binary", result.stdout)
+
+    def test_markers_reject_product_without_machos(self):
+        binary = self.root / "DerivedData/Build/Products/Release/Candela.app/Contents/MacOS/Candela"
+        binary.parent.mkdir(parents=True)
+        binary.write_text("#!/bin/sh\necho 'Where this display has been lit'\n")
+        binary.chmod(0o755)
+        result = self.make("markers", succeeds=False)
+        self.assertIn("no Mach-O files", result.stdout)
+
+    def test_markers_reject_inspection_tool_failures(self):
+        self.compile_binary("Contents/MacOS/Candela", "Where this display has been lit")
+        self.compile_binary("Contents/Frameworks/Nested", "No debug switches here")
+        for tool in ("find", "file", "strings"):
+            with self.subTest(tool=tool):
+                stub = self.root / "bin" / tool
+                actual_tool = shutil.which(tool)
+                # strings must succeed on the positive control, then fail on
+                # an embedded binary that the gate must not silently skip.
+                stub.write_text(
+                    "#!/bin/bash\n"
+                    "if [[ \"$*\" == *Contents/MacOS/Candela* ]]; then\n"
+                    f"  exec {actual_tool} \"$@\"\n"
+                    "fi\n"
+                    "echo 'fixture inspection failure' >&2\nexit 2\n"
+                )
+                stub.chmod(0o755)
+                try:
+                    result = self.make("markers", succeeds=False)
+                    self.assertIn("fixture inspection failure", result.stdout)
+                finally:
+                    stub.unlink()
+
+    def test_markers_reject_file_disappearing_before_inspection(self):
+        self.compile_binary("Contents/MacOS/Candela", "Where this display has been lit")
+        self.compile_binary("Contents/Frameworks/Disappearing", "No debug switches here")
+        wrapper = self.root / "bin/file"
+        actual_file = shutil.which("file")
+        # Use the real file command's handling of a missing path: macOS file
+        # reports the error on stdout and exits 0 unless error mode is enabled.
+        wrapper.write_text(
+            "#!/bin/bash\n"
+            "if [[ \"${!#}\" == *Contents/Frameworks/Disappearing ]]; then\n"
+            "  rm -- \"${!#}\"\n"
+            "fi\n"
+            f"exec {actual_file} \"$@\"\n"
+        )
+        wrapper.chmod(0o755)
+        result = self.make("markers", succeeds=False)
+        self.assertIn("could not identify file type", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/ci/test_verification.py
+++ b/tools/ci/test_verification.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Regression checks for selecting suites and rejecting incomplete CI results."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from verification import classify, verify
+
+SCRIPT = Path(__file__).with_name('verification.py')
+
+
+class ScopeTests(unittest.TestCase):
+    def test_documentation_needs_no_expensive_suite(self):
+        self.assertEqual(classify(['README.md', 'docs/guide/checkup.md', '.github/assets/icon.png']), (False, False))
+
+    def test_site_includes_its_markdown_and_configuration(self):
+        self.assertEqual(classify(['site/src/content/guides/oled.md', 'site/package-lock.json']), (False, True))
+
+    def test_app_and_unknown_files_require_app_verification(self):
+        for name in ['Candela/New.swift', 'CandelaAppTests/New.swift', 'CandelaKit/Package.swift', 'project.yml', 'Makefile', 'new-build-config']:
+            with self.subTest(name=name):
+                self.assertEqual(classify([name]), (True, False))
+
+    def test_workflow_or_selection_changes_exercise_both_suites(self):
+        for name in ['.github/workflows/site.yml', '.github/workflows/build-and-test.yml', 'tools/ci/verification.py']:
+            with self.subTest(name=name):
+                self.assertEqual(classify([name]), (True, True))
+
+    def test_mixed_changes_require_both(self):
+        self.assertEqual(classify(['Candela/New.swift', 'site/src/App.tsx']), (True, True))
+
+    def test_no_changes_can_skip_both(self):
+        self.assertEqual(classify([]), (False, False))
+
+    def test_cli_counts_removed_side_of_a_rename(self):
+        with tempfile.TemporaryDirectory() as folder:
+            root = Path(folder)
+            def git(*args):
+                return subprocess.run(['git', *args], cwd=root, check=True, capture_output=True)
+            git('init', '-q')
+            git('config', 'user.name', 'Fixture')
+            git('config', 'user.email', 'fixture@example.invalid')
+            (root / 'Old.swift').write_text('same content\n')
+            git('add', '.')
+            git('commit', '-qm', 'initial')
+            (root / 'Old.swift').rename(root / 'README.md')
+            git('add', '-A')
+            git('commit', '-qm', 'rename')
+            result = subprocess.run(['python3', str(SCRIPT), 'scope'], cwd=root,
+                                    env={**os.environ, 'GITHUB_EVENT_NAME': 'pull_request'},
+                                    capture_output=True, text=True, check=True)
+            self.assertIn('app=true', result.stdout)
+            self.assertIn('site=false', result.stdout)
+
+    def test_merge_commit_covers_all_pr_commits(self):
+        with tempfile.TemporaryDirectory() as folder:
+            root = Path(folder)
+            def git(*args):
+                return subprocess.run(['git', *args], cwd=root, check=True, capture_output=True)
+            git('init', '-q', '-b', 'main')
+            git('config', 'user.name', 'Fixture')
+            git('config', 'user.email', 'fixture@example.invalid')
+            (root / 'README.md').write_text('base\n')
+            git('add', '.')
+            git('commit', '-qm', 'initial')
+            git('checkout', '-qb', 'change')
+            (root / 'New.swift').write_text('source\n')
+            git('add', '.')
+            git('commit', '-qm', 'source first')
+            (root / 'README.md').write_text('updated docs\n')
+            git('add', '.')
+            git('commit', '-qm', 'docs last')
+            git('checkout', '-q', 'main')
+            git('merge', '--no-ff', '-qm', 'PR merge', 'change')
+            result = subprocess.run(['python3', str(SCRIPT), 'scope'], cwd=root,
+                                    env={**os.environ, 'GITHUB_EVENT_NAME': 'pull_request'},
+                                    capture_output=True, text=True, check=True)
+            self.assertIn('app=true', result.stdout)
+
+    def test_missing_git_parent_fails_instead_of_skipping(self):
+        with tempfile.TemporaryDirectory() as folder:
+            result = subprocess.run(['python3', str(SCRIPT), 'scope'], cwd=folder,
+                                    env={**os.environ, 'GITHUB_EVENT_NAME': 'pull_request'},
+                                    capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn('app=false', result.stdout)
+
+    def test_manual_or_push_run_requires_both(self):
+        for event in ['workflow_dispatch', 'push']:
+            result = subprocess.run(['python3', str(SCRIPT), 'scope'],
+                                    env={**os.environ, 'GITHUB_EVENT_NAME': event},
+                                    capture_output=True, text=True, check=True)
+            self.assertEqual(result.stdout, 'app=true\nsite=true\n')
+
+
+class GateTests(unittest.TestCase):
+    def needs(self, required='true', result='success', scope='success', suite='app'):
+        names = ['test', 'app-build', 'release-build'] if suite == 'app' else ['site']
+        return {'scope': {'result': scope, 'outputs': {suite: required}},
+                **{name: {'result': result} for name in names}}
+
+    def test_completed_suites_pass(self):
+        for suite in ['app', 'site']:
+            verify(self.needs(suite=suite), suite)
+
+    def test_explicitly_unneeded_suites_may_skip(self):
+        for suite in ['app', 'site']:
+            verify(self.needs(required='false', result='skipped', suite=suite), suite)
+
+    def test_every_required_job_must_succeed(self):
+        for job in ['test', 'app-build', 'release-build']:
+            for result in ['failure', 'cancelled', 'skipped', '']:
+                with self.subTest(job=job, result=result):
+                    needs = self.needs()
+                    needs[job]['result'] = result
+                    with self.assertRaises(ValueError):
+                        verify(needs, 'app')
+
+    def test_failed_or_missing_scope_cannot_pass(self):
+        for result in ['failure', 'cancelled', 'skipped', '']:
+            with self.assertRaises(ValueError):
+                verify(self.needs(scope=result), 'app')
+        with self.assertRaises(ValueError):
+            verify({}, 'app')
+
+    def test_invalid_scope_output_or_missing_jobs_cannot_pass(self):
+        for required in ['', 'maybe', None]:
+            with self.assertRaises(ValueError):
+                verify(self.needs(required=required), 'app')
+        needs = self.needs()
+        del needs['test']
+        with self.assertRaises(ValueError):
+            verify(needs, 'app')
+
+    def test_site_failure_is_not_hidden(self):
+        with self.assertRaises(ValueError):
+            verify(self.needs(result='failure', suite='site'), 'site')
+
+    def test_cli_reports_failure(self):
+        result = subprocess.run(['python3', str(SCRIPT), 'gate', 'app'],
+                                env={**os.environ, 'NEEDS_JSON': json.dumps(self.needs(result='failure'))},
+                                capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/ci/verification.py
+++ b/tools/ci/verification.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Select relevant PR suites and validate their final results."""
+import json
+import os
+import subprocess
+import sys
+
+
+def classify(paths):
+    app = site = False
+    for path in paths:
+        if path.startswith(('.github/workflows/', 'tools/ci/')):
+            app = site = True
+        elif path.startswith('site/'):
+            site = True
+        elif (path.endswith('.md') or path.startswith(('docs/', '.github/assets/', '.github/ISSUE_TEMPLATE/'))
+              or path == 'LICENSE'):
+            continue
+        else:
+            # Unknown paths require verification rather than disappearing from an allow-list.
+            app = True
+    return app, site
+
+
+def verify(needs, suite):
+    scope = needs.get('scope', {})
+    required = scope.get('outputs', {}).get(suite)
+    if scope.get('result') != 'success' or required not in ('true', 'false'):
+        raise ValueError('Suite selection did not finish successfully.')
+    jobs = {'app': ('test', 'app-build', 'release-build'), 'site': ('site',)}[suite]
+    expected = 'success' if required == 'true' else 'skipped'
+    for job in jobs:
+        result = needs.get(job, {}).get('result')
+        if result != expected:
+            raise ValueError(f'{job}: expected {expected}, received {result or "no result"}.')
+
+
+def main():
+    if sys.argv[1:] == ['scope']:
+        if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request':
+            # Checkout supplies the PR merge commit and its parents at depth two.
+            # Disable rename detection so moving source into docs still runs its suite.
+            result = subprocess.run(['git', 'diff', '--no-renames', '--name-only', '-z', 'HEAD^1', 'HEAD'],
+                                    check=True, capture_output=True)
+            paths = [path.decode('utf-8', errors='surrogateescape') for path in result.stdout.split(b'\0') if path]
+            app, site = classify(paths)
+        else:
+            # Push workflows already filter paths; manual runs always exercise their suite.
+            app = site = True
+        print(f'app={str(app).lower()}\nsite={str(site).lower()}')
+    elif len(sys.argv) == 3 and sys.argv[1] == 'gate' and sys.argv[2] in ('app', 'site'):
+        verify(json.loads(os.environ['NEEDS_JSON']), sys.argv[2])
+        print(f'{sys.argv[2]} verification passed.')
+    else:
+        raise ValueError('Usage: verification.py scope | gate app | gate site')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except (ValueError, KeyError, subprocess.CalledProcessError) as error:
+        print(f'Verification failed: {error}', file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## What

Contributors can build Debug or Release with `SIGNING=adhoc`, while the default keeps the maintainer's Developer ID settings. App builds and tests regenerate the Xcode project so new, renamed, and deleted sources reach the correct targets.

Local and CI Release builds share one marker check over every Mach-O. The check rejects missing products, missing positive controls, inspection failures, and any `CANDELA_` development switch that escaped into Release.

Every pull request gets an explicit **App verification** and **Site verification** result. A lightweight merge-diff check selects the relevant suites, so documentation-only changes do not spend macOS runner minutes. Selected jobs must pass; missing, cancelled, failed, or unexpectedly skipped results fail the gate.

## Why

Closes #81 and closes #83. The documented contributor command required an unavailable signing identity, local builds could silently omit new test files, and CI's marker pattern differed from the local gate. The existing path-filtered workflows could not be required safely because skipped workflows leave checks pending.

The active repository rule now requires both checks against the latest base, with the existing pull-request, deletion, and force-push protections preserved. Merge this PR first, then refresh existing PR branches from main so they receive the required checks.

Three poller cadence tests now assert the production tick's selected delay directly, including signal changes on the same poller. This removes scheduler-speed assumptions exposed by the first hosted run without changing production behavior.

## Hardware verification

This changes build and verification infrastructure only. No app was installed or launched, no permissions were changed, and no display writes were performed.

Disposable fixtures use real XcodeGen output to verify source membership and real Mach-O binaries to verify the Release gate. Negative controls catch a switch in an embedded binary, discovery/inspection failures, and a binary disappearing between discovery and inspection. CI tests cover multi-commit merge diffs, source-to-documentation renames, relevant-suite selection, and failure propagation.

## Checks

- [x] 12 build and marker regression tests passed, including failures demonstrated before their fixes.
- [x] 17 CI selection and gate tests passed. Mutations accepting failed jobs or hiding renamed sources were rejected.
- [x] Workflow lint, shell syntax/lint, whitespace checks, and independent code review passed.
- [x] Full `make check`: 2,512 engine tests and 586 host-free app tests passed.
- [x] Real `make build SIGNING=adhoc` and `make markers SIGNING=adhoc` passed. Both app signatures verify as ad-hoc with no team identifier; the Release control was found and all six Mach-Os were free of development markers.
- [x] Complete engine suite passed after the cadence test changes. Disabling each of the three scheduling signals independently made its corresponding test fail; the complete suite passed again after restoration.
- [x] [Hosted app checks](https://github.com/Rydersel/Candela/actions/runs/34384078489) passed: 2,512 engine tests, 586 app tests, 29 build/CI regression tests, Debug and Release builds, and all six Release Mach-Os scanned.
- [x] [Hosted site checks](https://github.com/Rydersel/Candela/actions/runs/34384078458) passed: lint, 87 tests, build, and the final verification gate.
- [x] Required-check rule readback confirmed both checks are enforced against the latest base and existing protections are preserved.
- [x] No ticket numbers in new source comments or new em dashes.

