### PR TITLE
Include monitor capabilities and control context in diagnostics reports

### DIFF
--- a/Candela/App/AppModel.swift
+++ b/Candela/App/AppModel.swift
@@ -582,6 +582,16 @@ final class AppModel {
     if recentDisplayEvents.count > 20 {
       recentDisplayEvents.removeLast(recentDisplayEvents.count - 20)
     }
+    redactRecentDisplayEvents()
+  }
+
+  /// Permanently scrub while facts are still available, so disconnecting a
+  /// display cannot restore its identifiers in a later report's event history.
+  private func redactRecentDisplayEvents() {
+    let identifiers = diagnosticsPrivateIdentifiers
+    recentDisplayEvents = recentDisplayEvents.map {
+      DiagnosticsCapabilityText.redactingIdentifiers(in: $0, identifiers: identifiers)
+    }
   }
 
   @ObservationIgnored private var capabilityProbesInFlight: Set<String> = []
@@ -746,7 +756,10 @@ final class AppModel {
       accessibilityGranted: accessibility.isGranted,
       launchAtLogin: launchAtLoginText,
       displays: allControlledStates.map { diagnosticsEntry($0, audioOutput: audioOutput) },
-      recentEvents: recentDisplayEvents
+      recentEvents: recentDisplayEvents.map {
+        DiagnosticsCapabilityText.redactingIdentifiers(in: $0, identifiers: diagnosticsPrivateIdentifiers)
+      },
+      sections: diagnosticsSystemSections(audioOutput: audioOutput, capturedAt: Date())
     )
   }
 
@@ -784,16 +797,34 @@ final class AppModel {
     let prefs = DisplayPrefs(persistenceKey: persistenceKey)
     let facts = hardwareFacts[persistenceKey]
     let isBuiltIn = builtIn?.id == state.id
+    let identifiers = diagnosticsPrivateIdentifiers
+    func scrub(_ text: String) -> String {
+      DiagnosticsCapabilityText.redactingIdentifiers(in: text, identifiers: identifiers)
+    }
+    let capabilityRequest: String
+    if isBuiltIn {
+      capabilityRequest = "not applicable (built-in display)"
+    } else if capabilityString[persistenceKey] != nil {
+      capabilityRequest = "answered"
+    } else if capabilityProbesInFlight.contains(persistenceKey) {
+      capabilityRequest = "in progress"
+    } else if volumeSupport[persistenceKey] != nil {
+      capabilityRequest = "no readable reply"
+    } else if state.controller.isHDREngaged {
+      capabilityRequest = "not asked while HDR is active"
+    } else {
+      capabilityRequest = "not asked yet"
+    }
     return DiagnosticsReportSnapshot.DisplayEntry(
-      name: DisplayOrdering.title(
+      name: scrub(DisplayOrdering.title(
         friendlyName: prefs.friendlyName, hardwareName: state.display.name
-      ),
-      hardwareName: state.display.name,
+      )),
+      hardwareName: scrub(state.display.name),
       // The built-in never passes through `DisplayDiscovery`, so its facts are
       // permanently absent and "not reported" would read as a failed lookup
       // rather than as a panel with no cable.
       connection: isBuiltIn ? "None: built-in display" : DiagnosticsCopy.transport(facts),
-      manufacturer: isBuiltIn ? nil : facts?.manufacturerID,
+      manufacturer: isBuiltIn ? nil : facts?.manufacturerID.map(scrub),
       hasSerial: facts?.numericSerialNumber != nil || facts?.alphanumericSerialNumber != nil,
       // Never `catalogs[...]?.current` directly: the catalog exists only for
       // displays something has already shown, so the built-in's entry would depend
@@ -820,9 +851,10 @@ final class AppModel {
       hdrEngaged: state.controller.isHDREngaged,
       nonDefaultPrefs: DiagnosticsPrefSummary.nonDefaultPrefs(
         prefs, remembersMode: displayModes.isRemembering(state.id)
-      ),
+      ).map(scrub),
       volumeAvailability: diagnosticsVolumeAvailability(state),
-      soundOutput: diagnosticsSoundOutput(state, device: audioOutput)
+      soundOutput: scrub(diagnosticsSoundOutput(state, device: audioOutput)),
+      sections: diagnosticsDisplaySections(state, capabilityRequest: capabilityRequest)
     )
   }
 
