### PR TITLE
Offer a save on the stale saved-layout notice, and pin the display sample to post time

### DIFF
--- a/Candela/App/ArrangementCoordinator.swift
+++ b/Candela/App/ArrangementCoordinator.swift
@@ -68,6 +68,12 @@ final class ArrangementCoordinator {
   /// set.
   private(set) var restoreNotice: ArrangementReapplyNotice?
 
+  /// The save offered on the stale-layout notice was refused, and by whom.
+  /// Not `blockedBy`: that raises the report card, whose one button clears the
+  /// notice and takes the save away with nothing saved. The refusal travels as a
+  /// caption under the button instead.
+  private(set) var saveRefusedBy: ReconfigurationClaimant?
+
   @ObservationIgnored weak var confirmation: (any ArrangementConfirmationPresenting)?
   /// Called after a commit actually wrote `savedArrangements`, so the propagation
   /// seam hears about it whichever surface answered. Owned here because a
@@ -128,7 +134,8 @@ final class ArrangementCoordinator {
     configurator: any DisplayArrangementConfiguring = CoreGraphicsArrangementConfigurator(),
     persistence: ArrangementPersistence = ArrangementPersistence(),
     rotationConfigurator: any DisplayRotationConfiguring = CoreGraphicsDisplayConfigurator(),
-    countdownSeconds: Int = 30
+    countdownSeconds: Int = 30,
+    notificationCenter: NotificationCenter = .default
   ) {
     self.gate = gate
     self.configurator = configurator
@@ -142,9 +149,18 @@ final class ArrangementCoordinator {
     // Observed here rather than in a pane: a display can depart while the canvas
     // is being dismissed for that very reason, and an outstanding preview over a
     // display set that no longer exists has to be dropped either way.
-    screenObserver = NotificationCenter.default.addObserver(
+    //
+    // Injected centre so a test can post to this coordinator alone: a post on
+    // `.default` reaches every coordinator alive in the process.
+    screenObserver = notificationCenter.addObserver(
       forName: NSApplication.didChangeScreenParametersNotification,
       object: nil,
+      // `.main` delivers INSIDE the post [MEASURED 2026-09-09]: `NotificationCenter`
+      // short-circuits when the target queue is already the current one, and AppKit
+      // posts on the main thread. `displaysChanged`'s arrival record needs that
+      // post-time sample, so the queue is not free to change;
+      // `ScreenParametersSampleTests` pins it. `.main` is the main thread either
+      // way, so `MainActor.assumeIsolated` below holds.
       queue: .main
     ) { [weak self] _ in
       MainActor.assumeIsolated { self?.displaysChanged() }
@@ -353,8 +369,15 @@ final class ArrangementCoordinator {
     lastFailure = nil
     blockedBy = nil
     recoverableLayout = nil
-    restoreNotice = nil
+    setRestoreNotice(nil)
     syncConfirmation()
+  }
+
+  /// The one writer of `restoreNotice`: the refusal caption sits under the
+  /// notice's save button, so it has to leave with the notice.
+  private func setRestoreNotice(_ notice: ArrangementReapplyNotice?) {
+    restoreNotice = notice
+    if notice == nil { saveRefusedBy = nil }
   }
 
   // MARK: - Operations (always inside the queue)
@@ -474,7 +497,7 @@ final class ArrangementCoordinator {
     } else {
       // The restore actor has already applied any accepted layout. Report its
       // outcome here without submitting the same configuration again.
-      restoreNotice = decision.notice
+      setRestoreNotice(decision.notice)
       if let restoreNotice {
         // Not every notice is a failure. A layout declined because the displays are
         // no longer the size it was recorded at is ordinary, and `.error` would put
@@ -545,6 +568,51 @@ final class ArrangementCoordinator {
       self.persistence.setRestoreEnabled(true)
       self.refreshArrangement()
       self.saveIfRestoring()
+      await self.gate.release(.arrangement)
+    }
+  }
+
+  /// Records the layout on screen NOW over whatever is stored for this display
+  /// set, the way out of a saved layout that has gone stale.
+  ///
+  /// Never automatic: a failed restore leaves a layout nobody chose on screen, and
+  /// rewriting the record from it would make that failure permanent.
+  ///
+  /// No post-gate revision recheck, unlike `setRestoringLayout`: `saveIfRestoring`
+  /// re-reads `isRestoreEnabled` for itself.
+  func saveCurrentLayout() {
+    // Captured without bumping: a remember toggle made after the click supersedes
+    // this save, never the other way round.
+    let revision = rememberRequestRevision
+    queue.enqueue {
+      // Whatever refused the last save is stale once this one dequeues.
+      self.saveRefusedBy = nil
+      guard revision == self.rememberRequestRevision else { return }
+      // Before the gate, so a save with the setting off is a clean no-op rather
+      // than a report about work that would do nothing.
+      guard self.persistence.isRestoreEnabled else { return }
+      // A layout captured while a preview stands is not one anybody approved. The
+      // gate cannot stand in for this guard: a claim by the claimant already
+      // holding it is granted, and this coordinator holds the arrangement preview.
+      // Both refusals publish `saveRefusedBy` and sync nothing, since the report
+      // card's button would clear the notice this save exists to answer.
+      guard await self.session.previewedArrangement == nil else {
+        self.saveRefusedBy = .arrangement
+        return
+      }
+      if let holder = await self.gate.claim(.arrangement).refusedBy {
+        self.saveRefusedBy = holder
+        return
+      }
+      // Re-read, never whatever `arrangement` was holding: this saves what is on
+      // screen.
+      self.refreshArrangement()
+      self.saveIfRestoring()
+      // The notice only. `dismissReport` would also drop `recoverableLayout`, a
+      // diverged apply's offer to put the displays back, which this says nothing
+      // about.
+      self.setRestoreNotice(nil)
+      self.syncConfirmation()
       await self.gate.release(.arrangement)
     }
   }
@@ -679,7 +747,9 @@ final class ArrangementCoordinator {
   /// Every write to `preview`, `lastInvalidLayout`, `lastFailure`, `blockedBy`,
   /// `recoverableLayout` or `restoreNotice` has to be followed by this call. An
   /// un-synced write leaves the window rendering a state that no longer exists,
-  /// which is an empty floating panel.
+  /// which is an empty floating panel. `saveRefusedBy` stays off that list:
+  /// nothing here renders it, and the card's button would clear the notice the
+  /// refused save was answering.
   private func syncConfirmation() {
     if let preview {
       // `confirmationDisplayID` is the display at the origin of the ACHIEVED

--- a/Candela/App/ArrangementCopy.swift
+++ b/Candela/App/ArrangementCopy.swift
@@ -100,6 +100,17 @@ enum ArrangementCopy {
 
   static var restore: LocalizedStringKey { "Put Them Back" }
 
+  /// Records what is on screen now, so the next reconnect restores this instead
+  /// of the layout that no longer fits.
+  static var saveThisLayout: LocalizedStringKey { "Save This Layout" }
+
+  /// Why the save is greyed. One sentence for both busy states (an unanswered
+  /// preview, an apply in flight): the user cannot tell them apart and the remedy
+  /// is the same.
+  static var saveThisLayoutBusy: LocalizedStringKey {
+    "A display change is still on screen. Answer it or wait for it to finish, then save this layout."
+  }
+
   /// Why a saved layout did not come back.
   ///
   /// Restore runs with nobody watching, so this is the only account the user
@@ -108,8 +119,13 @@ enum ArrangementCopy {
   /// `Text` rather than `LocalizedStringKey` for `invalidLayout`'s reason: a
   /// runtime value routed through a lookup key would translate the user's
   /// hardware.
+  ///
+  /// `offersSave` is keyed on whether the button sits under this sentence, not on
+  /// which surface is asking, so nothing tells a reader to rearrange their
+  /// displays directly above a button that does it in one click.
   static func restoreNotice(
-    _ notice: ArrangementReapplyNotice, name: (CGDirectDisplayID) -> String
+    _ notice: ArrangementReapplyNotice, name: (CGDirectDisplayID) -> String,
+    offersSave: Bool = false
   ) -> Text {
     switch notice {
     case .ambiguousIdentity:
@@ -123,7 +139,12 @@ enum ArrangementCopy {
       // A display that resized since the layout was saved is the ordinary cause,
       // and origins recorded for the old size cannot go back on the new one.
       // Deliberately unnamed: naming one screen reads as an accusation about it.
-      Text("Your displays are not the size they were when this arrangement was saved, so it was not restored. Arrange them again to save a new one.")
+      //
+      // Rearranging stays first even where the button exists: the button records
+      // what is on screen, which is not always the layout the reader wants back.
+      offersSave
+        ? Text("Your displays are not the size they were when this arrangement was saved, so it was not restored. Arrange them again, or save the layout you have now.")
+        : Text("Your displays are not the size they were when this arrangement was saved, so it was not restored. Arrange them again to save a new one.")
     case let .layoutNoLongerFits(problems):
       // The same sentence the interactive refusal uses, for the same fact:
       // origins that do not tile at the sizes they were recorded at.

--- a/Candela/App/DisplayModeCoordinator.swift
+++ b/Candela/App/DisplayModeCoordinator.swift
@@ -432,7 +432,8 @@ final class DisplayModeCoordinator {
   init(
     gate: DisplayReconfigurationGate,
     configurator: any DisplayConfiguring = CoreGraphicsDisplayConfigurator(),
-    persistence: ModePersistence = ModePersistence()
+    persistence: ModePersistence = ModePersistence(),
+    notificationCenter: NotificationCenter = .default
   ) {
     self.gate = gate
     self.configurator = configurator
@@ -441,9 +442,17 @@ final class DisplayModeCoordinator {
     // Observed here rather than in a pane: a display can depart while its pane
     // is being dismissed for that very reason, and an outstanding preview on a
     // departed display has to be dropped whether or not anything is on screen.
-    screenObserver = NotificationCenter.default.addObserver(
+    //
+    // Injected centre so a test can post to this coordinator alone: a post on
+    // `.default` reaches every coordinator alive in the process.
+    screenObserver = notificationCenter.addObserver(
       forName: NSApplication.didChangeScreenParametersNotification,
       object: nil,
+      // `.main` delivers INSIDE the post [MEASURED 2026-09-09]: `NotificationCenter`
+      // short-circuits when the target queue is already the current one, and AppKit
+      // posts on the main thread. That is what makes the sample below a post-time
+      // sample, so the queue is not free to change; `ScreenParametersSampleTests`
+      // pins it.
       queue: .main
     ) { [weak self] _ in
       // Sampled HERE, synchronously in the notification block, and carried into

--- a/Candela/App/MirrorTopologySampler.swift
+++ b/Candela/App/MirrorTopologySampler.swift
@@ -70,9 +70,11 @@ final class MirrorTopologySampler {
     observer = NotificationCenter.default.addObserver(
       forName: NSApplication.didChangeScreenParametersNotification,
       object: nil,
-      // `nil`, not `.main`: the block runs synchronously at post time instead of
-      // queueing behind whatever the main run loop is doing. AppKit posts on the
-      // main thread either way, so the queueing is what is avoided, not the hop.
+      // `nil`, not `.main`: `nil` updates the store on the posting thread by
+      // documented contract. `.main` lands in the same place today [MEASURED
+      // 2026-09-09], but only through `NotificationCenter`'s short-circuit when the
+      // target queue is already the current one. The guarantee is what `nil` buys,
+      // not a saved hop.
       queue: nil
     ) { [store, configurator] _ in
       store.update(MirrorTopology(configurator.displays()))

--- a/Candela/App/MirroringCoordinator.swift
+++ b/Candela/App/MirroringCoordinator.swift
@@ -163,9 +163,11 @@ final class MirroringCoordinator {
     screenObserver = NotificationCenter.default.addObserver(
       forName: NSApplication.didChangeScreenParametersNotification,
       object: nil,
-      // `nil`, not `.main`: the block runs synchronously at post time instead of
-      // queueing behind whatever the main run loop is doing. AppKit posts on the
-      // main thread either way, so the queueing is what is avoided, not the hop.
+      // `nil`, not `.main`: `nil` runs the block on the posting thread by documented
+      // contract, so the sample below rests on nothing undocumented. `.main` lands in
+      // the same place today [MEASURED 2026-09-09], but only through
+      // `NotificationCenter`'s short-circuit when the target queue is already the
+      // current one. The guarantee is what `nil` buys, not a saved hop.
       queue: nil
     ) { [weak self] _ in
       // Sampled HERE, synchronously, and carried across the hop, never re-read

--- a/Candela/App/RotationCoordinator.swift
+++ b/Candela/App/RotationCoordinator.swift
@@ -74,8 +74,13 @@ final class RotationCoordinator {
     self.topologyStore = topologyStore
     self.configurator = configurator
     session = RotationPreviewSession(configurator: configurator, timeoutSeconds: timeoutSeconds)
-    // A rotation fires this notification itself, so besides departures this is
-    // what re-reads the angle a picker is showing.
+    // Departures only, even though a rotation this app applies fires the
+    // notification too: the handler asks whether the display carrying an unanswered
+    // preview is still attached and writes nothing observable otherwise.
+    // `displayedRotation(of:)` re-reads the hardware only when `preview` changes.
+    //
+    // Nothing is sampled and carried, so `.main` is safe whatever the delivery
+    // timing: a block that runs late answers later, never wrongly.
     screenObserver = NotificationCenter.default.addObserver(
       forName: NSApplication.didChangeScreenParametersNotification,
       object: nil,

--- a/Candela/Settings/ArrangementPane.swift
+++ b/Candela/Settings/ArrangementPane.swift
@@ -414,15 +414,42 @@ struct ArrangementPane: View {
       // OK click is not the only thing that ends this notice, so the transaction
       // belongs to the mirror write and not to the button.
       if let report = shownRestoreNotice {
+        // Both busy flags are read live: they rise and fall synchronously, so a
+        // mirrored copy would grey the button a frame late and free it a frame late.
+        let noticeActions = RestoreNoticeActions(
+          notice: report,
+          isRestoringLayout: coordinator.isRestoringLayout,
+          isBusy: coordinator.preview != nil || coordinator.isApplying,
+          refusedBy: coordinator.saveRefusedBy
+        )
         notice(symbol: "clock.arrow.circlepath") {
-          ArrangementCopy.restoreNotice(report, name: displayName)
+          ArrangementCopy.restoreNotice(report, name: displayName, offersSave: noticeActions.offersSave)
             .font(.callout)
             .foregroundStyle(SettingsTheme.titleColor)
             .fixedSize(horizontal: false, vertical: true)
-          Button("OK") { coordinator.dismissReport() }
-            .buttonStyle(SettingsSecondaryButtonStyle())
-            .accessibilityLabel("OK")
-            .padding(.top, 2)
+          HStack(spacing: 8) {
+            // Save before OK: left-aligned prose rather than a dialog, so the
+            // reader meets the way out before the dismissal.
+            if noticeActions.offersSave {
+              Button(ArrangementCopy.saveThisLayout) { coordinator.saveCurrentLayout() }
+                .buttonStyle(SettingsSecondaryButtonStyle())
+                .accessibilityLabel("Save This Layout")
+                // Always attached, empty when there is nothing to say: VoiceOver
+                // has to hear the reason on the control, not only in the caption
+                // below it.
+                .accessibilityHint(noticeActions.caption.map { Text($0) } ?? Text(verbatim: ""))
+                .disabled(noticeActions.isBusy)
+            }
+            Button("OK") { coordinator.dismissReport() }
+              .buttonStyle(SettingsSecondaryButtonStyle())
+              .accessibilityLabel("OK")
+          }
+          .padding(.top, 2)
+          // A dead control's reason travels in its own row, as the Main Display
+          // section above does.
+          if let caption = noticeActions.caption {
+            SettingsCaption(caption)
+          }
         }
         .transition(.opacity)
       }

--- a/Candela/Settings/RestoreNoticeActions.swift
+++ b/Candela/Settings/RestoreNoticeActions.swift
@@ -1,0 +1,32 @@
+import CandelaKit
+import SwiftUI
+
+/// What the stale-layout notice offers besides "OK", derived from state rather
+/// than decided in a view body. Plain values rather than the coordinator, so a
+/// test reaches these rules with no view standing up behind them.
+struct RestoreNoticeActions {
+  let notice: ArrangementReapplyNotice
+  /// The remember setting. With it off the coordinator's save is a no-op, so the
+  /// button would be one that cannot work.
+  let isRestoringLayout: Bool
+  /// An unanswered display change, or one still in flight. One flag for both: the
+  /// remedy is the same and nobody can tell them apart.
+  let isBusy: Bool
+  /// Who refused the last save. A refusal raises no report card, so the caption
+  /// is the whole of its feedback.
+  let refusedBy: ReconfigurationClaimant?
+
+  var offersSave: Bool { notice.isResolvedBySavingCurrentLayout && isRestoringLayout }
+  var showsBusyCaption: Bool { offersSave && isBusy }
+
+  /// The one sentence under the buttons, or nothing.
+  ///
+  /// Busy outranks a refusal where both apply: an outstanding preview refuses the
+  /// save and greys the button, and the sentence has to describe the control the
+  /// reader is looking at. Silent where there is no save to explain.
+  var caption: LocalizedStringKey? {
+    if showsBusyCaption { return ArrangementCopy.saveThisLayoutBusy }
+    guard offersSave, let refusedBy else { return nil }
+    return ReconfigurationCopy.blocked(by: refusedBy)
+  }
+}

--- a/CandelaAppTests/CopyBuilderTests.swift
+++ b/CandelaAppTests/CopyBuilderTests.swift
@@ -180,14 +180,54 @@ struct CopyBuilderTests {
     #expect(resized.contains("not the size they were"))
     #expect(!resized.contains("overlap"))
     #expect(!resized.contains("cover each other"))
-    // It names the way out, because nothing else ends this state: the saved
-    // layout is deliberately never rewritten.
-    #expect(resized.contains("Arrange them again"))
+    // No save on offer here, so the sentence has to name the longer route out.
+    #expect(resized.contains("Arrange them again to save a new one"))
     // Says nothing about a particular screen; the fact is about the layout.
     #expect(!resized.contains("MAG 341C"))
     #expect(!resized.contains("DELL"))
 
     #expect(Set(Self.allReapplyNotices.map { render(ArrangementCopy.restoreNotice($0, name: Self.bothNamed)) }).count == 5)
+  }
+
+  /// Keyed on whether a save is on offer, not on which surface is asking: sending
+  /// a reader off to rearrange displays directly above a one-click button is the
+  /// incoherence this splits.
+  @Test func theStaleFootprintSentenceNamesTheSaveOnlyWhereTheSaveExists() {
+    let withSave = render(
+      ArrangementCopy.restoreNotice(
+        .savedForDifferentGeometry(["a"]), name: Self.bothNamed, offersSave: true))
+    #expect(withSave.contains("or save the layout you have now"))
+    // Rearranging stays first: the button records what is on screen, which is not
+    // always what the reader wants back.
+    #expect(withSave.contains("Arrange them again"))
+    #expect(!withSave.contains("to save a new one"))
+
+    // Every other notice says the same thing on both surfaces; only this one
+    // splits.
+    for notice in Self.allReapplyNotices {
+      if case .savedForDifferentGeometry = notice { continue }
+      #expect(
+        sentence(of: ArrangementCopy.restoreNotice(notice, name: Self.bothNamed, offersSave: true))
+          == sentence(of: ArrangementCopy.restoreNotice(notice, name: Self.bothNamed)),
+        "\(notice) has no save to name, so its sentence cannot depend on one")
+    }
+  }
+
+  /// A localized `Text` dumps the ADDRESS of its storage alongside its words, so
+  /// two separately built ones saying the same thing compare unequal. Stripped
+  /// here, so an equality between two builder calls is about the sentence.
+  private func sentence(of text: Text) -> String {
+    render(text).replacingOccurrences(of: "0x[0-9a-f]+", with: "", options: .regularExpression)
+  }
+
+  /// The stale-footprint refusal is the one restore notice with an in-app remedy,
+  /// so the pane offers a button and says when it cannot be pressed.
+  @Test func theStaleLayoutNoticeOffersASaveAndSaysWhenItCannot() {
+    // `render` dumps the reflection wrapper rather than the sentence, so the
+    // closing quote is what makes this an equality and not a prefix match.
+    #expect(render(ArrangementCopy.saveThisLayout).contains("key: \"Save This Layout\","))
+    // A greyed control has to say what to do about it, not merely what is wrong.
+    #expect(render(ArrangementCopy.saveThisLayoutBusy).contains("then save this layout"))
   }
 
   @Test func arrangementApplyNoticeNamesTheDisplayWhenItCan() {
@@ -968,6 +1008,8 @@ struct CopyBuilderTests {
     add("ArrangementCopy.keep", ArrangementCopy.keep)
     add("ArrangementCopy.revert", ArrangementCopy.revert)
     add("ArrangementCopy.restore", ArrangementCopy.restore)
+    add("ArrangementCopy.saveThisLayout", ArrangementCopy.saveThisLayout)
+    add("ArrangementCopy.saveThisLayoutBusy", ArrangementCopy.saveThisLayoutBusy)
     add("ArrangementCopy.applyFailure", ArrangementCopy.applyFailure)
     add("ArrangementCopy.resolveFailure", ArrangementCopy.resolveFailure)
     add("ArrangementCopy.expiryAlreadyRan", ArrangementCopy.expiryAlreadyRan)
@@ -988,7 +1030,11 @@ struct CopyBuilderTests {
         add("ArrangementCopy.invalidLayout", ArrangementCopy.invalidLayout(problems, name: name))
       }
       for notice in Self.allReapplyNotices {
-        add("ArrangementCopy.restoreNotice(\(notice))", ArrangementCopy.restoreNotice(notice, name: name))
+        for offersSave in [true, false] {
+          add(
+            "ArrangementCopy.restoreNotice(\(notice), offersSave: \(offersSave))",
+            ArrangementCopy.restoreNotice(notice, name: name, offersSave: offersSave))
+        }
       }
       for notice in Self.allApplyNotices {
         add("ArrangementCopy.notice(\(notice))", ArrangementCopy.notice(notice, name: name))

--- a/CandelaAppTests/Fakes/SynthesisFakes.swift
+++ b/CandelaAppTests/Fakes/SynthesisFakes.swift
@@ -37,6 +37,7 @@ final class FakeDisplayWorld: @unchecked Sendable {
   private(set) var mirrorChanges: [[MirrorChange]] = []
   private var _applies: [(mode: DisplayMode, displayID: CGDirectDisplayID)] = []
   private var _enumerations: [EnumerationCall] = []
+  private var _onlineListReads = 0
 
   /// Each of these is one full CoreGraphics enumeration on the real configurator.
   /// A fake answers from a dictionary, so this count is the only place a
@@ -80,6 +81,15 @@ final class FakeDisplayWorld: @unchecked Sendable {
 
   func recordApply(_ mode: DisplayMode, to displayID: CGDirectDisplayID) {
     lock.withLock { _applies.append((mode, displayID)) }
+  }
+
+  /// How many times the configurator was asked for the online list. Its own
+  /// counter rather than an `EnumerationCall`: asking who is attached is not an
+  /// enumeration, and several suites assert on `enumerations` exactly.
+  var onlineListReads: Int { lock.withLock { _onlineListReads } }
+
+  func recordOnlineListRead() {
+    lock.withLock { _onlineListReads += 1 }
   }
 
   func attach(
@@ -216,7 +226,14 @@ final class FakeSynthesisDisplayConfigurator: DisplayConfiguring, @unchecked Sen
   /// on the engage tail reads it off the object it configured.
   var applies: [(mode: DisplayMode, displayID: CGDirectDisplayID)] { world.applies }
 
-  func displays() -> [ConfiguredDisplay] { world.displays() }
+  /// One count per `displays()` call on THIS configurator. The world's own
+  /// internal reads, about a single display, do not move it.
+  var onlineListReads: Int { world.onlineListReads }
+
+  func displays() -> [ConfiguredDisplay] {
+    world.recordOnlineListRead()
+    return world.displays()
+  }
 
   func modes(for displayID: CGDirectDisplayID) -> [DisplayMode] {
     world.recordEnumeration(.modes)

--- a/CandelaAppTests/RestoreNoticeActionsTests.swift
+++ b/CandelaAppTests/RestoreNoticeActionsTests.swift
@@ -1,0 +1,98 @@
+import CandelaKit
+import Foundation
+import SwiftUI
+import Testing
+
+@Suite("Restore notice actions") @MainActor
+struct RestoreNoticeActionsTests {
+  /// Under the other notices the button would either do nothing or make the state
+  /// permanent.
+  @Test func onlyTheStaleFootprintNoticeOffersASave() {
+    #expect(RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: true, isBusy: false, refusedBy: nil
+    ).offersSave)
+
+    let withoutARemedy: [ArrangementReapplyNotice] = [
+      .ambiguousIdentity(["a"]),
+      .setDiffers(missing: ["a"], extra: ["b"]),
+      .layoutNoLongerFits([.overlap(1, 2)]),
+      .failed(DisplayConfigError(cgErrorCode: 1000)),
+    ]
+    for notice in withoutARemedy {
+      #expect(
+        !RestoreNoticeActions(
+          notice: notice, isRestoringLayout: true, isBusy: false, refusedBy: nil
+        ).offersSave,
+        "\(notice) is not a stale record a save replaces")
+    }
+  }
+
+  /// The save path no-ops with the setting off, so the button could not work.
+  @Test func theSaveIsAbsentWhileTheRememberSettingIsOff() {
+    #expect(!RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: false, isBusy: false, refusedBy: nil
+    ).offersSave)
+  }
+
+  @Test func aBusyDisplayChangeSaysWhyRatherThanGreyingSilently() {
+    #expect(RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: true, isBusy: true, refusedBy: nil
+    ).showsBusyCaption)
+    #expect(!RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: true, isBusy: false, refusedBy: nil
+    ).showsBusyCaption)
+    // Negative control: no caption under a notice that offers no save at all.
+    #expect(!RestoreNoticeActions(
+      notice: .setDiffers(missing: ["a"], extra: []), isRestoringLayout: true, isBusy: true, refusedBy: nil
+    ).showsBusyCaption)
+    #expect(!RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: false, isBusy: true, refusedBy: nil
+    ).showsBusyCaption)
+  }
+
+  /// The caption is the whole feedback a refused save gets. The report card is not
+  /// raised for one: its only button clears the notice, with nothing saved.
+  @Test func aRefusedSaveNamesWhoRefusedItUnderTheButton() throws {
+    let refused = RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: true, isBusy: false,
+      refusedBy: .rotation
+    )
+    let caption = try #require(refused.caption)
+    #expect(render(caption) == render(ReconfigurationCopy.blocked(by: .rotation)))
+
+    // Nothing to say when nothing refused it and nothing is in flight.
+    #expect(RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: true, isBusy: false,
+      refusedBy: nil
+    ).caption == nil)
+  }
+
+  /// Busy outranks a refusal: an outstanding preview refuses the save AND greys the
+  /// button, and the sentence has to match the control on screen.
+  @Test func theBusySentenceWinsOverAStaleRefusal() throws {
+    let busy = RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: true, isBusy: true,
+      refusedBy: .arrangement
+    )
+    let caption = try #require(busy.caption)
+    #expect(render(caption) == render(ArrangementCopy.saveThisLayoutBusy))
+  }
+
+  /// No caption where there is no save, whatever the coordinator last published.
+  @Test func noCaptionAppearsUnderANoticeThatOffersNoSave() {
+    #expect(RestoreNoticeActions(
+      notice: .setDiffers(missing: ["a"], extra: []), isRestoringLayout: true, isBusy: false,
+      refusedBy: .mirroring
+    ).caption == nil)
+    #expect(RestoreNoticeActions(
+      notice: .savedForDifferentGeometry(["a"]), isRestoringLayout: false, isBusy: false,
+      refusedBy: .mirroring
+    ).caption == nil)
+  }
+
+  /// `LocalizedStringKey` has no public text, so both sides of a comparison go
+  /// through the same reflection dump, as `CopyBuilderTests` does.
+  private func render(_ key: LocalizedStringKey) -> String {
+    String(describing: key)
+  }
+}

--- a/CandelaAppTests/SavedLayoutConfirmationTests.swift
+++ b/CandelaAppTests/SavedLayoutConfirmationTests.swift
@@ -165,6 +165,127 @@ struct SavedLayoutConfirmationTests {
     }
   }
 
+  @Test func savingFromTheStaleNoticeRecordsTheLayoutOnScreenAndClearsTheNotice() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) != nil)
+
+      let resized = try #require(rig.currentArrangement().tile(2)?.identity.key)
+      await reconnect(coordinator, rig, showing: Self.widening(rig.currentArrangement(), 2, by: 200))
+      #expect(coordinator.restoreNotice == .savedForDifferentGeometry([resized]))
+
+      coordinator.saveCurrentLayout()
+      // The queue is what the click hands the work to, so drain it before reading.
+      await coordinator.restoreSavedArrangement()
+      #expect(coordinator.restoreNotice == nil)
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+      #expect(saved.entries.count == 2)
+      #expect(saved.entries.first { $0.identity == resized }?.width == 1000)
+
+      // The point of the save: the next reconnect restores this layout instead of
+      // raising the same notice again.
+      await reconnect(coordinator, rig, showing: rig.currentArrangement())
+      #expect(coordinator.restoreNotice == nil)
+    }
+  }
+
+  @Test func savingDoesNothingWhileTheRememberSettingIsOff() async throws {
+    try await withCoordinator { coordinator, store, rig, _ in
+      coordinator.saveCurrentLayout()
+      await coordinator.restoreSavedArrangement()
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == nil)
+      // A save must not turn the setting on as a side effect.
+      #expect(!store.isRestoreEnabled)
+      // A no-op reports nothing, so no card is raised over work that would do nothing.
+      #expect(coordinator.blockedBy == nil)
+    }
+  }
+
+  @Test func savingDuringAnOutstandingPreviewSavesNothingAndSaysWhoBlockedIt() async throws {
+    try await withCoordinator { coordinator, store, rig, gate in
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+
+      let rotation = RotationCoordinator(gate: gate, topologyStore: MirrorTopologyStore(), configurator: rig)
+      let presenter = RotationReadyPresenter()
+      rotation.confirmation = presenter
+      rotation.rotate(2, to: .ninety)
+      for await _ in presenter.ready { break }
+      let preview = try #require(rotation.preview)
+
+      coordinator.saveCurrentLayout()
+      await coordinator.restoreSavedArrangement()
+      #expect(coordinator.saveRefusedBy == .rotation)
+      // Off the report card, whose one button would clear the notice the save
+      // exists to answer.
+      #expect(coordinator.blockedBy == nil)
+      // Not merely "no new record": the stored layout is the one saved before.
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == saved)
+      #expect(await rotation.revert(preview) == .reverted)
+    }
+  }
+
+  /// The gate cannot cover this branch: a claim by the claimant already holding the
+  /// gate is GRANTED, so an outstanding ARRANGEMENT preview gets past `gate.claim`
+  /// and only the preview guard stops the save.
+  @Test func savingDuringAnOutstandingArrangementPreviewLeavesTheRecordAndThePreviewAlone() async throws {
+    try await withCoordinator { coordinator, store, rig, gate in
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+
+      coordinator.apply(rig.currentArrangement().makingMain(2))
+      await coordinator.restoreSavedArrangement()
+      let preview = try #require(coordinator.preview)
+
+      coordinator.saveCurrentLayout()
+      await coordinator.restoreSavedArrangement()
+
+      #expect(coordinator.saveRefusedBy == .arrangement)
+      // Not the report card: its one button would clear the notice with nothing
+      // saved.
+      #expect(coordinator.blockedBy == nil)
+      // Equal, not merely present: the mid-preview layout did not overwrite the
+      // one the user approved.
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == saved)
+      // The preview still stands and still holds the gate: the refusal cost the
+      // user nothing.
+      #expect(coordinator.preview?.value == preview.value)
+      #expect(await gate.holder == .arrangement)
+      #expect(await coordinator.revert(preview) == .reverted)
+    }
+  }
+
+  /// A reconnect in the two steps the bookkeeping needs: a sample taken while the
+  /// display is gone makes its return an arrival, and the restore pass acts on it.
+  private func reconnect(
+    _ coordinator: ArrangementCoordinator, _ rig: ConfirmationLayoutRig,
+    showing layout: DisplayArrangement
+  ) async {
+    let present = rig.currentArrangement()
+    rig.layout = DisplayArrangement(tiles: present.tiles.filter { $0.id != 2 })
+    coordinator.displaysChanged()
+    rig.layout = layout
+    await coordinator.restoreSavedArrangement()
+  }
+
+  /// The same display set at a different size, which the saved origins no longer
+  /// describe.
+  private static func widening(
+    _ layout: DisplayArrangement, _ displayID: CGDirectDisplayID, by extra: Int
+  ) -> DisplayArrangement {
+    DisplayArrangement(tiles: layout.tiles.map { tile in
+      guard tile.id == displayID else { return tile }
+      return ArrangementTile(
+        id: tile.id, identity: tile.identity, name: tile.name,
+        rect: DisplayRect(x: tile.rect.x, y: tile.rect.y,
+                          width: tile.rect.width + extra, height: tile.rect.height),
+        mirroredIDs: tile.mirroredIDs)
+    })
+  }
+
   private func withCoordinator(
     _ body: (ArrangementCoordinator, ArrangementPersistence, ConfirmationLayoutRig, DisplayReconfigurationGate) async throws -> Void
   ) async throws {
@@ -186,10 +307,14 @@ private final class ConfirmationLayoutRig: DisplayArrangementConfiguring,
   private let lock = NSLock()
   // Installed before an operation starts; the test never mutates it in flight.
   var beforeCommit: (@Sendable () -> Void)?
-  private var layout = DisplayArrangement(tiles: [
+  private var storedLayout = DisplayArrangement(tiles: [
     tile(1, .init(x: 0, y: 0, width: 1000, height: 800)),
     tile(2, .init(x: 1000, y: 0, width: 800, height: 1200)),
   ])
+  var layout: DisplayArrangement {
+    get { lock.withLock { storedLayout } }
+    set { lock.withLock { storedLayout = newValue } }
+  }
   private var storedAngle: DisplayRotation = .twoSeventy
   var angle: DisplayRotation {
     get { lock.withLock { storedAngle } }
@@ -215,7 +340,7 @@ private final class ConfirmationLayoutRig: DisplayArrangementConfiguring,
   var revealsHiddenModes: Bool { false }
   var guardsWireTiming: Bool { true }
   func modesWithheldByWireTimingGuard(for displayID: CGDirectDisplayID) -> Int { 0 }
-  func currentArrangement() -> DisplayArrangement { lock.withLock { layout } }
+  func currentArrangement() -> DisplayArrangement { layout }
   func currentTopology() -> (displays: [ConfiguredDisplay], arrangement: DisplayArrangement) {
     let layout = currentArrangement()
     return (layout.tiles.map {
@@ -224,7 +349,7 @@ private final class ConfirmationLayoutRig: DisplayArrangementConfiguring,
   }
   func apply(_ plan: ArrangementPlan, scope: DisplayConfigScope) throws -> DisplayArrangement {
     if scope == .permanent { beforeCommit?() }
-    return lock.withLock { layout = plan.arrangement; return layout }
+    return lock.withLock { storedLayout = plan.arrangement; return storedLayout }
   }
   private static func tile(_ id: CGDirectDisplayID, _ rect: DisplayRect) -> ArrangementTile {
     .init(id: id, identity: .init(vendor: id, model: id, serial: id, isBuiltIn: false),

--- a/CandelaAppTests/ScreenParametersSampleTests.swift
+++ b/CandelaAppTests/ScreenParametersSampleTests.swift
@@ -1,0 +1,252 @@
+import AppKit
+import CandelaKit
+import CoreGraphics
+import Foundation
+import Testing
+
+// Characterisation pins. Every test here passes against today's coordinators; they
+// exist because the property holds by a mechanism nobody would guess from reading
+// the registrations, and losing it would be silent.
+//
+// [MEASURED 2026-09-09, standalone Foundation binary and this bundle] an observer
+// registered with `queue: .main` runs its block SYNCHRONOUSLY on the posting thread
+// when the post comes from the main thread: `OperationQueue.current` is
+// `OperationQueue.main` there, and `NotificationCenter` short-circuits when the
+// target queue is already the current one. AppKit posts
+// `didChangeScreenParametersNotification` on the main thread, so both `.main`
+// coordinators below sample inside the post. `queue: nil`, which the two mirroring
+// registrations use, gets the same delivery by documented contract.
+//
+// A late sample fails silently: an unplug and a replug inside one main-queue turn
+// read as a display that never left, so the remembered resolution and the saved
+// layout stay away. The control is one edit: delete the `center.post` line from
+// each test and all four fail.
+
+/// The screen-parameters sample is taken INSIDE AppKit's post, not on the far side
+/// of a main-queue hop.
+///
+/// `DisplayArrivalTracker.noteObserved(live:)` is written for a set sampled at post
+/// time: anything missing from it counts as departed, which is what makes the next
+/// appearance an arrival. Sample it later and a replug within one main-queue turn
+/// reads as a display that never left, so nothing is restored.
+///
+/// The counter tests run no `await` between the post and the assertion, so a read
+/// that happened can only have happened inside the post.
+@MainActor
+@Suite("Screen-parameters sampling", .timeLimit(.minutes(1)))
+struct ScreenParametersSampleTests {
+  private static let panelID: CGDirectDisplayID = 12
+  private static let native = DisplayMode(
+    ioModeID: 1, logicalWidth: 3440, logicalHeight: 1440,
+    pixelWidth: 3440, pixelHeight: 1440, refreshHz: 175, isNative: true
+  )
+  private static let smaller = DisplayMode(
+    ioModeID: 2, logicalWidth: 2560, logicalHeight: 1080,
+    pixelWidth: 2560, pixelHeight: 1080, refreshHz: 175, isNative: false
+  )
+
+  @Test func theModeCoordinatorSamplesTheOnlineListInsideThePost() {
+    let rig = Self.modeRig()
+    defer { rig.forgetPrefs() }
+
+    let before = rig.configurator.onlineListReads
+    rig.center.post(name: NSApplication.didChangeScreenParametersNotification, object: nil)
+
+    #expect(rig.configurator.onlineListReads == before + 1)
+  }
+
+  /// `currentTopology()` is this coordinator's online read: `displaysChanged` feeds
+  /// `noteObserved(live:)` straight off `topology.displays`.
+  @Test func theArrangementCoordinatorSamplesTheOnlineListInsideThePost() {
+    let fixture = Self.layoutFixture()
+    defer { fixture.forgetPrefs() }
+
+    let before = fixture.rig.topologyReads
+    fixture.center.post(name: NSApplication.didChangeScreenParametersNotification, object: nil)
+
+    #expect(fixture.rig.topologyReads == before + 1)
+  }
+
+  /// A replug compressed into one turn: the display leaves and is back before
+  /// anything queued on the main actor runs. Only the sample taken during the post
+  /// records the departure that makes the second pass an arrival.
+  @Test func aReplugInsideOneMainQueueTurnStillRestoresTheRememberedMode() async throws {
+    let rig = Self.modeRig()
+    defer { rig.forgetPrefs() }
+    rig.persistence.setEnabled(true, for: rig.identity)
+    rig.persistence.store(Self.smaller.descriptor, for: rig.identity)
+
+    await rig.modes.reapplyStoredModes()
+    #expect(rig.world.applies.count == 1)
+
+    rig.world.detach(Self.panelID)
+    rig.center.post(name: NSApplication.didChangeScreenParametersNotification, object: nil)
+    rig.world.attach(
+      Self.panel(rig.identity), modes: [Self.native, Self.smaller], current: Self.native,
+      nativePixels: (width: 3440, height: 1440)
+    )
+
+    // This handler runs on the far side of a hop by design, so the pass it feeds has
+    // to wait. Bounded rather than `Task.yield()`, which promises nothing about a
+    // task the notification block created.
+    try await Task.sleep(for: .milliseconds(50))
+    await rig.modes.reapplyStoredModes()
+
+    #expect(rig.world.applies.count == 2)
+  }
+
+  /// The layout half of the same replug. `TopologyArrivalTracker` also resets on a
+  /// signature change, no help here: the set is identical before and after, so the
+  /// sample is the only record that the display left.
+  @Test func aReplugInsideOneMainQueueTurnStillRestoresTheSavedLayout() async {
+    let fixture = Self.layoutFixture()
+    defer { fixture.forgetPrefs() }
+    let rig = fixture.rig
+    let saved = rig.currentArrangement()
+    fixture.store.setRestoreEnabled(true)
+    fixture.store.save(saved)
+
+    // Claims the launch arrival, so the second pass can only come from a departure.
+    await fixture.coordinator.restoreSavedArrangement()
+
+    let scrambled = saved.moving(2, to: DisplayPoint(x: -800, y: 0))
+    rig.setLayout(DisplayArrangement(tiles: scrambled.tiles.filter { $0.id != 2 }))
+    fixture.center.post(name: NSApplication.didChangeScreenParametersNotification, object: nil)
+    rig.setLayout(scrambled)
+
+    // No wait, unlike the mode half above: this coordinator's handler runs to
+    // completion inside the post, and `restoreSavedArrangement` drains the queue
+    // the handler enqueued on.
+    await fixture.coordinator.restoreSavedArrangement()
+
+    #expect(rig.currentArrangement() == saved)
+  }
+
+  // MARK: - Rigs
+
+  /// Its own notification centre: a post on `.default` would reach every
+  /// coordinator alive in the process, and Swift Testing runs suites in parallel.
+  private struct ModeRig {
+    let world: FakeDisplayWorld
+    let configurator: FakeSynthesisDisplayConfigurator
+    let modes: DisplayModeCoordinator
+    let persistence: ModePersistence
+    let identity: DisplayConfigIdentity
+    let center: NotificationCenter
+    let suiteName: String
+
+    func forgetPrefs() {
+      UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+  }
+
+  private static func panel(_ identity: DisplayConfigIdentity) -> ConfiguredDisplay {
+    ConfiguredDisplay(id: panelID, identity: identity, name: "MAG341C", isBuiltIn: false)
+  }
+
+  private static func modeRig() -> ModeRig {
+    let world = FakeDisplayWorld()
+    let identity = DisplayConfigIdentity(vendor: 0x3669, model: 9, serial: 9, isBuiltIn: false)
+    world.attach(
+      panel(identity), modes: [native, smaller], current: native,
+      nativePixels: (width: 3440, height: 1440)
+    )
+    let configurator = FakeSynthesisDisplayConfigurator(world)
+    let suiteName = "app-tests-screen-parameters-\(UUID().uuidString)"
+    let persistence = ModePersistence(defaults: UserDefaults(suiteName: suiteName)!)
+    let center = NotificationCenter()
+    let modes = DisplayModeCoordinator(
+      gate: DisplayReconfigurationGate(),
+      configurator: configurator,
+      persistence: persistence,
+      notificationCenter: center
+    )
+    return ModeRig(
+      world: world, configurator: configurator, modes: modes, persistence: persistence,
+      identity: identity, center: center, suiteName: suiteName
+    )
+  }
+
+  private struct LayoutFixture {
+    let rig: LayoutRig
+    let coordinator: ArrangementCoordinator
+    let store: ArrangementPersistence
+    let center: NotificationCenter
+    let suiteName: String
+
+    func forgetPrefs() {
+      UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+  }
+
+  private static func layoutFixture() -> LayoutFixture {
+    let suiteName = "app-tests-screen-parameters-layout-\(UUID().uuidString)"
+    let rig = LayoutRig()
+    let center = NotificationCenter()
+    let store = ArrangementPersistence(defaults: UserDefaults(suiteName: suiteName)!)
+    let coordinator = ArrangementCoordinator(
+      gate: DisplayReconfigurationGate(),
+      configurator: rig,
+      persistence: store,
+      rotationConfigurator: rig,
+      notificationCenter: center
+    )
+    return LayoutFixture(
+      rig: rig, coordinator: coordinator, store: store, center: center, suiteName: suiteName
+    )
+  }
+}
+
+/// A settable layout, the topology derived from it, and a count of the topology
+/// reads. Replaces only display I/O; the real coordinator, queue, preview session
+/// and restorer run. `SavedLayoutConfirmationTests`' rig is private to that file.
+///
+/// `@unchecked Sendable`: every stored field is read and written only under `lock`,
+/// so the notification block's thread and the test's own can touch it in either
+/// order.
+private final class LayoutRig: DisplayArrangementConfiguring, DisplayRotationConfiguring,
+  @unchecked Sendable {
+  private let lock = NSLock()
+  private var layout = DisplayArrangement(tiles: [
+    tile(1, .init(x: 0, y: 0, width: 1000, height: 800)),
+    tile(2, .init(x: 1000, y: 0, width: 800, height: 1200)),
+  ])
+  private var _topologyReads = 0
+
+  /// How many times the coordinator asked who is online. Counted on
+  /// `currentTopology()`, not `currentArrangement()`: the set the arrival record is
+  /// judged against comes off `topology.displays`.
+  var topologyReads: Int { lock.withLock { _topologyReads } }
+
+  func setLayout(_ layout: DisplayArrangement) {
+    lock.withLock { self.layout = layout }
+  }
+
+  func currentArrangement() -> DisplayArrangement { lock.withLock { layout } }
+
+  func currentTopology() -> (displays: [ConfiguredDisplay], arrangement: DisplayArrangement) {
+    let layout = lock.withLock {
+      _topologyReads += 1
+      return self.layout
+    }
+    return (layout.tiles.map {
+      .init(id: $0.id, identity: $0.identity, name: $0.name, isBuiltIn: false)
+    }, layout)
+  }
+
+  func apply(_ plan: ArrangementPlan, scope: DisplayConfigScope) throws -> DisplayArrangement {
+    setLayout(plan.arrangement)
+    return currentArrangement()
+  }
+
+  var canRotate: Bool { true }
+  func rotation(of displayID: CGDirectDisplayID) -> DisplayRotation? { .standard }
+  func applyRotation(_ rotation: DisplayRotation, to displayID: CGDirectDisplayID) throws {
+    Issue.record("Unexpected rotation change")
+  }
+
+  private static func tile(_ id: CGDirectDisplayID, _ rect: DisplayRect) -> ArrangementTile {
+    .init(id: id, identity: .init(vendor: id, model: id, serial: id, isBuiltIn: false),
+          name: "Display \(id)", rect: rect, mirroredIDs: [])
+  }
+}

--- a/CandelaKit/Sources/CandelaKit/Arrangement/ArrangementReapplyPolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Arrangement/ArrangementReapplyPolicy.swift
@@ -53,6 +53,21 @@ public enum ArrangementReapplyNotice: Sendable, Equatable {
     case .ambiguousIdentity, .setDiffers, .layoutNoLongerFits, .failed: true
     }
   }
+
+  /// Whether recording the layout that is on screen NOW ends this state.
+  ///
+  /// Saving over `failed` would record the un-restored layout the failure left on
+  /// screen, making the failure permanent. Over `ambiguousIdentity` it would record
+  /// a layout the next restore refuses for the same reason. `setDiffers` is about a
+  /// different display set, so there is no stale record here to replace, and
+  /// `layoutNoLongerFits` is hand-edited or corrupt data. Exhaustive on purpose: a
+  /// case added later has to decide.
+  public var isResolvedBySavingCurrentLayout: Bool {
+    switch self {
+    case .savedForDifferentGeometry: true
+    case .ambiguousIdentity, .setDiffers, .layoutNoLongerFits, .failed: false
+    }
+  }
 }
 
 /// One restore decision: what to put on screen, and what to say.

--- a/CandelaKit/Tests/CandelaKitTests/ArrangementReapplyPolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/ArrangementReapplyPolicyTests.swift
@@ -395,6 +395,22 @@ struct ArrangementReapplyPolicyTests {
     }
   }
 
+  /// The remedy is "record what is on screen now", which only makes sense where a
+  /// stored layout has gone stale.
+  @Test func onlyAStaleFootprintIsFixedBySavingTheLayoutOnScreen() {
+    #expect(ArrangementReapplyNotice.savedForDifferentGeometry(["a"]).isResolvedBySavingCurrentLayout)
+
+    let unresolved: [ArrangementReapplyNotice] = [
+      .ambiguousIdentity(["a"]),
+      .setDiffers(missing: ["a"], extra: ["b"]),
+      .layoutNoLongerFits([.overlap(1, 2)]),
+      .failed(DisplayConfigError(cgErrorCode: 1000)),
+    ]
+    for notice in unresolved {
+      #expect(!notice.isResolvedBySavingCurrentLayout, "\(notice) is not a stale record a save replaces")
+    }
+  }
+
   /// The overlap-refusal rule stays the backstop, reachable only for stored data that does not tile at the
   /// sizes it recorded: hand-edited or corrupt, since a layout is only saved from one the
   /// machine achieved. It is also the case `expectsExactOrigins` turns the post-commit


### PR DESCRIPTION
Closes #54.

## What changed

**Save This Layout.** The Arrangement pane's notice that a saved layout no longer fits the displays offered only OK, and neither of the two ways out (rearranging on the canvas, or toggling the remember setting) was named. The notice now carries a Save This Layout button beside OK. It re-samples the arrangement and saves it through the same queue, revision and gate discipline the remember toggle uses, refuses while a preview is outstanding, and is hidden while the remember setting is off. A refused save shows its reason under the buttons, naming the coordinator that holds the display (a rotation or resolution change in flight), rather than raising the report card whose OK would have cleared the notice. The notice sentence names the one-click route only on the surface that has the button.

**The late display sample was not late.** The issue described the mode and arrangement coordinators sampling the display set one main-queue turn late, so a fast unplug and replug could be missed. Measured 2026-09-10: an observer registered on the main queue runs its block synchronously when AppKit posts from the main thread, and AppKit posts this notification there, so both coordinators already sample inside the post and a fast dock cycle is already recorded as a departure. No behaviour changes. Four tests pin the property so a queue change or a platform change turns them red, and the comments in four coordinators now describe the mechanism as measured; two of them had given the same wrong mechanism as their rationale.

## Hardware verification

Run locally with the MSI MAG 341C OLED and Dell U2725QE attached. The initial UI checks used this branch; the final reconnect checks used a signed Release build combining the pending fixes.

- Stale layout: with the remember setting on and a layout saved, the Dell was held on a smaller mode so the saved footprint no longer matched. A relaunch raised the notice with both buttons and logged the stale geometry. Pressing Save This Layout cleared the notice and replaced the stored record; a further relaunch stayed clean. Passed.
- Remember off: with the setting off, a relaunch into the same mismatch showed no notice and no button, and the stored record was untouched. Passed.
- Gate refusal: with the stale notice up and a rotation preview standing on the Dell, pressing Save left the notice and the button in place and showed "Candela is already rotating a display. Finish that first." under them; no report card appeared. Passed. One follow-up: that caption stays until the next click after the rotation resolves; it self-corrects and is filed as a follow-up.
- The confirmation card is unchanged, verified by the diff (its file is untouched and it renders the notice without the new clause); it was not raised on the rig.
- Quick physical MSI reconnects passed with the menu-bar popover closed and open. Each return initially reached macOS's 100 Hz mode and shifted position; Candela then restored the saved 60 Hz mode and original position. Independent display-state sampling recorded both transitions.
- Positive control: with both remember settings off, the same reconnect retained 100 Hz and the shifted position. This distinguishes Candela's restoration from macOS restoring the same state on its own.
- The original remember settings were restored after the test. Live VoiceOver testing was deliberately skipped; the existing accessibility controls were inspected.

The branch passed 2,591 engine tests and 701 app tests. CI passed on the final head, and independent review found no remaining actionable findings.

## Scope notes

- The in-flight caption and the one-enumeration catalog refresh from the same issue shipped earlier and are not part of this change.
- A "Forget this layout" control is not included; the persistence seam for it exists with no caller.
