### PR TITLE
Remember display rotations with confirmed arrangements

### DIFF
--- a/Candela/App/ArrangementCoordinator.swift
+++ b/Candela/App/ArrangementCoordinator.swift
@@ -89,6 +89,16 @@ final class ArrangementCoordinator {
   @ObservationIgnored var synthesisPairings: () -> [SynthesisPairing] = { [] }
 
   @ObservationIgnored private let configurator: any DisplayArrangementConfiguring
+  @ObservationIgnored private let rotationConfigurator: any DisplayRotationConfiguring
+  @ObservationIgnored private let savedLayoutRestorer: SavedArrangementRestorer
+  private var pendingRememberChoice: Bool?
+  @ObservationIgnored private var rememberRequestRevision = 0
+
+  /// A visible choice on the confirmation, committed only with Keep.
+  var remembersThisLayout: Bool {
+    get { pendingRememberChoice ?? persistence.remembersConfirmedLayout }
+    set { pendingRememberChoice = newValue }
+  }
   /// The display-reconfiguration gate. Held from just before the layout applies until nothing is outstanding.
   /// Not defaulted: a per-coordinator default would compile, run, and exclude
   /// nobody.
@@ -117,11 +127,14 @@ final class ArrangementCoordinator {
     gate: DisplayReconfigurationGate,
     configurator: any DisplayArrangementConfiguring = CoreGraphicsArrangementConfigurator(),
     persistence: ArrangementPersistence = ArrangementPersistence(),
+    rotationConfigurator: any DisplayRotationConfiguring = CoreGraphicsDisplayConfigurator(),
     countdownSeconds: Int = 30
   ) {
     self.gate = gate
     self.configurator = configurator
     self.persistence = persistence
+    self.rotationConfigurator = rotationConfigurator
+    savedLayoutRestorer = SavedArrangementRestorer(arrangements: configurator, rotations: rotationConfigurator)
     session = ArrangementPreviewSession(
       configurator: configurator, countdownSeconds: countdownSeconds
     )
@@ -445,19 +458,12 @@ final class ArrangementCoordinator {
       return
     }
 
-    let decision = ArrangementReapplyPolicy.decide(
-      isEnabled: persistence.isRestoreEnabled,
-      arrivals: claimed,
-      stored: persistence.savedArrangement(
-        // The ONLINE spelling of the signature, the one the arrival gate above
-        // signs. They diverge on one input, a display whose bounds are unreadable,
-        // which the layout spelling drops and this one keeps: inert here, because
-        // `decide` defers on that discrepancy before it consults `stored`.
-        for: TopologySignature(online: topology.displays, substituting: substituting)
-      ),
-      attached: topology.displays,
-      current: topology.arrangement,
-      substituting: substituting
+    let stored = persistence.savedArrangement(
+      for: TopologySignature(online: topology.displays, substituting: substituting)
+    )
+    let decision = await savedLayoutRestorer.restore(
+      stored, arrivals: claimed, substituting: substituting,
+      isEnabled: { [persistence] in persistence.isRestoreEnabled }
     )
 
     if decision.isDeferred {
@@ -466,14 +472,9 @@ final class ArrangementCoordinator {
       // event tries again with a machine that can answer.
       release(claimed)
     } else {
-      // Handled independently rather than as an either/or: the decision type does
-      // not promise they are exclusive, and a policy that both applies something
-      // and has something to say must not have the apply skipped by a `??`.
-      var notice = decision.notice
-      if let layout = decision.arrangementToApply {
-        notice = apply(restored: layout, over: topology.arrangement) ?? notice
-      }
-      restoreNotice = notice
+      // The restore actor has already applied any accepted layout. Report its
+      // outcome here without submitting the same configuration again.
+      restoreNotice = decision.notice
       if let restoreNotice {
         // Not every notice is a failure. A layout declined because the displays are
         // no longer the size it was recorded at is ordinary, and `.error` would put
@@ -493,32 +494,6 @@ final class ArrangementCoordinator {
     // authority on whether anything is outstanding, and freeing a claim that
     // protects a preview is the interleave the gate exists to prevent.
     if await session.previewedArrangement == nil { await gate.release(.arrangement) }
-  }
-
-  /// Commits a restored layout. Returns `nil` on success, or what to report.
-  private func apply(
-    restored layout: DisplayArrangement, over live: DisplayArrangement
-  ) -> ArrangementReapplyNotice? {
-    guard let plan = ArrangementPlan(applying: layout, to: live) else {
-      // A structural refusal of the layout as a whole: an origin outside `Int32`,
-      // or a display that became a mirror slave since the read. Reported rather
-      // than swallowed, since unattended silence looks like a restore that worked.
-      return .failed(DisplayConfigError(cgErrorCode: CGError.illegalArgument.rawValue))
-    }
-    do {
-      _ = try configurator.apply(plan, scope: ArrangementReapplyPolicy.scope)
-      log.log("Restored the saved layout for \(plan.changes.count, privacy: .public) displays")
-      return nil
-    } catch let error as DisplayConfigError {
-      // `apply` throws when a stage or the completion fails AND when the achieved
-      // layout is not the requested one. On the unattended path that second case is
-      // precisely what must not be swallowed: the machine is in a layout
-      // CoreGraphics chose, and `try?` would leave the app reporting a successful
-      // restore.
-      return .failed(error)
-    } catch {
-      return .failed(DisplayConfigError(cgErrorCode: -1))
-    }
   }
 
   private func release(_ claimed: Set<CGDirectDisplayID>) {
@@ -542,20 +517,35 @@ final class ArrangementCoordinator {
   /// The `savedArrangements` fan-out is announced from inside `saveIfRestoring`,
   /// not by the caller.
   func setRestoringLayout(_ restoring: Bool) {
-    persistence.setRestoreEnabled(restoring)
-    guard restoring else { return }
+    rememberRequestRevision += 1
+    let revision = rememberRequestRevision
+    if !restoring {
+      persistence.setRestoreEnabled(false)
+      return
+    }
     queue.enqueue {
-      // NOT while a preview stands: the layout on screen during a countdown is one
-      // nobody has approved, and the settings window and the confirmation panel sit
-      // on screen together for thirty seconds, so this is reachable. Asked of the
-      // SESSION, which `preview` cannot answer for several awaits after a `begin()`
-      // succeeds. Keeping the change saves it through `resolve` anyway.
-      guard await self.session.previewedArrangement == nil else { return }
-      // A fresh sample rather than the last one this coordinator holds: the pane
-      // can sit open across a reconfiguration, and saving a stale layout would file
-      // an arrangement the machine is not in.
+      guard revision == self.rememberRequestRevision else { return }
+      // Enabling saves the current setup, so it must obey the same exclusion
+      // as a display change. A preview is not an approved setup.
+      guard await self.session.previewedArrangement == nil else {
+        self.blockedBy = .arrangement
+        self.syncConfirmation()
+        return
+      }
+      if let holder = await self.gate.claim(.arrangement).refusedBy {
+        self.blockedBy = holder
+        self.syncConfirmation()
+        return
+      }
+      guard revision == self.rememberRequestRevision else {
+        await self.gate.release(.arrangement)
+        return
+      }
+      self.blockedBy = nil
+      self.persistence.setRestoreEnabled(true)
       self.refreshArrangement()
       self.saveIfRestoring()
+      await self.gate.release(.arrangement)
     }
   }
 
@@ -570,8 +560,27 @@ final class ArrangementCoordinator {
     // Filed under the panel, never under the virtual display standing in
     // for it. A layout saved while a synthesized size stands has to survive the
     // size being dropped, and the virtual display does not.
-    persistence.save(arrangement, substituting: synthesisSubstitutions)
+    persistence.save(arrangement, substituting: synthesisSubstitutions,
+                     rotations: savedRotations())
     didSaveArrangement()
+  }
+
+  /// A kept rotation changes both the angle and the layout's footprint.
+  /// It updates an enabled saved setup, without opting a rotation-only user in.
+  func rotationWasConfirmed() {
+    // Called synchronously before RotationCoordinator releases its gate. Do
+    // not enqueue a later sample that might belong to another preview.
+    guard persistence.isRestoreEnabled else { return }
+    refreshArrangement()
+    saveIfRestoring()
+  }
+
+  private func savedRotations() -> [CGDirectDisplayID: DisplayRotation] {
+    var result: [CGDirectDisplayID: DisplayRotation] = [:]
+    for tile in arrangement.tiles where tile.mirroredIDs.isEmpty && synthesisSubstitutions[tile.id] == nil {
+      result[tile.id] = rotationConfigurator.rotation(of: tile.id)
+    }
+    return result
   }
 
   /// Remembers the layout to offer back after an apply that DIVERGED.
@@ -592,9 +601,23 @@ final class ArrangementCoordinator {
   }
 
   private func resolve(_ answered: Preview, keeping: Bool) async -> PreviewOutcome {
+    let remember = remembersThisLayout
+    let revision = rememberRequestRevision
+    let wasOutstanding = await session.previewedArrangement == answered.value
     let outcome = keeping
       ? await session.confirm(answered.value)
       : await session.revert(answered.value)
+    // Capture the achieved, approved setup while the preview still owns the
+    // gate. The session can repeat its last outcome on a duplicate answer.
+    if wasOutstanding, case .committed = outcome {
+      refreshArrangement()
+      // A Settings opt-out made while the hardware commit was running is newer
+      // than the checkbox captured with Keep and must win.
+      let currentChoice = revision == rememberRequestRevision ? remember : persistence.isRestoreEnabled
+      persistence.saveConfirmed(arrangement, remember: currentChoice,
+                                substituting: synthesisSubstitutions, rotations: savedRotations())
+      didSaveArrangement()
+    }
     switch outcome {
     case .committed, .reverted:
       await adopt(.clear)
@@ -606,10 +629,6 @@ final class ArrangementCoordinator {
       await adopt(.keep)
     }
     refreshArrangement()
-    // AFTER the re-read, and only for a layout the user kept: the one moment a
-    // layout is known to be both on screen and approved. macOS adjusts a request
-    // silently, so saving the requested layout would store one never achieved.
-    if case .committed = outcome { saveIfRestoring() }
     return outcome
   }
 
@@ -620,6 +639,7 @@ final class ArrangementCoordinator {
   private func adopt(_ failure: FailureUpdate) async {
     guard let outstanding = await session.previewedArrangement else {
       preview = nil
+      pendingRememberChoice = nil
       stopCountdown()
       // THE release. Here rather than at each call site because this funnel
       // already runs after every path that can end a preview. Unconditional: the

--- a/Candela/App/RotationCoordinator.swift
+++ b/Candela/App/RotationCoordinator.swift
@@ -39,6 +39,7 @@ final class RotationCoordinator {
   /// fact about the display.
   private(set) var blockedBy: ReconfigurationClaimant?
   private(set) var isApplying = false
+  @ObservationIgnored var didConfirmRotation: () -> Void = {}
 
   @ObservationIgnored weak var confirmation: (any RotationConfirmationPresenting)?
 
@@ -227,9 +228,12 @@ final class RotationCoordinator {
   // MARK: - Serialisation
 
   private func resolve(_ answered: Preview, keeping: Bool) async -> PreviewOutcome {
+    let wasOutstanding = await session.previewed == answered.request
     let outcome = keeping
       ? await session.confirm(answered.request)
       : await session.revert(answered.request)
+    // Save the approved state before adopt releases the reconfiguration gate.
+    if wasOutstanding, case .committed = outcome { didConfirmRotation() }
     switch outcome {
     case .committed, .reverted: await adopt(.clear)
     case let .failed(error): await adopt(.set(error))

--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -403,6 +403,9 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     rotationConfirmation.displayName = displayName
     self.rotationConfirmation = rotationConfirmation
     model.rotation.confirmation = rotationConfirmation
+    model.rotation.didConfirmRotation = { [weak model] in
+      model?.arrangement.rotationWasConfirmed()
+    }
 
     // Arrangement's own surface: another CALLER of `ConfirmationPanel`, not
     // another window type, which is how one of the others once shipped with an
@@ -436,6 +439,7 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
     // No persistence key, since the layout is a fact about the display SET.
     model.arrangement.didSaveArrangement = { [weak self] in
       self?.settingsActions.prefDidChange(.savedArrangements)
+      self?.settingsActions.prefDidChange(.restoreArrangement)
     }
 
     // The orphaned-shade fix (see `MirroringCoordinator.rebuildSoftwareDimming`).

--- a/Candela/AppKitIslands/ArrangementConfirmationWindow.swift
+++ b/Candela/AppKitIslands/ArrangementConfirmationWindow.swift
@@ -97,6 +97,15 @@ struct ArrangementConfirmationView: View {
           ConfirmationCaption(ArrangementCopy.expiryAlreadyRan)
         }
 
+        Toggle("Remember this display setup", isOn: Binding(
+          get: { coordinator.remembersThisLayout },
+          set: { coordinator.remembersThisLayout = $0 }
+        ))
+        .toggleStyle(.checkbox)
+        .font(.callout)
+        .disabled(coordinator.isApplying)
+        ConfirmationCaption("Restore saved rotations and positions when these displays reconnect.")
+
         ConfirmationAnswers {
           // Both answers carry the preview THIS window is rendering, so an
           // answer can only ever resolve what the user was looking at.

--- a/Candela/Settings/ArrangementPane.swift
+++ b/Candela/Settings/ArrangementPane.swift
@@ -363,9 +363,9 @@ struct ArrangementPane: View {
   /// Present with one display attached, for the reason the whole pane is.
   /// What changes is the caption, not the control.
   private var savedLayoutSection: some View {
-    SettingsCardSection(title: "Saved Arrangements") {
+    SettingsCardSection(title: "Saved Display Setups") {
       SettingRow(caption: rememberCaption) {
-        Toggle("Remember how these displays are arranged", isOn: Binding(
+        Toggle("Remember display rotations and positions", isOn: Binding(
           get: { coordinator.isRestoringLayout },
           set: { restoring in
             // Only the FLAG is announced here. Turning it on ALSO saves the
@@ -377,7 +377,7 @@ struct ArrangementPane: View {
           }
         ))
         .themedSwitch()
-        .accessibilityLabel("Remember how these displays are arranged")
+        .accessibilityLabel("Remember display rotations and positions")
         .prefIdentifier(.restoreArrangement)
       }
       // The mirror hooks hang HERE, on the one row of this section that is
@@ -445,12 +445,9 @@ struct ArrangementPane: View {
     // `SettingsCaption`'s `verbatim` initialiser keeps the pane's caption
     // styling on a composed sentence.
     let restores = coordinator.arrangement.tiles.count > 1
-      ? "Puts these displays back this way when they reconnect or \(AppInfo.productName) launches."
-      : "Puts a set of displays back the way you left them when that set reconnects or \(AppInfo.productName) launches."
-    guard coordinator.arrangement.tiles.count > 1 else {
-      return SettingsCaption(verbatim: "\(restores) With one display connected there is no arrangement to save yet.")
-    }
-    let updates = "Turning it on saves the arrangement on screen now, and keeping a change you make here updates it."
+      ? "Restores these displays’ rotations and positions when they reconnect or \(AppInfo.productName) launches."
+      : "Restores a saved display setup when that set reconnects or \(AppInfo.productName) launches."
+    let updates = "Turning it on saves the current positions and rotations. Keeping arrangement or rotation changes in Candela updates the saved setup."
     let elsewhere = "Changes you make in System Settings are left alone until the displays reconnect."
     return SettingsCaption(verbatim: "\(restores) \(updates) \(elsewhere)")
   }

--- a/CandelaAppTests/SavedLayoutConfirmationTests.swift
+++ b/CandelaAppTests/SavedLayoutConfirmationTests.swift
@@ -1,0 +1,244 @@
+import CandelaKit
+import CoreGraphics
+import Foundation
+import Testing
+
+@Suite("Remember a confirmed display setup", .timeLimit(.minutes(1)))
+@MainActor
+struct SavedLayoutConfirmationTests {
+  @Test func keepingTheFirstArrangementEnablesAndSavesItsRotations() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      #expect(!coordinator.isRestoringLayout)
+      coordinator.apply(rig.currentArrangement().makingMain(2))
+      // A reconnect while the preview is up must not save or restore it.
+      await coordinator.restoreSavedArrangement()
+      let preview = try #require(coordinator.preview)
+      #expect(coordinator.remembersThisLayout)
+      #expect(!store.isRestoreEnabled)
+      #expect(await coordinator.confirm(preview) == .committed)
+      #expect(store.isRestoreEnabled)
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+      #expect(saved.entries.first { $0.identity == rig.currentArrangement().tile(2)?.identity.key }?.rotation == .twoSeventy)
+    }
+  }
+
+  @Test func revertingDoesNotCommitTheSuggestedRememberChoice() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.apply(rig.currentArrangement().makingMain(2))
+      await coordinator.restoreSavedArrangement()
+      let preview = try #require(coordinator.preview)
+      #expect(await coordinator.revert(preview) == .reverted)
+      #expect(!store.isRestoreEnabled)
+      #expect(store.remembersConfirmedLayout)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == nil)
+      _ = await coordinator.confirm(preview)
+      #expect(!store.isRestoreEnabled)
+    }
+  }
+
+  @Test func anExplicitOptOutRemainsUncheckedAndIsNotOverriddenByKeep() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.setRestoringLayout(false)
+      coordinator.apply(rig.currentArrangement().makingMain(2))
+      await coordinator.restoreSavedArrangement()
+      let preview = try #require(coordinator.preview)
+      #expect(!coordinator.remembersThisLayout)
+      #expect(await coordinator.confirm(preview) == .committed)
+      #expect(!store.isRestoreEnabled)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == nil)
+    }
+  }
+
+  @Test func uncheckingTheConfirmationChoicePersistsTheOptOut() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.apply(rig.currentArrangement().makingMain(2))
+      await coordinator.restoreSavedArrangement()
+      let preview = try #require(coordinator.preview)
+      coordinator.remembersThisLayout = false
+      #expect(await coordinator.confirm(preview) == .committed)
+      #expect(!store.remembersConfirmedLayout)
+      #expect(!store.isRestoreEnabled)
+    }
+  }
+
+  @Test func keepingANewRotationRefreshesAnAlreadyRememberedSetup() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      rig.angle = .ninety
+      coordinator.rotationWasConfirmed()
+      await coordinator.restoreSavedArrangement()
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+      #expect(saved.entries.first { $0.identity == rig.currentArrangement().tile(2)?.identity.key }?.rotation == .ninety)
+    }
+  }
+
+  @Test func enablingRememberDuringARotationPreviewCannotSaveTheRejectedAngle() async throws {
+    try await withCoordinator { coordinator, store, rig, gate in
+      let rotation = RotationCoordinator(gate: gate, topologyStore: MirrorTopologyStore(), configurator: rig)
+      let presenter = RotationReadyPresenter()
+      rotation.confirmation = presenter
+      rotation.didConfirmRotation = { coordinator.rotationWasConfirmed() }
+      rotation.rotate(2, to: .ninety)
+      for await _ in presenter.ready { break }
+      let preview = try #require(rotation.preview)
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      #expect(!store.isRestoreEnabled)
+      #expect(coordinator.blockedBy == .rotation)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == nil)
+      #expect(await rotation.revert(preview) == .reverted)
+      #expect(rig.angle == .twoSeventy)
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+      #expect(saved.entries.first { $0.identity == rig.currentArrangement().tile(2)?.identity.key }?.rotation == .twoSeventy)
+    }
+  }
+
+  @Test func rotationKeepCapturesBeforeReturningAndDuplicateAnswersDoNotSaveAgain() async throws {
+    try await withCoordinator { coordinator, store, rig, gate in
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      let rotation = RotationCoordinator(gate: gate, topologyStore: MirrorTopologyStore(), configurator: rig)
+      let presenter = RotationReadyPresenter()
+      rotation.confirmation = presenter
+      var captures = 0
+      rotation.didConfirmRotation = {
+        captures += 1
+        coordinator.rotationWasConfirmed()
+      }
+      rotation.rotate(2, to: .ninety)
+      for await _ in presenter.ready { break }
+      let preview = try #require(rotation.preview)
+      #expect(await rotation.confirm(preview) == .committed)
+      #expect(captures == 1)
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+      #expect(saved.entries.first { $0.identity == rig.currentArrangement().tile(2)?.identity.key }?.rotation == .ninety)
+      rig.angle = .twoSeventy
+      _ = await rotation.confirm(preview)
+      #expect(captures == 1)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == saved)
+    }
+  }
+
+  @Test func duplicateArrangementKeepDoesNotCaptureALaterRotation() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.apply(rig.currentArrangement().makingMain(2))
+      await coordinator.restoreSavedArrangement()
+      let preview = try #require(coordinator.preview)
+      #expect(await coordinator.confirm(preview) == .committed)
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+      rig.angle = .ninety
+      _ = await coordinator.confirm(preview)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == saved)
+    }
+  }
+
+  @Test func switchingOffCancelsAnEarlierQueuedEnable() async throws {
+    try await withCoordinator { coordinator, store, rig, gate in
+      coordinator.setRestoringLayout(true)
+      coordinator.setRestoringLayout(false)
+      await coordinator.restoreSavedArrangement()
+      #expect(!store.isRestoreEnabled)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == nil)
+      #expect(await gate.holder == nil)
+    }
+  }
+
+  @Test func switchingOffWhileKeepCommitsPreservesTheExplicitOptOut() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.apply(rig.currentArrangement().makingMain(2))
+      await coordinator.restoreSavedArrangement()
+      let preview = try #require(coordinator.preview)
+      rig.beforeCommit = {
+        let finished = DispatchSemaphore(value: 0)
+        Task { @MainActor in
+          coordinator.setRestoringLayout(false)
+          finished.signal()
+        }
+        #expect(finished.wait(timeout: .now() + 5) == .success)
+      }
+      #expect(await coordinator.confirm(preview) == .committed)
+      #expect(!store.isRestoreEnabled)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == nil)
+    }
+  }
+
+  private func withCoordinator(
+    _ body: (ArrangementCoordinator, ArrangementPersistence, ConfirmationLayoutRig, DisplayReconfigurationGate) async throws -> Void
+  ) async throws {
+    let suite = "test.saved-layout.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let store = ArrangementPersistence(defaults: defaults)
+    let rig = ConfirmationLayoutRig()
+    let gate = DisplayReconfigurationGate()
+    let coordinator = ArrangementCoordinator(gate: gate,
+      configurator: rig, persistence: store, rotationConfigurator: rig)
+    try await body(coordinator, store, rig, gate)
+  }
+}
+
+/// Replaces only display I/O; the actual coordinator, queue and preview session run.
+private final class ConfirmationLayoutRig: DisplayArrangementConfiguring,
+  DisplayConfiguring, @unchecked Sendable {
+  private let lock = NSLock()
+  // Installed before an operation starts; the test never mutates it in flight.
+  var beforeCommit: (@Sendable () -> Void)?
+  private var layout = DisplayArrangement(tiles: [
+    tile(1, .init(x: 0, y: 0, width: 1000, height: 800)),
+    tile(2, .init(x: 1000, y: 0, width: 800, height: 1200)),
+  ])
+  private var storedAngle: DisplayRotation = .twoSeventy
+  var angle: DisplayRotation {
+    get { lock.withLock { storedAngle } }
+    set { lock.withLock { storedAngle = newValue } }
+  }
+  var canRotate: Bool { true }
+  func rotation(of displayID: CGDirectDisplayID) -> DisplayRotation? {
+    displayID == 2 ? angle : .standard
+  }
+  func applyRotation(_ rotation: DisplayRotation, to displayID: CGDirectDisplayID) throws {
+    angle = rotation
+  }
+  func displays() -> [ConfiguredDisplay] { currentTopology().displays }
+  func modes(for displayID: CGDirectDisplayID) -> [DisplayMode] { [] }
+  func currentMode(for displayID: CGDirectDisplayID) -> DisplayMode? { nil }
+  func nativePixels(for displayID: CGDirectDisplayID) -> (width: Int, height: Int)? { nil }
+  func apply(_ mode: DisplayMode, to displayID: CGDirectDisplayID, scope: DisplayConfigScope) throws {
+    Issue.record("Unexpected mode change")
+  }
+  func applyMirroring(_ changes: [MirrorChange], scope: DisplayConfigScope) throws {
+    Issue.record("Unexpected mirroring change")
+  }
+  var revealsHiddenModes: Bool { false }
+  var guardsWireTiming: Bool { true }
+  func modesWithheldByWireTimingGuard(for displayID: CGDirectDisplayID) -> Int { 0 }
+  func currentArrangement() -> DisplayArrangement { lock.withLock { layout } }
+  func currentTopology() -> (displays: [ConfiguredDisplay], arrangement: DisplayArrangement) {
+    let layout = currentArrangement()
+    return (layout.tiles.map {
+      .init(id: $0.id, identity: $0.identity, name: $0.name, isBuiltIn: false)
+    }, layout)
+  }
+  func apply(_ plan: ArrangementPlan, scope: DisplayConfigScope) throws -> DisplayArrangement {
+    if scope == .permanent { beforeCommit?() }
+    return lock.withLock { layout = plan.arrangement; return layout }
+  }
+  private static func tile(_ id: CGDirectDisplayID, _ rect: DisplayRect) -> ArrangementTile {
+    .init(id: id, identity: .init(vendor: id, model: id, serial: id, isBuiltIn: false),
+          name: "Display \(id)", rect: rect, mirroredIDs: [])
+  }
+}
+
+@MainActor
+private final class RotationReadyPresenter: RotationConfirmationPresenting {
+  let ready: AsyncStream<Void>
+  private let continuation: AsyncStream<Void>.Continuation
+  init() { (ready, continuation) = AsyncStream.makeStream() }
+  func presentRotationConfirmation(_ content: RotationConfirmationContent) {
+    if case .preview = content { continuation.yield(()) }
+  }
+  func dismissRotationConfirmation() {}
+}

--- a/CandelaKit/Sources/CandelaKit/Arrangement/ArrangementPersistence.swift
+++ b/CandelaKit/Sources/CandelaKit/Arrangement/ArrangementPersistence.swift
@@ -93,13 +93,17 @@ public struct SavedArrangementEntry: Sendable, Equatable, Codable {
   public let y: Int
   public let width: Int
   public let height: Int
+  /// Missing in version 1. Absence means leave rotation alone, never assume 0°.
+  public let rotation: DisplayRotation?
 
-  public init(identity: String, x: Int, y: Int, width: Int, height: Int) {
+  public init(identity: String, x: Int, y: Int, width: Int, height: Int,
+              rotation: DisplayRotation? = nil) {
     self.identity = identity
     self.x = x
     self.y = y
     self.width = width
     self.height = height
+    self.rotation = rotation
   }
 
   /// Spelled out rather than synthesized: these strings are an on-disk format, and
@@ -111,6 +115,7 @@ public struct SavedArrangementEntry: Sendable, Equatable, Codable {
     case y
     case width
     case height
+    case rotation
   }
 }
 
@@ -127,7 +132,7 @@ public struct SavedArrangement: Sendable, Equatable, Codable {
   public let version: Int
   public let entries: [SavedArrangementEntry]
 
-  public static let currentVersion = 1
+  public static let currentVersion = 2
 
   public init(version: Int = SavedArrangement.currentVersion, entries: [SavedArrangementEntry]) {
     self.version = version
@@ -138,12 +143,15 @@ public struct SavedArrangement: Sendable, Equatable, Codable {
   /// identities for the same reason it applies to the key: a layout saved while a
   /// synthesized size stood would otherwise name a virtual display that is gone the
   /// moment it is read back.
-  public init(_ arrangement: DisplayArrangement, substituting: [CGDirectDisplayID: String] = [:]) {
+  public init(_ arrangement: DisplayArrangement, substituting: [CGDirectDisplayID: String] = [:],
+              rotations: [CGDirectDisplayID: DisplayRotation] = [:]) {
     self.init(entries: arrangement.tiles.map {
       SavedArrangementEntry(
         identity: substituting[$0.id] ?? $0.identity.key,
         x: $0.rect.x, y: $0.rect.y,
-        width: $0.rect.width, height: $0.rect.height
+        width: $0.rect.width, height: $0.rect.height,
+        // A synthesized desktop is not the physical panel's orientation.
+        rotation: substituting[$0.id] == nil ? rotations[$0.id] : nil
       )
     })
   }
@@ -195,6 +203,23 @@ public final class ArrangementPersistence: @unchecked Sendable {
     defaults.bool(forKey: PrefName.restoreArrangement.rawValue)
   }
 
+  /// The initial confirmation suggests remembering; launch alone enables nothing.
+  /// An explicitly stored false remains false across upgrades and confirmations.
+  public var remembersConfirmedLayout: Bool {
+    defaults.object(forKey: PrefName.restoreArrangement.rawValue) == nil || isRestoreEnabled
+  }
+
+  public func saveConfirmed(
+    _ arrangement: DisplayArrangement, remember: Bool? = nil,
+    substituting: [CGDirectDisplayID: String] = [:],
+    rotations: [CGDirectDisplayID: DisplayRotation] = [:]
+  ) {
+    guard !arrangement.isEmpty else { return }
+    let remembering = remember ?? remembersConfirmedLayout
+    setRestoreEnabled(remembering)
+    if remembering { save(arrangement, substituting: substituting, rotations: rotations) }
+  }
+
   public func setRestoreEnabled(_ enabled: Bool) {
     defaults.set(enabled, forKey: PrefName.restoreArrangement.rawValue)
   }
@@ -223,12 +248,13 @@ public final class ArrangementPersistence: @unchecked Sendable {
   /// exists only while the size does, which reads back as a different set. The map is
   /// runtime IDs, handed in with the sample; nothing here stores one.
   public func save(
-    _ arrangement: DisplayArrangement, substituting: [CGDirectDisplayID: String] = [:]
+    _ arrangement: DisplayArrangement, substituting: [CGDirectDisplayID: String] = [:],
+    rotations: [CGDirectDisplayID: DisplayRotation] = [:]
   ) {
     let signature = TopologySignature(arrangement, substituting: substituting)
     guard !signature.isEmpty,
           let data = try? JSONEncoder().encode(
-            SavedArrangement(arrangement, substituting: substituting)
+            SavedArrangement(arrangement, substituting: substituting, rotations: rotations)
           )
     else { return }
     defaults.set(data, forKey: key(.savedArrangements, signature))

--- a/CandelaKit/Sources/CandelaKit/Arrangement/SavedArrangementRestorer.swift
+++ b/CandelaKit/Sources/CandelaKit/Arrangement/SavedArrangementRestorer.swift
@@ -1,0 +1,131 @@
+import CoreGraphics
+import Foundation
+
+/// Runs blocking rotation and arrangement writes away from the main actor.
+/// The caller holds the display reconfiguration gate for this entire operation.
+public actor SavedArrangementRestorer {
+  private let arrangements: any DisplayArrangementConfiguring
+  private let rotations: any DisplayRotationConfiguring
+
+  public init(arrangements: any DisplayArrangementConfiguring,
+              rotations: any DisplayRotationConfiguring) {
+    self.arrangements = arrangements
+    self.rotations = rotations
+  }
+
+  /// The returned decision describes work already performed. Callers must not
+  /// apply its arrangementToApply again.
+  public func restore(
+    _ saved: SavedArrangement?, arrivals: Set<CGDirectDisplayID>,
+    substituting: [CGDirectDisplayID: String] = [:],
+    isEnabled: @Sendable () -> Bool = { true }
+  ) -> ArrangementReapplyDecision {
+    guard isEnabled(), !Task.isCancelled, !arrivals.isEmpty, let saved,
+          !saved.entries.isEmpty, saved.version <= SavedArrangement.currentVersion
+    else { return .doNothing }
+
+    let initial = arrangements.currentTopology()
+    // A missing footprint during reconnect must not be mistaken for a smaller setup.
+    guard initial.displays.allSatisfy({ $0.isMirrorSlave || initial.arrangement.tile($0.id) != nil })
+    else { return .deferred }
+
+    var requests: [RotationRequest] = []
+    var projected: [ArrangementTile] = []
+    for tile in initial.arrangement.tiles {
+      let identity = substituting[tile.id] ?? tile.identity.key
+      guard let angle = saved.entries.first(where: { $0.identity == identity })?.rotation else {
+        projected.append(tile)
+        continue
+      }
+      // Rotation of a synthesized desktop does not describe the physical panel.
+      // Preserve its existing position-only behavior until the pairing is removed.
+      guard substituting[tile.id] == nil else {
+        projected.append(tile)
+        continue
+      }
+      guard let current = rotations.rotation(of: tile.id) else { return .deferred }
+      guard current != angle else {
+        projected.append(tile)
+        continue
+      }
+      guard case let .rotate(request) = RotationPolicy.decide(
+        display: tile.id, to: angle, in: initial.displays, currentRotation: current,
+        isSupported: rotations.canRotate, isSynthesizedSize: false
+      ), tile.mirroredIDs.isEmpty else { return Self.failed() }
+      requests.append(request)
+      let swap = current.swapsAxes != angle.swapsAxes
+      projected.append(ArrangementTile(
+        id: tile.id, identity: tile.identity, name: tile.name,
+        rect: DisplayRect(x: tile.rect.x, y: tile.rect.y,
+                          width: swap ? tile.rect.height : tile.rect.width,
+                          height: swap ? tile.rect.width : tile.rect.height),
+        mirroredIDs: tile.mirroredIDs
+      ))
+    }
+
+    // Validate the WHOLE saved setup before the first write. A true resolution
+    // change must not be "repaired" by rotating an otherwise unrelated display.
+    let preflight = ArrangementReapplyPolicy.decide(
+      isEnabled: true, arrivals: arrivals, stored: saved, attached: initial.displays,
+      current: DisplayArrangement(tiles: projected), substituting: substituting
+    )
+    guard preflight.notice == nil, !preflight.isDeferred else { return preflight }
+
+    for request in requests {
+      guard isEnabled(), !Task.isCancelled else { return .doNothing }
+      let live = arrangements.currentTopology()
+      // IDs can be reassigned while a blocking display operation is in flight.
+      // Defer the whole operation rather than send the next write to a new panel.
+      guard Self.sameDisplays(initial.displays, live.displays),
+            rotations.rotation(of: request.display) == request.from
+      else { return .deferred }
+      do {
+        try rotations.applyRotation(request.to, to: request.display)
+      } catch let error as DisplayConfigError {
+        return Self.failed(error)
+      } catch {
+        return Self.failed()
+      }
+      guard rotations.rotation(of: request.display) == request.to else { return Self.failed() }
+    }
+
+    guard isEnabled(), !Task.isCancelled else { return .doNothing }
+    let achieved = arrangements.currentTopology()
+    guard Self.sameDisplays(initial.displays, achieved.displays) else { return .deferred }
+    // Re-read actual dimensions AFTER rotation; macOS can move other displays too.
+    let decision = ArrangementReapplyPolicy.decide(
+      isEnabled: true, arrivals: arrivals, stored: saved, attached: achieved.displays,
+      current: achieved.arrangement, substituting: substituting
+    )
+    guard decision.notice == nil, !decision.isDeferred else { return decision }
+    if let layout = decision.arrangementToApply {
+      guard let plan = ArrangementPlan(applying: layout, to: achieved.arrangement) else {
+        return Self.failed()
+      }
+      do {
+        _ = try arrangements.apply(plan, scope: ArrangementReapplyPolicy.scope)
+      } catch let error as DisplayConfigError {
+        return Self.failed(error)
+      } catch {
+        return Self.failed()
+      }
+    }
+    let final = arrangements.currentTopology()
+    guard Self.sameDisplays(initial.displays, final.displays) else { return .deferred }
+    for tile in final.arrangement.tiles where substituting[tile.id] == nil {
+      if let angle = saved.entries.first(where: { $0.identity == tile.identity.key })?.rotation,
+         rotations.rotation(of: tile.id) != angle { return Self.failed() }
+    }
+    return decision
+  }
+
+  private static func sameDisplays(_ a: [ConfiguredDisplay], _ b: [ConfiguredDisplay]) -> Bool {
+    a.sorted { $0.id < $1.id } == b.sorted { $0.id < $1.id }
+  }
+
+  private static func failed(
+    _ error: DisplayConfigError = .init(cgErrorCode: CGError.cannotComplete.rawValue)
+  ) -> ArrangementReapplyDecision {
+    .init(arrangementToApply: nil, notice: .failed(error))
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayConfiguring.swift
@@ -220,7 +220,7 @@ enum MirrorVerification {
 /// The seam between display-configuration policy and CoreGraphics. Everything
 /// decidable is tested against a fake conformance; the real one is a thin
 /// adapter with no judgement in it.
-public protocol DisplayConfiguring: Sendable {
+public protocol DisplayConfiguring: DisplayRotationConfiguring {
   /// Every display that is ONLINE, whether or not it is currently drawing.
   /// Deliberately not "active": callers read absence from this list as a
   /// DEPARTURE, and a display asleep on the idle timer has not gone anywhere.
@@ -279,6 +279,11 @@ public protocol DisplayConfiguring: Sendable {
   /// is off), so a caller reporting this must report `guardsWireTiming` with it.
   func modesWithheldByWireTimingGuard(for displayID: CGDirectDisplayID) -> Int
 
+}
+
+/// The rotation operations shared by interactive previews and saved-layout restore.
+public protocol DisplayRotationConfiguring: Sendable {
+
   /// Whether this build can rotate displays at all.
   ///
   /// A missing private symbol is a capability answer, not a crash. When
@@ -295,7 +300,8 @@ public protocol DisplayConfiguring: Sendable {
   /// `SLSConfigureDisplayRotation`, so rotation cannot be staged into a
   /// `CGBeginDisplayConfiguration` transaction the way a mirror change can. N
   /// displays would be N independent calls, each able to fail alone, so the
-  /// half-applied state stays unrepresentable by never offering the batch.
+  /// calls cannot form an atomic batch. Callers restoring several displays
+  /// must handle partial success.
   ///
   /// **Verifies the readback.** A `CGError` of 0 is not evidence: `-90`
   /// and `360` both return success and change nothing. Throws

--- a/CandelaKit/Tests/CandelaKitTests/ArrangementPersistenceTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ArrangementPersistenceTests.swift
@@ -221,7 +221,7 @@ struct ArrangementPersistenceTests {
     let object = try #require(
       try JSONSerialization.jsonObject(with: data) as? [String: Any]
     )
-    #expect(object["version"] as? Int == 1)
+    #expect(object["version"] as? Int == 2)
     let entries = try #require(object["entries"] as? [[String: Any]])
     #expect(Set(entries[0].keys) == ["identity", "x", "y", "width", "height"])
   }

--- a/CandelaKit/Tests/CandelaKitTests/SavedArrangementRestorerTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/SavedArrangementRestorerTests.swift
@@ -1,0 +1,182 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import CandelaKit
+
+/// Confined to one restore actor at a time; tests inspect it only after awaiting
+/// completion. The fake models rotation changing geometry and moving the desktop.
+private final class LayoutRig: DisplayArrangementConfiguring, DisplayRotationConfiguring,
+  @unchecked Sendable {
+  var layout: DisplayArrangement
+  var angles: [CGDirectDisplayID: DisplayRotation] = [1: .standard, 9: .standard]
+  var events: [String] = []
+  var canRotate = true
+  var failRotation = false
+  var ignoreRotation = false
+  var departAfterRotation = false
+  var disableAfterRotation = false
+  var enabled = true
+  var wroteOnMain = false
+  var extraOnlineDisplay: ConfiguredDisplay?
+
+  init() {
+    layout = DisplayArrangement(tiles: [
+      Self.tile(1, key: 1, .init(x: 0, y: 0, width: 1000, height: 800)),
+      Self.tile(9, key: 2, .init(x: 1000, y: 0, width: 1200, height: 800)),
+    ])
+  }
+
+  static func tile(_ id: CGDirectDisplayID, key: UInt32, _ rect: DisplayRect) -> ArrangementTile {
+    .init(id: id, identity: .init(vendor: key, model: key, serial: key, isBuiltIn: false),
+          name: "Display \(key)", rect: rect, mirroredIDs: [])
+  }
+
+  var saved: SavedArrangement {
+    // The physical display saved as ID2 has returned as ID9.
+    SavedArrangement(DisplayArrangement(tiles: [
+      Self.tile(1, key: 1, .init(x: 0, y: 0, width: 1000, height: 800)),
+      Self.tile(2, key: 2, .init(x: 0, y: 800, width: 800, height: 1200)),
+    ]), rotations: [1: .standard, 2: .twoSeventy])
+  }
+
+  func currentArrangement() -> DisplayArrangement { layout }
+  func currentTopology() -> (displays: [ConfiguredDisplay], arrangement: DisplayArrangement) {
+    var displays = layout.tiles.map {
+      ConfiguredDisplay(id: $0.id, identity: $0.identity, name: $0.name, isBuiltIn: false)
+    }
+    if let extraOnlineDisplay { displays.append(extraOnlineDisplay) }
+    return (displays, layout)
+  }
+  func rotation(of displayID: CGDirectDisplayID) -> DisplayRotation? { angles[displayID] }
+  func applyRotation(_ rotation: DisplayRotation, to displayID: CGDirectDisplayID) throws {
+    wroteOnMain = wroteOnMain || Thread.isMainThread
+    events.append("rotate:\(displayID):\(rotation.rawValue)")
+    if failRotation { throw DisplayConfigError(cgErrorCode: 1001) }
+    if ignoreRotation { return }
+    let swap = angles[displayID]?.swapsAxes != rotation.swapsAxes
+    angles[displayID] = rotation
+    layout = DisplayArrangement(tiles: layout.tiles.compactMap { tile in
+      if departAfterRotation && tile.id == 1 { return nil }
+      guard tile.id == displayID else { return tile }
+      return .init(id: tile.id, identity: tile.identity, name: tile.name,
+                   rect: .init(x: 1000, y: 0,
+                               width: swap ? tile.rect.height : tile.rect.width,
+                               height: swap ? tile.rect.width : tile.rect.height), mirroredIDs: [])
+    })
+    if disableAfterRotation { enabled = false }
+  }
+  func apply(_ plan: ArrangementPlan, scope: DisplayConfigScope) throws -> DisplayArrangement {
+    wroteOnMain = wroteOnMain || Thread.isMainThread
+    events.append("layout")
+    #expect(scope == .permanent)
+    layout = plan.arrangement
+    return layout
+  }
+}
+
+@Suite("Restore rotation before saved positions")
+struct SavedArrangementRestorerTests {
+  @Test @MainActor func rotatesTheReassignedDisplayThenRestoresFreshGeometryOffMainActor() async {
+    let rig = LayoutRig()
+    let result = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9])
+    #expect(result.notice == nil)
+    #expect(rig.events == ["rotate:9:270", "layout"])
+    #expect(rig.angles[9] == .twoSeventy)
+    #expect(rig.layout.tile(9)?.rect == .init(x: 0, y: 800, width: 800, height: 1200))
+    #expect(!rig.wroteOnMain)
+  }
+
+  @Test func rotationFailureDoesNotApplyPositionsToTheWrongFootprint() async {
+    let rig = LayoutRig()
+    rig.failRotation = true
+    let result = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9])
+    #expect(result.notice == .failed(.init(cgErrorCode: 1001)))
+    #expect(rig.events == ["rotate:9:270"])
+  }
+
+  @Test func aSuccessfulReturnWithoutTheRequestedAngleIsNotSuccess() async {
+    let rig = LayoutRig()
+    rig.ignoreRotation = true
+    let result = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9])
+    #expect(result.notice != nil)
+    #expect(rig.events == ["rotate:9:270"])
+  }
+
+  @Test func optOutAndNonArrivalNeverTouchDisplays() async {
+    let rig = LayoutRig()
+    let restorer = SavedArrangementRestorer(arrangements: rig, rotations: rig)
+    _ = await restorer.restore(rig.saved, arrivals: [1, 9], isEnabled: { false })
+    _ = await restorer.restore(rig.saved, arrivals: [])
+    #expect(rig.events.isEmpty)
+  }
+
+  @Test func anOptOutDuringRotationStopsBeforeRepositioning() async {
+    let rig = LayoutRig()
+    rig.disableAfterRotation = true
+    _ = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9], isEnabled: { rig.enabled })
+    #expect(rig.events == ["rotate:9:270"])
+  }
+
+  @Test func aDepartureDuringRotationDefersWithoutApplyingOldPositions() async {
+    let rig = LayoutRig()
+    rig.departAfterRotation = true
+    let result = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9])
+    #expect(result.isDeferred)
+    #expect(rig.events == ["rotate:9:270"])
+  }
+
+  @Test func changedResolutionIsNotMistakenForChangedRotation() async {
+    let rig = LayoutRig()
+    rig.layout = .init(tiles: [rig.layout.tile(1)!, LayoutRig.tile(9, key: 2,
+      .init(x: 1000, y: 0, width: 1920, height: 1080))])
+    let result = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9])
+    #expect(result.notice == .savedForDifferentGeometry([rig.layout.tile(9)!.identity.key]))
+    #expect(rig.events.isEmpty)
+  }
+
+  @Test func anIncompleteDisplayReadWaitsBeforeAnyRotation() async {
+    let rig = LayoutRig()
+    rig.extraOnlineDisplay = .init(id: 20,
+      identity: .init(vendor: 20, model: 20, serial: 20, isBuiltIn: false),
+      name: "Unreadable display", isBuiltIn: false)
+    let result = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9, 20])
+    #expect(result.isDeferred)
+    #expect(rig.events.isEmpty)
+  }
+
+  @Test func aLegacyLayoutRestoresPositionsWithoutTouchingAngles() async {
+    let rig = LayoutRig()
+    let saved = SavedArrangement(rig.layout.makingMain(9))
+    let result = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(saved, arrivals: [1, 9])
+    #expect(result.notice == nil)
+    #expect(rig.events == ["layout"])
+    #expect(rig.layout.mainDisplayID == 9)
+  }
+
+  @Test func oppositePortraitAnglesAreDifferentDespiteMatchingSizes() async {
+    let rig = LayoutRig()
+    rig.angles[9] = .ninety
+    rig.layout = .init(tiles: [rig.layout.tile(1)!, LayoutRig.tile(9, key: 2,
+      .init(x: 0, y: 800, width: 800, height: 1200))])
+    _ = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(rig.saved, arrivals: [1, 9])
+    #expect(rig.angles[9] == .twoSeventy)
+    #expect(rig.events == ["rotate:9:270", "layout"])
+  }
+
+  @Test func anAlreadyCorrectSetupIsNotReconfigured() async {
+    let rig = LayoutRig()
+    let saved = SavedArrangement(rig.layout, rotations: rig.angles)
+    _ = await SavedArrangementRestorer(arrangements: rig, rotations: rig)
+      .restore(saved, arrivals: [1, 9])
+    #expect(rig.events.isEmpty)
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/SavedLayoutRotationTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/SavedLayoutRotationTests.swift
@@ -1,0 +1,64 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import CandelaKit
+
+@Suite("Saved layout rotations")
+struct SavedLayoutRotationTests {
+  @Test func firstConfirmedArrangementIsRememberedWithoutEnablingOnLaunch() throws {
+    let store = ArrangementPersistence(defaults: InMemoryDefaults())
+    #expect(!store.isRestoreEnabled)
+    #expect(store.remembersConfirmedLayout)
+    store.saveConfirmed(ArrangementFixtures.pair, rotations: [2: .twoSeventy])
+    #expect(store.isRestoreEnabled)
+    let saved = try #require(store.savedArrangement(for: TopologySignature(ArrangementFixtures.pair)))
+    #expect(saved.entries.first { $0.identity == ArrangementFixtures.pair.tile(2)?.identity.key }?.rotation == .twoSeventy)
+  }
+
+  @Test func existingOptOutSurvivesAConfirmedArrangement() {
+    let store = ArrangementPersistence(defaults: InMemoryDefaults())
+    store.setRestoreEnabled(false)
+    #expect(!store.remembersConfirmedLayout)
+    store.saveConfirmed(ArrangementFixtures.pair)
+    #expect(!store.isRestoreEnabled)
+    #expect(store.savedArrangement(for: TopologySignature(ArrangementFixtures.pair)) == nil)
+  }
+
+  @Test func uncheckingRememberAtConfirmationIsAnExplicitOptOut() {
+    let store = ArrangementPersistence(defaults: InMemoryDefaults())
+    store.saveConfirmed(ArrangementFixtures.pair, remember: false)
+    #expect(!store.isRestoreEnabled)
+    #expect(!store.remembersConfirmedLayout)
+    store.saveConfirmed(ArrangementFixtures.pair)
+    #expect(store.savedArrangement(for: TopologySignature(ArrangementFixtures.pair)) == nil)
+  }
+
+  @Test func anEmptyCaptureDoesNotEnableRestoration() {
+    let store = ArrangementPersistence(defaults: InMemoryDefaults())
+    store.saveConfirmed(DisplayArrangement(tiles: []))
+    #expect(!store.isRestoreEnabled)
+    #expect(store.remembersConfirmedLayout)
+  }
+  @Test func savedRotationSurvivesDecodingAndReencoding() throws {
+    let data = Data(#"{"version":2,"entries":[{"identity":"dell","x":0,"y":0,"width":1440,"height":2560,"rotation":270}]}"#.utf8)
+    let saved = try JSONDecoder().decode(SavedArrangement.self, from: data)
+    let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(saved)) as! [String: Any]
+    let entries = try #require(encoded["entries"] as? [[String: Any]])
+    #expect(entries.first?["rotation"] as? Int == 270)
+  }
+
+  @Test func invalidStoredRotationIsRejectedInsteadOfSilentlyDiscarded() {
+    let data = Data(#"{"version":2,"entries":[{"identity":"dell","x":0,"y":0,"width":1440,"height":2560,"rotation":45}]}"#.utf8)
+    #expect(throws: (any Error).self) {
+      try JSONDecoder().decode(SavedArrangement.self, from: data)
+    }
+  }
+
+  @Test func legacyLayoutDoesNotInventAStandardRotation() throws {
+    let data = Data(#"{"version":1,"entries":[{"identity":"dell","x":0,"y":0,"width":1440,"height":2560}]}"#.utf8)
+    let saved = try JSONDecoder().decode(SavedArrangement.self, from: data)
+    let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(saved)) as! [String: Any]
+    let entries = try #require(encoded["entries"] as? [[String: Any]])
+    #expect(entries.first?["rotation"] == nil)
+  }
+}

--- a/docs/guide/display-setups.md
+++ b/docs/guide/display-setups.md
@@ -1,0 +1,28 @@
+# Remembering a display setup
+
+Candela can remember the positions and rotations of a set of displays and
+restore them when that set reconnects or Candela starts.
+
+When you first arrange displays in Candela and choose **Keep**, **Remember this
+display setup** is selected in the confirmation. Uncheck it if you only want to
+change the current arrangement. Installing or opening Candela alone does not
+enable restoration, and an existing decision to turn it off stays off.
+
+You can also enable **Remember display rotations and positions** in
+**Settings → Arrangement → Saved Display Setups**. This saves the current setup. Finish any active display-change preview first.
+Keeping subsequent arrangement or rotation changes in Candela updates it.
+Changes made in System Settings are left alone while the displays stay connected;
+the saved setup is used on their next reconnect. Turn restoration off to let
+macOS handle reconnects instead.
+
+Candela matches monitors by their stored identities, since their temporary display
+IDs can change after a reconnect. It restores rotations before placing displays,
+then checks the actual dimensions. A rotation failure stops position restoration;
+a changed resolution, missing monitor, or ambiguous identity can prevent the saved
+setup from being restored. These cases are reported in Arrangement.
+
+Existing saved layouts continue to restore positions. They gain rotation values
+the next time you save the setup. Displays saved without a rotation reading,
+and synthesized display sizes, keep position-only restoration.
+Rotation and position changes use separate macOS operations, so a failed restore
+can leave a partially restored setup; Candela reports the failure.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -13,6 +13,8 @@ hatches for hardware that misbehaves.
 - [Resolutions](resolutions.md). The size list, the HiDPI sizes macOS does not
   list, the in-between sizes Candela renders, and what happens when a size
   fails.
+- [Saved display setups](display-setups.md). Remembering rotations and positions,
+  what happens on reconnect, and when a saved setup cannot be restored.
 - [Diagnostics](diagnostics.md). What the per-display Diagnostics page reports
   and how to export it for an issue.
 - [Advanced settings](advanced-settings.md). The knobs that are set with


### PR DESCRIPTION
## What

Save each display's rotation with its position, restore rotations first, then re-read display geometry before restoring positions. The first arrangement confirmed in Candela offers a selected **Remember this display setup** checkbox; installation alone does not enable restoration, and existing opt-outs remain off.

Keeping later rotations updates an enabled saved setup. Legacy position-only layouts remain readable. Saving obeys the shared display-preview gate and preserves later opt-outs, including ones made while a commit is running.

## Why

Saved arrangements previously recorded positions only. If a portrait monitor reconnects at a different angle, its saved positions cannot restore the intended setup. This adds orientation to the existing feature without changing the separate adaptive OLED protection work.

## Hardware verification

Tested commit `74b855b5` on 2026-09-09 with the Developer ID signed Release build, a Dell U2725QE at 270° and MSI MAG 341C OLED through the Thunderbolt dock.

- MSI monitor-end disconnect/reconnect: Ryder confirmed correct rotation and arrangement. Fresh CoreGraphics readback matched every original display's identity, rotation, origin, dimensions, pixel mode and mirroring state.
- Whole dock upstream disconnect/reconnect: the same visual and readback checks passed. Candela remained PID5021 across both reconnects; no watchdog restart occurred during these two checks.
- Controlled opt-out and restore: turned Remember off through the UI, quit Candela, and used a temporary helper restricted to the Dell's identity to set it to Standard. Launching with Remember off left it at 0° and its changed footprint through startup. After quitting and enabling only the persisted restore flag, without replacing the saved descriptor, launching Candela restored 270° and the exact original positions and dimensions of all displays. The saved descriptor remained unchanged. This establishes app restoration separately from macOS's own reconnect behavior.

The local contributor ad-hoc build initially failed before app code ran because Sparkle failed library validation. The normal Developer ID Release build passed signature verification and the marker gate and was used for all hardware checks. The installed app and pre-test saved-layout preferences were restored afterward.

These results cover this layout change. They do not resolve the earlier watchdog findings in the separate adaptive OLED PR, and the original dock reset's underlying cause remains unconfirmed.

## Checks

- [x] `make check`: 2,530 engine tests and 596 app tests pass.
- [x] Tests cover rotation-before-position ordering, changed display IDs, legacy data, unreadable topology, rotation failures, opt-outs, preview rejection, duplicate answers, and opt-outs during a commit.
- [x] Independent review completed; all findings addressed.
- [x] `make build SIGNING=adhoc` and `make markers SIGNING=adhoc`: Debug and Release builds pass; Release marker scan passes with its positive control.
- [x] No ticket numbers in source comments or new em dashes in user-visible text/comments.
- [x] Live reconnect and controlled opt-out/restore verification described above.
