### PR TITLE
Rewrite site comments to state their rules directly

### DIFF
--- a/site/src/components/Hero.css
+++ b/site/src/components/Hero.css
@@ -1,6 +1,5 @@
-/* The first screen: one warm light source in a near-black room (SR12). Every
-   colour here is derived from a token with color-mix; nothing bypasses the
-   palette. */
+/* The first screen: one warm light source in a near-black room. Every colour
+   here is derived from a token with color-mix; nothing bypasses the palette. */
 
 .hero {
   --hero-edge: color-mix(in srgb, var(--text) 10%, transparent);
@@ -122,7 +121,7 @@
   text-decoration-color: var(--accent);
 }
 
-/* SR2 keeps Download the one conversion. Homebrew is a single-line install
+/* Download stays the one conversion. Homebrew is a single-line install
    rail, not a second CTA or a miniature terminal: open sides and measured
    hairlines carry the same visual grammar as the feature sections. */
 .hero-brew {
@@ -195,8 +194,8 @@
   color: var(--danger);
 }
 
-/* SR8: hero-level, load-bearing. Amber, tracked, and lit; part of the action
-   cluster rather than a caption under it. */
+/* The foss line is hero-level and load-bearing. Amber, tracked, and lit; part
+   of the action cluster rather than a caption under it. */
 .hero-foss {
   margin-top: 1.4rem;
   font-size: var(--fs-small);

--- a/site/src/components/Hero.tsx
+++ b/site/src/components/Hero.tsx
@@ -59,7 +59,7 @@ function BrewInstall() {
 
 // First screen: the premise, the one-liner, the two actions, and the capture
 // glowing out of the dark underneath them. The foss line rides with the CTA
-// cluster per SR8, never below the fold and never footer-weight.
+// cluster, never below the fold and never footer-weight.
 export function Hero() {
   return (
     <section id="top" className="hero">

--- a/site/src/content/copy.ts
+++ b/site/src/content/copy.ts
@@ -1,11 +1,11 @@
 // Every user-visible string on candela.fyi. Components import from here and
 // hold no copy of their own, so the two gates run in one place: the product's
-// copy filter on every lead, and an editing pass on all of it (SR15).
+// copy filter on every lead, and the editing pass on all of it.
 //
 // Rules that bind edits to this file:
 // - No em dashes anywhere, site copy included. scripts/check-copy.sh enforces it.
 // - Competitor names appear in exactly one place, the FAQ entry below, question
-//   and answer both (SR5).
+//   and answer both.
 // - Measured claims only. Estimates are labeled as estimates in the sentence
 //   that makes them, not in a footnote. The idle dim is described as the
 //   shipped staged dim, not the wear-weighted dim, until that feature lands;


### PR DESCRIPTION
## What

Rewrites six header comments under `site/src` (the copy module, `Hero.css`, and `Hero.tsx`) so each states the reason for its rule in words instead of pointing at a short alphanumeric tag. No user-visible string, style, or behaviour changes.

## Why

A comment that says why a rule exists stands on its own for anyone reading the file. A tag only helps someone who knows what it refers to, and those references go stale.

## Hardware verification

Hardware-free: comments only, no logic changed. `site/scripts/check-copy.sh` passes on the branch.

## Checks

- [ ] `make check` passes (engine and app suites) - not run, no code under `Candela/` or `CandelaKit/` changed
- [ ] Tests cover the new logic, or it is hardware-only and says so above - no new logic
- [x] No ticket numbers in source comments, and no em dashes in user-visible
      text or new comments