@@ -1390,6 +1422,7 @@ final class AppModel {
   /// before the drain task exits, so no explicit `waitForPendingWrites()` is
   /// needed.
   private func performRefresh(settling: Bool = false) async -> [CGDirectDisplayID] {
+    redactRecentDisplayEvents()
     // The display set is about to be re-derived, so a memoized "discovery does
     // not know this id" is no longer evidence about anything.
     discoveredPersistenceKeys.clear()

--- a/Candela/App/DiagnosticsPageCopy.swift
+++ b/Candela/App/DiagnosticsPageCopy.swift
@@ -230,7 +230,7 @@ enum DiagnosticsPageCopy {
   // MARK: - Actions
 
   static var reportScope: LocalizedStringKey {
-    "Covers every display. The report doesn't include serial numbers."
+    "Covers your display setup, reported capabilities and control state. Identifying fields are redacted."
   }
 
   /// `NavigationRow` takes plain strings, so these are not `LocalizedStringKey`.

--- a/Candela/App/DiagnosticsSnapshot.swift
+++ b/Candela/App/DiagnosticsSnapshot.swift
@@ -1,0 +1,196 @@
+import CandelaKit
+import CoreGraphics
+import Darwin
+import Foundation
+
+struct DiagnosticsAvailability {
+  let brightness: String
+  let contrast: String
+  let mute: String
+  let hdr: String
+}
+
+extension AppModel {
+  typealias ReportField = DiagnosticsReportSnapshot.Field
+  typealias ReportSection = DiagnosticsReportSnapshot.Section
+
+  func diagnosticsAvailability(_ state: DisplayState) -> DiagnosticsAvailability {
+    let prefs = DisplayPrefs(persistenceKey: state.display.persistenceKey)
+    let builtIn = self.builtIn?.id == state.id
+    return DiagnosticsAvailability(
+      brightness: DiagnosticsCopy.brightnessAvailability(state.controller.brightnessPath),
+      contrast: builtIn ? "Not applicable: built-in display" : DiagnosticsCopy.contrastAvailability(
+        isAvailable: state.contrast.isAvailable, forceSoftware: prefs.forceSoftware),
+      mute: builtIn ? "Not applicable: built-in display" : DiagnosticsCopy.muteAvailability(
+        muteEnabled: prefs.enableMuteUnmute, volumeAvailable: state.volume.isAvailable,
+        forceSoftware: prefs.forceSoftware, override: prefs.audioSinkOverride,
+        muteSupport: muteSupport[state.display.persistenceKey] ?? .unknown),
+      hdr: builtIn ? "Managed by macOS" : (!state.controller.hdrCapabilityProbed
+        ? "Not checked yet" : DiagnosticsCopy.hdrAvailability(
+          displayServicesAvailable: DisplayServices.isAvailable,
+          supportsHDR: state.controller.supportsHDR, app: AppInfo.productName))
+    )
+  }
+
+  var diagnosticsWatchedKeyFamilies: [String] {
+    guard let config = lastArmedTapConfig else { return [] }
+    return DiagnosticsCopy.watchedKeyFamilies(
+      brightness: config.watchedKeys.contains(.brightnessUp) || config.watchedKeys.contains(.brightnessDown),
+      volume: config.watchedKeys.contains(.volumeUp) || config.watchedKeys.contains(.volumeDown),
+      mute: config.watchedKeys.contains(.mute))
+  }
+
+  var diagnosticsWatchedKeys: String {
+    DiagnosticsCopy.watchedKeys(families: diagnosticsWatchedKeyFamilies, tapRunning: lastArmedTapConfig != nil)
+  }
+
+  /// Only human-readable fields use this list. VCP numbers and dimensions are
+  /// measurements, even when their digits happen to equal a short serial.
+  var diagnosticsPrivateIdentifiers: [String] {
+    let storageKeys = allControlledStates.map(\.display.persistenceKey) + Array(hardwareFacts.keys)
+      + Array(capabilityString.keys)
+    let configKeys = displayModes.catalogs.values.map { $0.display.identity.key }
+      + mirrorTopology.topology().displays.map { $0.identity.key }
+    let serials = hardwareFacts.values.flatMap {
+      [$0.alphanumericSerialNumber, $0.numericSerialNumber.map(String.init)].compactMap { $0 }
+    }
+    let capabilityIdentifiers = capabilityString.values.flatMap { DiagnosticsCapabilityText.identifiers(in: $0) }
+    return (storageKeys + configKeys + serials + capabilityIdentifiers).filter { !$0.isEmpty && $0 != "builtIn" }
+  }
+
+  func diagnosticsSystemSections(audioOutput: AudioOutputDevice?, capturedAt: Date) -> [ReportSection] {
+    let topology = mirrorTopology.topology()
+    let controlledIDs = Set(allControlledStates.map(\.id))
+    let uncontrolled = topology.displays.filter { !controlledIDs.contains($0.id) }
+    let identifiers = diagnosticsPrivateIdentifiers
+    func scrub(_ value: String) -> String {
+      DiagnosticsCapabilityText.redactingIdentifiers(in: value, identifiers: identifiers)
+    }
+    var sections: [ReportSection] = [
+      .init("system", [
+        .init("captured at", capturedAt.formatted(.iso8601)),
+        .init("Mac model", DiagnosticsSystemInfo.macModel ?? "not reported"),
+        .init("screen recording", CGPreflightScreenCaptureAccess() ? "granted" : "not granted"),
+        .init("keys being watched", diagnosticsWatchedKeys),
+        .init("default sound output", scrub(audioOutput?.name ?? DiagnosticsCopy.noDefaultOutputDevice)),
+        .init("output has macOS volume control", audioOutput.map { $0.canSetOwnVolume ? "yes" : "no" }
+          ?? "not applicable (no output device)"),
+      ]),
+      .init("display inventory", [
+        .init("controlled displays", String(allControlledStates.count)),
+        .init("displays in cached topology", topology.displays.isEmpty ? "no topology sample available" : String(topology.displays.count)),
+        .init("scope", "Controlled displays are detailed below. Other displays use the cached topology; it may lag a connection change."),
+      ]),
+      .init("reading this report", [
+        .init("collection", "Uses recorded state. Export does not test commands or change display settings."),
+        .init("values", "App values may be requested or stored. Command acceptance does not confirm a physical change."),
+        .init("privacy", "Serial fields, known device identifiers and unrecognized capability payloads are redacted. Review custom device names before sharing."),
+      ]),
+    ]
+    if !uncontrolled.isEmpty {
+      sections.append(.init("other displays in cached topology", uncontrolled.map { display in
+        let reason = virtualDisplays.ownedDisplayIDs.contains(display.id)
+          ? "Virtual display created by Candela; no hardware control"
+          : "Not in the current control pool; exclusion reason was not recorded"
+        return .init(scrub(display.name), reason)
+      }))
+    }
+    return sections
+  }
+
+  func diagnosticsDisplaySections(_ state: DisplayState, capabilityRequest: String) -> [ReportSection] {
+    let key = state.display.persistenceKey
+    let prefs = DisplayPrefs(persistenceKey: key)
+    let isBuiltIn = builtIn?.id == state.id
+    let availability = diagnosticsAvailability(state)
+    let identifiers = diagnosticsPrivateIdentifiers
+    func scrub(_ value: String) -> String {
+      DiagnosticsCapabilityText.redactingIdentifiers(in: value, identifiers: identifiers)
+    }
+    var capabilityFields: [ReportField] = [.init("capability request", capabilityRequest)]
+    if let raw = capabilityString[key], !isBuiltIn {
+      // Derive from the original response, never the export's redacted text.
+      let codes = CapabilityString.codes(in: raw)
+      let exported = DiagnosticsCapabilityText(raw, identifiers: identifiers)
+      capabilityFields += [
+        .init("capability parsing", codes == nil ? "could not parse" : "parsed"),
+        .init("MCCS version", exported.metadata("mccs_ver")),
+        .init("capability model", exported.metadata("model")),
+        .init("display type", exported.metadata("type")),
+        .init("advertised VCP codes", codes.map { $0.sorted().map { String(format: "%02X", $0) }.joined(separator: " ") }
+          ?? "unknown (description did not parse)"),
+        .init("commands Candela uses", DiagnosticsCopy.advertisedCommands(codes, app: AppInfo.productName)),
+        .init("capability text treatment", exported.wasRedacted ? "redacted; parser results above use the original response" : "unchanged"),
+        .init("capability description", exported.text),
+      ]
+    } else {
+      capabilityFields.append(.init("capability description", capabilityRequest))
+    }
+
+    let noWire = "Not applicable: built-in display"
+    var sections: [ReportSection] = [
+      .init("reported capabilities", capabilityFields),
+      .init("availability", [
+        .init("brightness availability", availability.brightness),
+        .init("contrast availability", availability.contrast),
+        .init("mute availability", availability.mute),
+        .init("HDR availability", availability.hdr),
+      ]),
+      .init("recorded read evidence", [
+        .init("brightness read", isBuiltIn ? noWire : DiagnosticsReadEvidence.describe(state.controller.readEvidence)),
+        .init("volume read", isBuiltIn ? noWire : DiagnosticsReadEvidence.describe(state.volume.readEvidence)),
+        .init("contrast read", isBuiltIn ? noWire : DiagnosticsReadEvidence.describe(state.contrast.readEvidence)),
+        .init("brightness scale", isBuiltIn ? noWire : DiagnosticsCopy.brightnessScale(
+          didReadMax: state.controller.didReadMaxDDC, maxValue: state.controller.maxDDCValue,
+          evidence: state.controller.readEvidence, app: AppInfo.productName)),
+        .init("volume reported maximum", isBuiltIn ? noWire : state.volume.readMax.map(String.init) ?? "not recorded"),
+        .init("contrast reported maximum", isBuiltIn ? noWire : state.contrast.readMax.map(String.init) ?? "not recorded"),
+      ]),
+      .init("current app state", [
+        .init("brightness value", SliderSnap.percentText(state.controller.brightness)),
+        .init("volume value", isBuiltIn ? noWire : SliderSnap.percentText(state.volume.value)),
+        .init("contrast value", isBuiltIn ? noWire : SliderSnap.percentText(state.contrast.value)),
+        .init("muted in Candela", isBuiltIn ? noWire : state.volume.isMuted ? "yes" : "no"),
+        .init("last brightness command", DiagnosticsCopy.lastWrite(
+          target: state.controller.lastAppliedTarget(), failed: state.controller.lastApplyFailed())),
+        .init("OLED care enrolled", prefs.oledCareEnrolled ? "yes" : "no"),
+        .init("mirroring", DiagnosticsCopy.mirroring(
+          isMirrorSlave: mirrorTopology.topology().displays.first { $0.id == state.id }?.isMirrorSlave,
+          isSynthesized: synthesis.isEngaged(displayID: state.id))),
+        .init("last resolution problem", displayModes.report(for: state.id).map {
+          scrub(DiagnosticsCopy.reapplyProblem($0.notice, app: AppInfo.productName))
+        } ?? "none recorded"),
+      ]),
+    ]
+    if let facts = hardwareFacts[key] {
+      sections.append(.init("display hardware", [
+        .init("physical size", facts.physicalWidthCm.flatMap { width in
+          facts.physicalHeightCm.map { DiagnosticsCopy.displaySize(widthCm: width, heightCm: $0) }
+        } ?? "not reported"),
+        .init("hardware match score", String(facts.ioregMatchScore)),
+      ]))
+    }
+    if let catalog = displayModes.catalogs[state.id] {
+      sections.append(.init("resolution inventory", [
+        .init("resolutions listed by macOS", String(catalog.all.count { $0.provenance == .coreGraphics })),
+        .init("additional resolutions found", DiagnosticsCopy.additionalResolutions(
+          revealed: catalog.all.count(where: \.isRevealed), revealsHiddenModes: displayModes.revealsHiddenModes)),
+        .init("wire timing check", displayModes.guardsWireTiming ? "on" : "off"),
+        .init("withheld by wire timing check", String(catalog.withheldForWireTiming)),
+      ]))
+    } else {
+      sections.append(.init("resolution inventory", [.init("status", "not enumerated yet")]))
+    }
+    return sections
+  }
+}
+
+private enum DiagnosticsSystemInfo {
+  static var macModel: String? {
+    var count = 0
+    guard sysctlbyname("hw.model", nil, &count, nil, 0) == 0, count > 1, count < 256 else { return nil }
+    var bytes = [UInt8](repeating: 0, count: count)
+    guard sysctlbyname("hw.model", &bytes, &count, nil, 0) == 0 else { return nil }
+    return String(bytes: bytes.prefix { $0 != 0 }, encoding: .utf8)
+  }
+}

--- a/Candela/Settings/DiagnosticsPage.swift
+++ b/Candela/Settings/DiagnosticsPage.swift
@@ -457,7 +457,7 @@ struct DiagnosticsPage: View {
   /// display reports no HDR modes" about a panel whose HDR macOS drives fine.
   @ViewBuilder private var availabilityRows: some View {
     LabeledContent("Brightness") {
-      valueText(DiagnosticsCopy.brightnessAvailability(brightnessPath))
+      valueText(model.diagnosticsAvailability(state).brightness)
     }
 
     if !isBuiltIn {
@@ -469,30 +469,19 @@ struct DiagnosticsPage: View {
 
       SettingsCardDivider()
       LabeledContent("Contrast") {
-        valueText(DiagnosticsCopy.contrastAvailability(
-          isAvailable: state.contrast.isAvailable, forceSoftware: prefs.forceSoftware))
+        valueText(model.diagnosticsAvailability(state).contrast)
       }
       .help(DiagnosticsPageCopy.contrastHelp)
 
       SettingsCardDivider()
       LabeledContent("Mute") {
-        valueText(DiagnosticsCopy.muteAvailability(
-          muteEnabled: prefs.enableMuteUnmute,
-          volumeAvailable: state.volume.isAvailable,
-          forceSoftware: prefs.forceSoftware,
-          override: prefs.audioSinkOverride,
-          muteSupport: model.muteSupport[persistenceKey] ?? .unknown
-        ))
+        valueText(model.diagnosticsAvailability(state).mute)
       }
       .help(DiagnosticsPageCopy.muteHelp)
 
       SettingsCardDivider()
       LabeledContent("HDR") {
-        valueText(DiagnosticsCopy.hdrAvailability(
-          displayServicesAvailable: DisplayServices.isAvailable,
-          supportsHDR: state.controller.supportsHDR,
-          app: AppInfo.productName
-        ))
+        valueText(model.diagnosticsAvailability(state).hdr)
       }
     }
   }
@@ -623,8 +612,7 @@ struct DiagnosticsPage: View {
   /// Reads the LAST ARMED config, not a freshly computed one: the two differ
   /// exactly when a rearm failed, which is the case this row is for.
   private var watchedKeysText: String {
-    DiagnosticsCopy.watchedKeys(
-      families: watchedKeyFamilies, tapRunning: model.lastArmedTapConfig != nil)
+    model.diagnosticsWatchedKeys
   }
 
   /// Whether the tap is watching everything it ever watches. False while any
@@ -633,21 +621,6 @@ struct DiagnosticsPage: View {
     guard let config = model.lastArmedTapConfig else { return false }
     return config.watchedKeys.isSuperset(
       of: [.brightnessUp, .brightnessDown, .volumeUp, .volumeDown, .mute])
-  }
-
-  /// Split out so the row can tell "watching nothing" from "not running" and
-  /// caption the first without recomputing the words.
-  private var watchedKeyFamilies: [String] {
-    guard let config = model.lastArmedTapConfig else { return [] }
-    return DiagnosticsCopy.watchedKeyFamilies(
-      brightness: config.watchedKeys.contains(.brightnessUp)
-        || config.watchedKeys.contains(.brightnessDown),
-      // Reported apart because they are ARMED apart: the two write different
-      // registers, and a display can list one and deny the other.
-      volume: config.watchedKeys.contains(.volumeUp)
-        || config.watchedKeys.contains(.volumeDown),
-      mute: config.watchedKeys.contains(.mute)
-    )
   }
 
   private var audioMatchText: String {

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -352,7 +352,7 @@ struct CopyBuilderTests {
     #expect(render(DiagnosticsPageCopy.hdrTurnedOnOutside).contains("HDR was turned on outside"))
     #expect(render(DiagnosticsPageCopy.watchedKeys).contains("go straight to macOS"))
     #expect(render(DiagnosticsPageCopy.accessibilityMissing).contains("does not have Accessibility permission"))
-    #expect(render(DiagnosticsPageCopy.reportScope).contains("doesn't include serial numbers"))
+    #expect(render(DiagnosticsPageCopy.reportScope).contains("Identifying fields are redacted"))
     #expect(DiagnosticsPageCopy.controlMethodTitle == "Hardware control not responding?")
     #expect(DiagnosticsPageCopy.controlMethodValue == "Control Method")
     #expect(render(DiagnosticsPageCopy.copyReport).contains("Copy Report"))

--- a/CandelaAppTests/DiagnosticsSnapshotTests.swift
+++ b/CandelaAppTests/DiagnosticsSnapshotTests.swift
@@ -1,4 +1,5 @@
 import CandelaKit
+import CoreGraphics
 import Foundation
 import Testing
 
@@ -70,6 +71,184 @@ struct DiagnosticsSnapshotTests {
     #expect(report.contains("  volume: \(reason)\n"))
   }
 
+  @Test func reportIncludesTheCapabilityInputAndParsedCommandsForEveryDisplay() async throws {
+    let raw = "(prot(monitor)type(lcd)model(P32U)cmds(01 03 F3)vcp(10 12 60(0F 11))mccs_ver(2.2))"
+    let model = await model(audio: FakeAudio(), capabilities: raw)
+    for _ in 0..<200 where model.volumeSupport.count < 2 { await Task.yield() }
+    #expect(model.volumeSupport.count == 2)
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    let sections = report.components(separatedBy: "\ndisplay: ")
+    for name in ["Left Monitor", "Right Monitor"] {
+      let section = try #require(sections.first { $0.hasPrefix(name + "\n") })
+      #expect(section.contains(raw))
+      #expect(section.contains("MCCS version: 2.2"))
+      #expect(section.contains("advertised VCP codes: 10 12 60"))
+      #expect(section.contains("capability parsing: parsed"))
+    }
+    Attachment.record(report, named: "Diagnostics sample with simulated displays.txt")
+  }
+
+  @Test func reportDistinguishesMalformedCapabilitiesFromAnUnansweredRequest() async throws {
+    let malformed = await model(audio: FakeAudio(), capabilities: "(vcp(10 ZZ))")
+    let unanswered = await model(audio: FakeAudio())
+    for _ in 0..<200 where malformed.volumeSupport.count < 2 || unanswered.volumeSupport.count < 2 {
+      await Task.yield()
+    }
+    #expect(malformed.volumeSupport.count == 2)
+    #expect(unanswered.volumeSupport.count == 2)
+    let badReport = DiagnosticsReport.render(malformed.diagnosticsSnapshot())
+    let noReport = DiagnosticsReport.render(unanswered.diagnosticsSnapshot())
+    #expect(badReport.contains("capability parsing: could not parse"))
+    #expect(badReport.contains("(vcp(10 ZZ))"))
+    #expect(noReport.contains("capability description: no readable reply"))
+    #expect(!noReport.contains("advertised VCP codes: none"))
+  }
+
+  @Test func reportDoesNotPublishIdentifierOrVendorPayloadsFromCapabilities() async throws {
+    let raw = "(prot(monitor)model(P32U PRIVATE-SERIAL-123)serial(PRIVATE-SERIAL-123)vendor_data(PRIVATE-VENDOR-456)vcp(10 12))"
+    let model = await model(audio: FakeAudio(), capabilities: raw)
+    for _ in 0..<200 where model.volumeSupport.count < 2 { await Task.yield() }
+    #expect(model.volumeSupport.count == 2)
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(report.contains("vcp(10 12)"))
+    #expect(report.contains("serial([redacted])"))
+    #expect(report.contains("vendor_data([redacted])"))
+    #expect(!report.contains("PRIVATE-SERIAL-123"))
+    #expect(!report.contains("PRIVATE-VENDOR-456"))
+    #expect(report.contains("capability model: P32U [redacted]"))
+  }
+
+  @Test func departedDisplaysCannotRestoreIdentifiersInRecentEvents() async throws {
+    let key = "report-departed-\(UUID().uuidString)"
+    let discovery = ScriptedDiscovery([(id: 70004, key: key, name: "Monitor PRIVATE123 \(key)")])
+    let model = AppModel(
+      shade: FakeShade(), gamma: FakeGamma(), hdrToggling: FakeHDR(), audioDevices: FakeAudio(),
+      safeMode: true, discoverDisplays: {
+        let entries = discovery.discover($0)
+        for entry in entries {
+          (entry.writer as? FakeDDCWriter)?.capabilities = "(serial(PRIVATE123)vcp(10))"
+        }
+        return entries
+      })
+    _ = await model.refresh()
+    for _ in 0..<200 where model.volumeSupport[key] == nil { await Task.yield() }
+    _ = try #require(model.volumeSupport[key])
+    let before = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(!before.contains("PRIVATE123"))
+    #expect(!before.contains(key))
+    discovery.topology = []
+    _ = await model.refresh()
+    #expect(model.capabilityString[key] == nil)
+    #expect(model.hardwareFacts[key] == nil)
+    let after = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(after.contains("arrived"))
+    #expect(after.contains("departed"))
+    #expect(!after.contains("PRIVATE123"))
+    #expect(!after.contains(key))
+  }
+
+  @Test func uncontrolledTopologyNamesAreScrubbedWithTheirOwnIdentity() {
+    let model = AppModel(shade: FakeShade(), gamma: FakeGamma(), hdrToggling: FakeHDR(),
+                         audioDevices: FakeAudio(), safeMode: true, discoverDisplays: { _ in [] })
+    let identity = DisplayConfigIdentity(vendor: 100, model: 200, serial: 7391955, isBuiltIn: false)
+    model.mirrorTopology.update(MirrorTopology([
+      ConfiguredDisplay(id: 70005, identity: identity, name: "Other \(identity.key)", isBuiltIn: false),
+    ]))
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(report.contains("other displays in cached topology:"))
+    #expect(report.contains("Other [redacted]"))
+    #expect(!report.contains(identity.key))
+  }
+
+  @Test func reportIncludesPerControlEvidenceAndCurrentAudioVolumeOwnership() async {
+    let audio = FakeAudio(device: .init(id: 1, name: "Left Monitor", canSetOwnVolume: false))
+    let model = await model(audio: audio)
+    let before = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    for label in ["brightness availability:", "contrast availability:", "mute availability:",
+                  "HDR availability:", "brightness read:", "volume read:", "contrast read:",
+                  "keys being watched:", "screen recording:", "Mac model:", "captured at:"] {
+      #expect(before.contains(label), "Missing \(label)")
+    }
+    #expect(before.contains("output has macOS volume control: no"))
+    audio.device = .init(id: 2, name: "Headphones", canSetOwnVolume: true)
+    let after = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(after.contains("output has macOS volume control: yes"))
+    audio.device = nil
+    #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains(
+      "output has macOS volume control: not applicable (no output device)"))
+  }
+
+  @Test func reportDistinguishesPendingCapabilitiesAndUnprobedHDR() async throws {
+    let writer = ReportPendingWriter()
+    let key = "report-pending-\(UUID().uuidString)"
+    let discovery = ScriptedDiscovery([(id: 70006, key: key, name: "Pending monitor")])
+    let model = AppModel(shade: FakeShade(), gamma: FakeGamma(), hdrToggling: FakeHDR(),
+      audioDevices: FakeAudio(), safeMode: true, discoverDisplays: {
+        discovery.discover($0).map { (display: $0.display, writer: writer, facts: $0.facts) }
+      })
+    _ = await model.refresh()
+    let pending = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    await writer.resolve()
+    #expect(pending.contains("capability request: in progress"))
+    #expect(pending.contains("HDR availability: Not checked yet"))
+    for _ in 0..<200 where model.volumeSupport[key] == nil { await Task.yield() }
+    _ = try #require(model.volumeSupport[key])
+    #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains("capability request: no readable reply"))
+  }
+
+  @Test func reportDistinguishesAnUnavailableTapFromIntentionallyWatchingNoKeys() {
+    let model = AppModel(shade: FakeShade(), gamma: FakeGamma(), hdrToggling: FakeHDR(),
+                         audioDevices: FakeAudio(), safeMode: true, discoverDisplays: { _ in [] })
+    #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains("None: the media-key tap is not running"))
+    model.noteTapArmed(.init(watchedKeys: [], interceptAlternateBrightnessKeys: false))
+    #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains("None: every media key is going straight to macOS"))
+    model.noteTapArmed(.init(watchedKeys: [.volumeUp, .volumeDown], interceptAlternateBrightnessKeys: false))
+    #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains("keys being watched: volume"))
+    model.noteTapDisarmed()
+    #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains("None: the media-key tap is not running"))
+  }
+
+  @Test func snapshotDoesNotIssueHardwareRequestsOrChangeStoredValues() async throws {
+    let key = "report-read-only-\(UUID().uuidString)"
+    let writer = ReportCountingWriter()
+    let model = AppModel(
+      shade: FakeShade(), gamma: FakeGamma(), hdrToggling: FakeHDR(), audioDevices: FakeAudio(),
+      safeMode: true, discoverDisplays: { _ in
+        [(display: ExternalDisplay(id: 70003, name: "Read-only fixture", persistenceKey: key),
+          writer: writer,
+          facts: DisplayHardwareFacts(transportUpstream: "DP", transportDownstream: nil,
+            manufacturerID: "TEST", alphanumericSerialNumber: "PRIVATE-SERIAL-987", numericSerialNumber: nil,
+            physicalWidthCm: 60, physicalHeightCm: 34, ioDisplayLocation: "PRIVATE-IOREG", ioregMatchScore: 20))]
+      })
+    _ = await model.refresh()
+    for _ in 0..<200 where model.volumeSupport[key] == nil { await Task.yield() }
+    _ = try #require(model.volumeSupport[key])
+    let state = try #require(model.displays.first)
+    let beforeCalls = await writer.calls
+    let beforeValues = [state.controller.brightness, state.volume.value, state.contrast.value]
+    let snapshot = model.diagnosticsSnapshot()
+    let report = DiagnosticsReport.render(snapshot)
+    #expect(DiagnosticsReport.render(snapshot) == report)
+    #expect(await writer.calls == beforeCalls)
+    #expect([state.controller.brightness, state.volume.value, state.contrast.value] == beforeValues)
+    #expect(!report.contains(key))
+    #expect(!report.contains("PRIVATE-SERIAL-987"))
+    #expect(!report.contains("PRIVATE-IOREG"))
+    #expect(report.contains("capability model: Test [redacted]"))
+    #expect(report.contains("advertised VCP codes: 10 12"))
+  }
+
+  @Test func reportKeepsParserFailureWhenRawPayloadsAreRedacted() async {
+    let model = await model(audio: FakeAudio(), capabilities: "(vcp(10 PRIVATE-SERIAL))")
+    for _ in 0..<200 where model.volumeSupport.count < 2 { await Task.yield() }
+    #expect(model.volumeSupport.count == 2)
+    let report = DiagnosticsReport.render(model.diagnosticsSnapshot())
+    #expect(report.contains("capability parsing: could not parse"))
+    #expect(report.contains("advertised VCP codes: unknown"))
+    #expect(report.contains("vcp(10 [redacted])"))
+    #expect(!report.contains("PRIVATE-SERIAL"))
+  }
+
   @Test func reportUsesTheDisplaysVolumeAndAudioNameOverrides() async throws {
     let audio = FakeAudio(device: .init(id: 1, name: "Desk Speakers", canSetOwnVolume: false))
     let model = await model(audio: audio)
@@ -88,5 +267,37 @@ struct DiagnosticsSnapshotTests {
     prefs.audioSinkOverride = .forcePresent
     #expect(DiagnosticsReport.render(model.diagnosticsSnapshot()).contains(
       "volume: Available: you set this display's volume slider to always on"))
+  }
+}
+
+private actor ReportCountingWriter: DDCWriting {
+  private(set) var calls = 0
+  func write(command: UInt8, value: UInt16) async -> Bool {
+    calls += 1
+    return true
+  }
+  func read(command: UInt8) async -> (current: UInt16, max: UInt16)? {
+    calls += 1
+    return nil
+  }
+  func readCapabilityString() async -> String? {
+    calls += 1
+    return "(model(Test PRIVATE-SERIAL-987)vcp(10 12))"
+  }
+}
+
+private actor ReportPendingWriter: DDCWriting {
+  private var released = false
+  private var continuation: CheckedContinuation<String?, Never>?
+  func write(command: UInt8, value: UInt16) async -> Bool { true }
+  func read(command: UInt8) async -> (current: UInt16, max: UInt16)? { nil }
+  func readCapabilityString() async -> String? {
+    if released { return nil }
+    return await withCheckedContinuation { continuation = $0 }
+  }
+  func resolve() {
+    released = true
+    continuation?.resume(returning: nil)
+    continuation = nil
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -380,6 +380,10 @@ public final class BrightnessController: PendingWireDraining {
   /// HDR settle window: the display blanks and re-modes for ~2 s after an HDR
   /// toggle. Internal so tests can shrink it.
   @ObservationIgnored var settleDelay: Duration = .seconds(2)
+  /// Lets overlap tests hold the exit between its two supersession fences.
+  @ObservationIgnored var waitForHDRExitSettle: @Sendable (Duration) async -> Void = {
+    try? await Task.sleep(for: $0)
+  }
   /// Pause between the wire-settling rounds a restore runs before it re-engages
   /// HDR. Sized in `WireQuiescence` to outlast a reconfiguration's write gate;
   /// internal so tests can shrink it.
@@ -1345,7 +1349,7 @@ public final class BrightnessController: PendingWireDraining {
       cachedHDRActive = true // assume locked: see the rule above
       return false
     }
-    try? await Task.sleep(for: settleDelay)
+    await waitForHDRExitSettle(settleDelay)
     guard hdrTransitionGeneration == generation else {
       cachedHDRActive = true // assume locked: see the rule above
       return false // post-settle

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCapabilityText.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsCapabilityText.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// An export-only view of device-provided text. Parser verdicts must use the
+/// original response, because redaction can change its syntax.
+public struct DiagnosticsCapabilityText: Sendable {
+  public let text: String
+  public let wasRedacted: Bool
+  private let source: String?
+  private let identifiers: [String]
+
+  public init(_ raw: String, identifiers: [String] = []) {
+    guard raw.utf8.count <= 16_384 else {
+      text = "[withheld: capability description exceeds 16384 bytes]"
+      wasRedacted = true
+      source = nil
+      self.identifiers = []
+      return
+    }
+    source = raw
+    let identifiers = identifiers + Self.identifiers(in: raw)
+    self.identifiers = identifiers
+    let chars = Array(raw)
+    var output = ""
+    var index = 0
+    while index < chars.count {
+      let character = chars[index]
+      if character == "(" || character == ")" || character.isWhitespace {
+        output.append(character)
+        index += 1
+        continue
+      }
+      let start = index
+      while index < chars.count, Self.isTagCharacter(chars[index]) { index += 1 }
+      guard index > start, index < chars.count, chars[index] == "(" else {
+        if index == start { index += 1 }
+        output += "[redacted]"
+        continue
+      }
+      let name = String(chars[start..<index])
+      let bodyStart = index + 1
+      var end = bodyStart
+      var depth = 1
+      while end < chars.count {
+        if chars[end] == "(" { depth += 1 }
+        if chars[end] == ")" { depth -= 1 }
+        if depth == 0 { break }
+        end += 1
+      }
+      let body = String(chars[bodyStart..<end])
+      let knownNames = ["prot", "type", "model", "cmds", "vcp", "mccs_ver", "mswhql",
+                        "serial", "serial_number", "sn", "vendor_data", "asset_tag"]
+      let safeName = knownNames.contains(name.lowercased()) ? name : "[redacted field]"
+      output += safeName + "("
+      output += Self.metadata(body, field: name, identifiers: identifiers)
+      // Do not repair truncated replies: the missing closing parenthesis is evidence.
+      if end < chars.count { output += ")" }
+      index = min(end + 1, chars.count)
+    }
+    text = output
+    wasRedacted = output != raw
+  }
+
+  /// Parsed metadata uses the same identifier set and size limit as the raw
+  /// export, including identifiers learned from the response itself.
+  public func metadata(_ field: String) -> String {
+    guard let source else { return "withheld (oversized description)" }
+    return Self.metadata(CapabilityString.tag(field, in: source), field: field, identifiers: identifiers)
+  }
+
+  public static func identifiers(in raw: String) -> [String] {
+    guard raw.utf8.count <= 16_384,
+          let regex = try? NSRegularExpression(
+            pattern: #"(?i)(?<![a-z0-9_])(?:serial(?:[_ -]?(?:number|no))?|sn|asset[_ -]?tag|uuid)\s*\(([^()]*)"#)
+    else { return [] }
+    return regex.matches(in: raw, range: NSRange(raw.startIndex..., in: raw)).compactMap { match in
+      guard let range = Range(match.range(at: 1), in: raw) else { return nil }
+      let value = raw[range].trimmingCharacters(in: .whitespacesAndNewlines)
+      return value.isEmpty ? nil : value
+    }
+  }
+
+  public static func metadata(_ value: String?, field: String, identifiers: [String] = []) -> String {
+    guard let body = value else { return "not stated" }
+    let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    switch field.lowercased() {
+    case "vcp", "cmds":
+      return Self.codeList(body)
+    case "model":
+      let simple = body.count <= 128 && !body.contains("(") && !body.contains(")")
+        && body.unicodeScalars.allSatisfy { $0.value >= 32 && $0.value < 127 }
+      let labelsIdentity = body.range(
+        of: #"\b(?:serial(?:[_ -]?(?:number|no))?|sn|asset[_ -]?tag|uuid|edid)\s*[:=]"#,
+        options: [.regularExpression, .caseInsensitive]) != nil
+      return simple && !labelsIdentity
+        ? Self.redactingIdentifiers(in: body, identifiers: identifiers) : "[redacted]"
+    case "prot":
+      return trimmed.lowercased() == "monitor" ? body : "[redacted]"
+    case "type":
+      return ["lcd", "crt", "oled", "led"].contains(trimmed.lowercased()) ? body : "[redacted]"
+    case "mccs_ver":
+      return trimmed.range(of: #"^[0-9]{1,3}\.[0-9]{1,3}$"#, options: .regularExpression) != nil
+        ? body : "[redacted]"
+    case "mswhql":
+      return trimmed.range(of: #"^[0-9]{1,2}$"#, options: .regularExpression) != nil ? body : "[redacted]"
+    default:
+      return "[redacted]"
+    }
+  }
+
+  public static func redactingIdentifiers(in text: String, identifiers: [String]) -> String {
+    let patterns = Set(identifiers.filter { !$0.isEmpty }).sorted { $0.count > $1.count }
+      .map(NSRegularExpression.escapedPattern(for:))
+    guard !patterns.isEmpty,
+          let regex = try? NSRegularExpression(pattern: patterns.joined(separator: "|"), options: .caseInsensitive)
+    else { return text }
+    return regex.stringByReplacingMatches(in: text, range: NSRange(text.startIndex..., in: text), withTemplate: "[redacted]")
+  }
+
+  private static func isTagCharacter(_ character: Character) -> Bool {
+    character.isASCII && (character.isLetter || character.isNumber || "_-.".contains(character))
+  }
+
+  private static func codeList(_ body: String) -> String {
+    var output = ""
+    var token = ""
+    func flush() {
+      guard !token.isEmpty else { return }
+      // Keep short malformed codes such as ZZ and +1 useful for parser diagnosis.
+      let safe = token.count <= 2 && token.allSatisfy {
+        $0.isASCII && ($0.isLetter || $0.isNumber || "+-".contains($0))
+      }
+      output += safe ? token : "[redacted]"
+      token = ""
+    }
+    for character in body {
+      if character == "(" || character == ")" || character.isWhitespace {
+        flush()
+        output.append(character)
+      } else {
+        token.append(character)
+      }
+    }
+    flush()
+    return output
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsReadEvidence.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsReadEvidence.swift
@@ -1,0 +1,11 @@
+public enum DiagnosticsReadEvidence {
+  public static func describe(_ evidence: DDCReadEvidence) -> String {
+    switch evidence {
+    case .notAttempted: "No usable read result recorded yet"
+    case .answered: "A read returned a value with a nonzero maximum"
+    case .allZeros: "Recorded a zero-valued or zero-maximum reply; no usable value"
+    case .noReply: "No readable reply recorded (silence or an invalid response)"
+    case .refused: "The display reported that this command is unsupported"
+    }
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Support/DiagnosticsReport.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/DiagnosticsReport.swift
@@ -3,6 +3,26 @@
 /// `recentEvents` arrive pre-formatted so the renderer stays pure: one snapshot
 /// always renders to the same bytes, which is what makes two pasted reports diffable.
 public struct DiagnosticsReportSnapshot: Sendable {
+  public struct Field: Sendable {
+    public let name: String
+    public let value: String
+
+    public init(_ name: String, _ value: String) {
+      self.name = name
+      self.value = value
+    }
+  }
+
+  public struct Section: Sendable {
+    public let name: String
+    public let fields: [Field]
+
+    public init(_ name: String, _ fields: [Field]) {
+      self.name = name
+      self.fields = fields
+    }
+  }
+
   public struct DisplayEntry: Sendable {
     public let name: String
     public let hardwareName: String
@@ -21,11 +41,13 @@ public struct DiagnosticsReportSnapshot: Sendable {
     /// name and value only (`forceSw = true`), never a full storage key: a
     /// persistence key carries the display's serial.
     public let nonDefaultPrefs: [String]
+    public let sections: [Section]
 
     public init(name: String, hardwareName: String, connection: String?,
                 manufacturer: String?, hasSerial: Bool, currentMode: String?,
                 controlMethod: String, readbackVerdict: String, hdrEngaged: Bool,
-                nonDefaultPrefs: [String], volumeAvailability: String, soundOutput: String) {
+                nonDefaultPrefs: [String], volumeAvailability: String, soundOutput: String,
+                sections: [Section] = []) {
       self.name = name
       self.hardwareName = hardwareName
       self.connection = connection
@@ -38,6 +60,7 @@ public struct DiagnosticsReportSnapshot: Sendable {
       self.nonDefaultPrefs = nonDefaultPrefs
       self.volumeAvailability = volumeAvailability
       self.soundOutput = soundOutput
+      self.sections = sections
     }
   }
 
@@ -49,10 +72,11 @@ public struct DiagnosticsReportSnapshot: Sendable {
   public let displays: [DisplayEntry]
   /// Newest first, each already carrying its own short timestamp.
   public let recentEvents: [String]
+  public let sections: [Section]
 
   public init(appVersion: String, osVersion: String, safeMode: Bool,
               accessibilityGranted: Bool, launchAtLogin: String,
-              displays: [DisplayEntry], recentEvents: [String]) {
+              displays: [DisplayEntry], recentEvents: [String], sections: [Section] = []) {
     self.appVersion = appVersion
     self.osVersion = osVersion
     self.safeMode = safeMode
@@ -60,12 +84,13 @@ public struct DiagnosticsReportSnapshot: Sendable {
     self.launchAtLogin = launchAtLogin
     self.displays = displays
     self.recentEvents = recentEvents
+    self.sections = sections
   }
 }
 
 public enum DiagnosticsReport {
   public static func render(_ s: DiagnosticsReportSnapshot) -> String {
-    var lines = ["Candela diagnostics report", ""]
+    var lines = ["Candela diagnostics report", "report format: 2", ""]
 
     lines += [
       "app: \(s.appVersion)",
@@ -75,6 +100,9 @@ public enum DiagnosticsReport {
       "launch at login: \(s.launchAtLogin)",
       "",
     ]
+    for section in s.sections {
+      lines += render(section, indent: "") + [""]
+    }
 
     if s.displays.isEmpty {
       lines += ["displays: none", ""]
@@ -100,6 +128,9 @@ public enum DiagnosticsReport {
           lines.append("  non-default settings:")
           lines += display.nonDefaultPrefs.map { "    \($0)" }
         }
+        for section in display.sections {
+          lines += render(section, indent: "  ")
+        }
       }
       lines.append("")
     }
@@ -118,5 +149,13 @@ public enum DiagnosticsReport {
   /// absent capability to whoever triages the paste.
   private static func reported(_ value: String?) -> String {
     value ?? "not reported"
+  }
+
+  private static func render(_ section: DiagnosticsReportSnapshot.Section, indent: String) -> [String] {
+    ["\(indent)\(section.name):"] + section.fields.flatMap { field in
+      let parts = field.value.split(separator: "\n", omittingEmptySubsequences: false)
+      return ["\(indent)  \(field.name): \(parts.first ?? "")"]
+        + parts.dropFirst().map { "\(indent)    \($0)" }
+    }
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/DiagnosticsCapabilityTextTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DiagnosticsCapabilityTextTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import CandelaKit
+
+@Suite("Capability text exported in reports")
+struct DiagnosticsCapabilityTextTests {
+  @Test func preservesOrdinaryResponsesIncludingMalformedCommandTokens() {
+    for raw in ["(prot(monitor)type(lcd)model(P32U)cmds(01 03 F3)vcp(10 60(01 03 62))mccs_ver(2.2))",
+                "(VCP(10 12)\n model(P32U) mswhql(1))", "(vcp(10 ZZ +1))", "vcp(10 12)",
+                "(vcp(10 12)", "(vcp(10 12)))"] {
+      let result = DiagnosticsCapabilityText(raw)
+      #expect(result.text == raw)
+      #expect(!result.wasRedacted)
+    }
+  }
+
+  @Test func withholdsUnknownAndNestedIdentifierPayloadsWithoutRepairingTruncation() {
+    let cases = [
+      ("(serial(PRIVATE-123)vcp(10 12))", "(serial([redacted])vcp(10 12))"),
+      ("(vendor_data(nested(PRIVATE-123))vcp(10 12))", "(vendor_data([redacted])vcp(10 12))"),
+      ("(model(serial(PRIVATE-123))vcp(10))", "(model([redacted])vcp(10))"),
+      ("(vcp(PRIVATE-123))", "(vcp([redacted]))"),
+      ("(vcp(10)serial(PRIVATE-123", "(vcp(10)serial([redacted]"),
+      ("(vcp(10))PRIVATE-123", "(vcp(10))[redacted]"),
+      ("(PRIVATE123(value)vcp(10))", "([redacted field]([redacted])vcp(10))"),
+      ("(PRIVATESERIAL(value)vcp(10))", "([redacted field]([redacted])vcp(10))"),
+    ]
+    for (raw, expected) in cases {
+      let result = DiagnosticsCapabilityText(raw)
+      #expect(result.text == expected)
+      #expect(result.wasRedacted)
+      #expect(!result.text.contains("PRIVATE"))
+    }
+  }
+
+  @Test func removesKnownIdentifiersFromModelWithoutChangingCommandValues() {
+    let result = DiagnosticsCapabilityText("(model(P32U PRIVATE-123)vcp(10 12))", identifiers: ["PRIVATE-123"])
+    #expect(result.text == "(model(P32U [redacted])vcp(10 12))")
+    #expect(result.wasRedacted)
+  }
+
+  @Test func boundsUntrustedPayloads() {
+    let result = DiagnosticsCapabilityText("(model(" + String(repeating: "a", count: 20_000) + "))")
+    #expect(result.wasRedacted)
+    #expect(result.text == "[withheld: capability description exceeds 16384 bytes]")
+    #expect(result.metadata("model") == "withheld (oversized description)")
+  }
+
+  @Test func separatelyExportedMetadataCannotBypassRedaction() {
+    #expect(DiagnosticsCapabilityText.metadata("serial(PRIVATE)", field: "model") == "[redacted]")
+    #expect(DiagnosticsCapabilityText.metadata("PRIVATE", field: "mccs_ver") == "[redacted]")
+    #expect(DiagnosticsCapabilityText.metadata("PRIVATE", field: "type") == "[redacted]")
+    #expect(DiagnosticsCapabilityText.metadata("P32U secret", field: "model", identifiers: ["secret"]) == "P32U [redacted]")
+    #expect(DiagnosticsCapabilityText.metadata("P32U serial=PRIVATE123", field: "model") == "[redacted]")
+    #expect(DiagnosticsCapabilityText.metadata("P32U Serial Number: PRIVATE123", field: "model") == "[redacted]")
+  }
+
+  @Test func identifyingFieldsAlsoRedactCopiesElsewhereInTheResponse() {
+    for raw in ["(serial(PRIVATE123)model(P32U PRIVATE123)vcp(10))",
+                "(model(P32U PRIVATE123)serial(PRIVATE123)vcp(10))",
+                "(model(P32U PRIVATE123)asset_tag(PRIVATE123)vcp(10))"] {
+      let exported = DiagnosticsCapabilityText(raw)
+      #expect(!exported.text.contains("PRIVATE123"))
+      #expect(exported.text.contains("model(P32U [redacted])"))
+      #expect(exported.text.contains("vcp(10)"))
+      #expect(exported.metadata("model") == "P32U [redacted]")
+    }
+  }
+
+  @Test func preservesWhitespaceWithinRecognizedScalarFields() {
+    let raw = "(prot( monitor )type( LCD )mccs_ver( 2.2 )mswhql( 1 )vcp(10))"
+    #expect(DiagnosticsCapabilityText(raw).text == raw)
+    #expect(!DiagnosticsCapabilityText(raw).wasRedacted)
+  }
+
+  @Test func redactsIdentifiersOnceWithoutRewritingInsertedMarkers() {
+    #expect(DiagnosticsCapabilityText.redactingIdentifiers(in: "secret redacted", identifiers: ["secret", "redacted"])
+      == "[redacted] [redacted]")
+  }
+}

--- a/CandelaKit/Tests/CandelaKitTests/PathSelectionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PathSelectionTests.swift
@@ -148,6 +148,24 @@ final class MemoInvalidationRecorder: PendingWireDraining {
   func drainPendingWrites() async -> Bool { true }
 }
 
+private actor HDRExitSettleGate {
+  private(set) var entered = false
+  private var released = false
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    entered = true
+    if released { return }
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func release() {
+    released = true
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
 /// A DDC writer that holds every write until released, and records what the HDR
 /// backend had been told at the moment it finally applied one. A shared
 /// timeline rather than two independent counters, so "the write landed before
@@ -946,24 +964,36 @@ struct PathSelectionTests {
   @Test func anExitSupersededDuringItsSettleDropsNoMemos() async {
     let volume = MemoInvalidationRecorder()
     let contrast = MemoInvalidationRecorder()
-    // Sized against the poll below, which returns within a few milliseconds of
-    // the drop being issued: the supersession lands inside the settle window by
-    // construction rather than by scheduling luck.
-    let h = Harness(
-      hdrEnabled: true, settle: .milliseconds(150),
-      configure: { prefs, _ in prefs.hdrMode = .alwaysOn },
-      wireSiblings: { _ in [volume, contrast] }
+    let prefs = DisplayPrefs(defaults: InMemoryDefaults(), persistenceKey: "t")
+    prefs.hdrMode = .alwaysOn
+    let hdr = GatedTransitionHDR()
+    let settle = HDRExitSettleGate()
+    let controller = BrightnessController(
+      writer: FakeDDC(readResult: nil),
+      backends: BrightnessBackends(
+        applierNative: FakeNativeApplier(), hdr: hdr,
+        shade: RecordingShade(), gamma: RecordingGamma()
+      ),
+      prefs: prefs, displayID: 7, wireSiblings: [volume, contrast]
     )
-    await h.prime()
+    controller.settleDelay = .milliseconds(5)
+    controller.waitForHDRExitSettle = { _ in await settle.wait() }
+    await controller.initialHDRRefresh?.value
+    await hdr.releaseDisengage()
 
-    let exit = Task { await h.controller.setHDRMode(.off) }
-    #expect(await eventually { await h.hdr!.recordedSetCalls() == [false] })
-    let engage = Task { await h.controller.setHDRMode(.alwaysOn) }
+    // Hold the exit after its first fence until the newer transition has
+    // taken ownership. Neither order depends on a wall-clock window.
+    let exit = Task { await controller.setHDRMode(.off) }
+    #expect(await eventually { await settle.entered })
+    let engage = Task { await controller.setHDRMode(.alwaysOn) }
+    #expect(await eventually { await hdr.engageCallCount() == 1 })
+    await settle.release()
     await exit.value
 
     #expect(volume.memoResets == 0)
     #expect(contrast.memoResets == 0)
 
+    await hdr.releaseEngage()
     await engage.value
   }
 

--- a/docs/guide/diagnostics.md
+++ b/docs/guide/diagnostics.md
@@ -50,16 +50,39 @@ clipboard and **Save Report...** writes it to a file you choose. Either one
 covers every connected display, not only the one you are looking at, which is
 what makes it useful on an issue where two displays interact.
 
-The report contains the app version, the macOS version, whether Safe Mode is
-on, whether Accessibility is granted, the launch-at-login state, and for each
-display its names, connection, manufacturer, current mode, control method,
-readback verdict and HDR state, followed by any settings you have changed from
-their defaults and a short list of recent events.
+For a support request, reproduce the issue and then save or copy the report.
+There is no need to copy the raw capability description separately. Both
+buttons use the same report format and take a new snapshot when used.
 
-Two things are deliberately not in it. **Serial numbers never appear**: the
-report is written to be pasted into a public issue, and presence or absence of
-a serial is all that display-identity diagnosis needs. And changed settings are
-listed as a bare name and value, never as a full storage key, because a storage
-key carries the display's serial.
+The report includes:
+
+- **System:** capture time, report format version, app and macOS versions, Mac
+  model, Safe Mode, Accessibility and Screen Recording grants, launch-at-login
+  state, the media keys Candela is watching, and the selected sound output and
+  whether macOS can control its volume.
+- **Display setup:** the controlled displays, their names, connections,
+  manufacturers and modes, plus any other displays in the cached topology.
+  That sample can lag a connection change. If discovery did not record why a
+  display was excluded, the report says so rather than guessing.
+- **Reported capabilities:** the request state, parser result, MCCS version,
+  advertised command codes and capability description for each external
+  display. Not asked, still checking, no readable reply and a description that
+  could not be parsed are distinct states.
+- **Controls:** availability and reasons for brightness, volume, contrast, mute
+  and HDR; recorded read evidence and reported maxima for individual controls;
+  current app values and mute state; and the last brightness command result.
+- **Context:** OLED care enrollment, mirroring, recorded resolution problems,
+  cached resolution counts, non-default settings and recent display events.
+
+Export does not send test commands or change display settings. A reported app
+value or an accepted command is not confirmation that the physical brightness
+or audible volume changed. The report also cannot tell where an analog speaker
+cable is connected or whether sound is audible.
+
+Identifying fields are redacted for sharing: serial fields, known serials and
+storage keys in text, and unrecognized capability payloads. Capability text
+over 16,384 bytes is withheld. Redactions are marked; the parser result always
+describes the original response. Review custom display and audio-device names
+before sharing, since those may contain information you entered yourself.
 
 Nothing is uploaded. The report exists only where you put it.


### PR DESCRIPTION
## What

Expand Copy Report and Save Report into one versioned support report containing the original monitor capability description with identifying fields redacted, its parsing result and advertised commands, per-control availability and read evidence, audio routing, permissions, and display configuration context.

The report distinguishes pending, unanswered, malformed, and unprobed states. Parser results use the original response. Serial fields, known device identifiers, and unrecognized capability payloads are redacted, including copies in model text and events retained after disconnect. Copy and Save continue using the same snapshot and renderer.

The branch also stabilizes an existing HDR overlap test exposed by CI: a controlled settle pause replaces a 150 ms scheduling assumption. The production wait retains the same duration and cancellation behavior. Removing the post-settle guard makes the test fail at both memo assertions.

## Why

Issue #70 required a separate copy of each monitor's capability description because it was absent from the report. Including it with the control and system context reduces follow-up requests for this and similar reports. This also improves the diagnostics portion of #57; its other lifecycle and discovery questions remain open.

## Hardware verification

Reporting changes only. Automated integration tests verify that taking and rendering a snapshot adds no hardware requests and does not change control values. Tests cover multiple displays, audio routing changes, capability states, identifier redaction after disconnect, and media-key tap state.

Live Copy Report and Save Report checks passed in the signed Release build with the built-in display, Dell U2725QE, and MSI MAG 341C OLED connected. The copied and saved reports include all three displays, the Dell capability response and parsed commands, the MSI unanswered state, per-control evidence, and audio routing. Known Dell identifiers are absent from the saved report. Display controls and preferences were not changed during the check.

## Checks

- [x] `make -f Makefile check`: 2,538 engine tests and 606 app tests passed
- [x] Tests cover the new logic
- [x] Debug app build passed
- [x] Release build, debug-marker checks, and Developer ID signing verification passed
- [x] No ticket numbers in source comments, and no em dashes in new text or comments
- [x] `git diff --check` and public-content gate passed
- [x] Final branch review found no material issues after the HDR test correction
- [x] GitHub app tests, Debug and Release builds, and required verification checks passed at `81d5dbeb`
