### PR TITLE
Seal DDC read requests over the source address as well

### DIFF
--- a/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
+++ b/CandelaKit/Sources/CandelaKit/Brightness/BrightnessController.swift
@@ -530,6 +530,9 @@ public final class BrightnessController: PendingWireDraining {
     guard !usesNative else { return }
     let tuning = prefs.tuning(for: .brightness)
     guard !tuning.unavailableDDC else { return }
+    // The software path writes no DDC brightness, so the register still holds the
+    // monitor's own value; adopting it would overwrite the saved software brightness.
+    guard !prefs.forceSoftware else { return }
     // Reads use only the first remap code; trailing codes affect writes alone.
     let readCode = tuning.remapCodes.first ?? VCP.brightness
     bindReadRegister(to: readCode)

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -206,13 +206,9 @@ public class Arm64DDC: NSObject {
     let dataAddress = ARM64_DDC_DATA_ADDRESS
     // [0x80 | messageLength][op][offsetHi][offsetLo][checksum]
     var packet: [UInt8] = [0x80 | 3, 0xF3, UInt8(offset >> 8), UInt8(offset & 0xFF), 0]
-    // Seeded like the READ path (0x6E alone, not 0x6E ^ 0x51): a capabilities
-    // request is a request-with-reply exactly like Get VCP, and the fork's two
-    // seeds are empirical, not derived. If a panel NAKs every fragment while
-    // answering Get VCP fine, try the write seed (0x6E ^ dataAddress) before
-    // concluding the panel is silent.
+    // Neither I2C address travels inside the packet, so both seed the checksum.
     packet[packet.count - 1] = self.checksum(
-      chk: ARM64_DDC_7BIT_ADDRESS << 1, data: &packet, start: 0, end: packet.count - 2
+      chk: ARM64_DDC_7BIT_ADDRESS << 1 ^ dataAddress, data: &packet, start: 0, end: packet.count - 2
     )
     // Max frame: source + length byte + (op + 2 offset + 32 payload) + checksum.
     var reply = [UInt8](repeating: 0, count: 38)
@@ -242,7 +238,8 @@ public class Arm64DDC: NSObject {
     /// checksum-clean frame came back.
     case ok
     /// The panel wrote zeros over the sentinel: it is on the bus and saying
-    /// nothing. The write-only signature.
+    /// nothing. Not proof it cannot read back; a malformed request checksum drew
+    /// the same answer from a panel that validates the seal.
     case answeredZeros
     /// Nothing usable: a NAKed write, a failed read call, a buffer the read
     /// left untouched, or a frame that failed its checksum.
@@ -336,9 +333,13 @@ public class Arm64DDC: NSObject {
   /// The retry ladder. Split from the entry point so a nil service is refused
   /// before any sleep, and so a test can hand it a panel.
   static func runTransaction(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], replyCommand: UInt8?, writeSleepTime: UInt32?, numOfWriteCycles: UInt8?, readSleepTime: UInt32?, numOfRetryAttemps: UInt8?, retrySleepTime: UInt32?, pacer: DDCBusPacer?, transport: I2CTransport) -> TransactionOutcome {
-    let dataAddress = ARM64_DDC_DATA_ADDRESS
     var packet: [UInt8] = [UInt8(0x80 | (send.count + 1)), UInt8(send.count)] + send + [0] // Note: the last byte is the place of the checksum, see next line!
-    packet[packet.count - 1] = self.checksum(chk: send.count == 1 ? ARM64_DDC_7BIT_ADDRESS << 1 : ARM64_DDC_7BIT_ADDRESS << 1 ^ dataAddress, data: &packet, start: 0, end: packet.count - 2)
+    // Same seed for reads and writes: neither I2C address travels inside the
+    // packet, so both go into the checksum.
+    packet[packet.count - 1] = self.checksum(
+      chk: ARM64_DDC_7BIT_ADDRESS << 1 ^ ARM64_DDC_DATA_ADDRESS,
+      data: &packet, start: 0, end: packet.count - 2
+    )
     var outcome = TransactionOutcome.silent
     let pacing = writeSleepTime ?? 10000
     // Only the FIRST packet is paced from the bus; a second write cycle or a

--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDCService.swift
@@ -2,8 +2,7 @@ import CandelaPrivateAPIs
 import CoreGraphics
 import os
 
-/// One line per DDC read. Nothing else reports which of the two silent verdicts
-/// a panel earned, and that is the whole of a write-only panel's signature.
+/// One line per DDC read: nothing else reports which silent verdict a panel earned.
 let ddcReadLog = Logger(subsystem: "com.rydersel.Candela", category: "ddcread")
 
 /// Serializes DDC I/O for one display's IOAVService (spec §5: serial per-display actor).

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -561,3 +561,87 @@ private func pacerOnAQuietBus(_ clock: FakeClock) -> DDCBusPacer {
       == .frame(current: 50, max: 100)
   )
 }
+
+// MARK: - The request checksum on the wire
+
+/// DDC/CI seals a host packet over both I2C addresses, and neither byte travels
+/// inside the packet.
+private let ddcDestinationAddress: UInt8 = 0x6E
+private let ddcSourceAddress: UInt8 = 0x51
+
+/// The read stub fails, so the ladder stops after one attempt.
+///
+/// `@unchecked Sendable`: `runTransaction` calls the closures synchronously and
+/// has returned before the test reads `packets`.
+private final class PacketRecorder: @unchecked Sendable {
+  private(set) var packets: [[UInt8]] = []
+
+  var transport: Arm64DDC.I2CTransport {
+    Arm64DDC.I2CTransport(
+      write: { _, bytes, count in
+        self.packets.append(Array(UnsafeRawBufferPointer(start: bytes, count: Int(count))))
+        return 0
+      },
+      read: { _, _, _ in -1 },
+      sleep: { _ in }
+    )
+  }
+}
+
+private func firstPacket(send: [UInt8], expectsReply: Bool) -> [UInt8]? {
+  let recorder = PacketRecorder()
+  var send = send
+  var reply = expectsReply ? [UInt8](repeating: 0, count: DDCReplyFrame.expectedLength) : []
+  _ = Arm64DDC.runTransaction(
+    service: nil, send: &send, reply: &reply, replyCommand: send.first,
+    writeSleepTime: 0, numOfWriteCycles: nil, readSleepTime: 0,
+    numOfRetryAttemps: 0, retrySleepTime: 0, pacer: nil, transport: recorder.transport
+  )
+  return recorder.packets.first
+}
+
+/// XOR of the whole packet, checksum byte included, which leaves the seed.
+private func recoveredSeed(_ packet: [UInt8]) -> UInt8 {
+  packet.reduce(0, ^)
+}
+
+/// Sealed without the source address, a read draws zeros from a panel that checks
+/// it. Expected byte comes from the spec by hand, not from `checksum`.
+@Test func aReadRequestIsSealedOverBothAddresses() {
+  // [0x80 | 2][data length 1, which for Get VCP is also the op code][VCP code][checksum]
+  let lengthByte: UInt8 = 0x82
+  let opCode: UInt8 = 0x01
+  let brightness: UInt8 = 0x10
+  let expected = ddcDestinationAddress ^ ddcSourceAddress ^ lengthByte ^ opCode ^ brightness
+  #expect(expected == 0xAC)
+  #expect(firstPacket(send: [brightness], expectsReply: true) == [0x82, 0x01, 0x10, expected])
+}
+
+@Test func aWriteRequestIsSealedOverBothAddresses() {
+  // [0x80 | 4][data length 3, which for Set VCP is also the op code][VCP code][hi][lo][checksum]
+  let lengthByte: UInt8 = 0x84
+  let opCode: UInt8 = 0x03
+  let brightness: UInt8 = 0x10
+  let high: UInt8 = 0x00
+  let low: UInt8 = 0x32
+  var expected = ddcDestinationAddress ^ ddcSourceAddress ^ lengthByte ^ opCode
+  expected ^= brightness ^ high ^ low
+  #expect(expected == 0x9A)
+  #expect(
+    firstPacket(send: [brightness, high, low], expectsReply: false)
+      == [0x84, 0x03, 0x10, 0x00, 0x32, expected]
+  )
+}
+
+/// Recovered from the bytes rather than the expression, so a divergence between
+/// the read and write seeds is caught whatever shape it takes.
+@Test func neitherRequestPathSealsWithASeedOfItsOwn() {
+  guard let read = firstPacket(send: [0x10], expectsReply: true),
+        let write = firstPacket(send: [0x10, 0x00, 0x32], expectsReply: false)
+  else {
+    Issue.record("no packet reached the bus")
+    return
+  }
+  #expect(recoveredSeed(read) == ddcDestinationAddress ^ ddcSourceAddress)
+  #expect(recoveredSeed(write) == recoveredSeed(read))
+}

--- a/CandelaKit/Tests/CandelaKitTests/PathSelectionTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/PathSelectionTests.swift
@@ -1383,6 +1383,24 @@ struct PathSelectionTests {
     #expect(approx(h.controller.brightness, 0.5))
   }
 
+  @Test func refreshLeavesAForcedSoftwareDisplayAlone() async {
+    let h = Harness(ddcRead: (current: 50, max: 100)) { prefs, _ in prefs.forceSoftware = true }
+    h.controller.setBrightness(0.3)
+
+    await h.controller.refreshFromHardware()
+
+    // Forced software writes no DDC brightness, so 50/100 is stale: keep the saved 0.3.
+    #expect(approx(h.controller.brightness, 0.3))
+    #expect(approx(h.store.values[Harness.storageKey] ?? -1, 0.3))
+    #expect(await h.ddc.recordedReadCount() == 0, "and the wire is never asked")
+
+    // Same frame without the opt-out adopts, so the guard is what held 0.3 above.
+    let control = Harness(ddcRead: (current: 50, max: 100))
+    control.controller.setBrightness(0.3)
+    await control.controller.refreshFromHardware()
+    #expect(approx(control.controller.brightness, 0.75))
+  }
+
   // MARK: Reconfigure
 
   @Test func reconfigureRecapturesAndReappliesSoftwareLeg() async {


### PR DESCRIPTION
Fixes #100.

VCP read requests were sealed with a checksum that omitted the source address, so every read this app has ever sent was wrong by exactly 0x51.

## The change

`Arm64DDC.runTransaction` chose its checksum seed from the shape of the packet: reads seeded with `ARM64_DDC_7BIT_ADDRESS << 1` (0x6E), writes with that value XOR the data address (0x3F). DDC/CI seals a host-to-display message over the destination address and the source address, and neither travels inside the packet, so both belong in the seed. Reads were missing one of them. `readCapabilityFragment` carried the same defect, with a comment noting it had been copied from the read path.

Both sites now use one seed. The ternary is gone rather than left selecting the same value twice.

## Why it went unnoticed

A monitor that validates the seal rejects the frame and returns a zero-filled reply, which reads exactly like a panel that accepts commands and never answers. A monitor that does not validate answers anyway. The development setup had one of each, and the tolerant one was treated as the reference for read behaviour, so it confirmed a broken implementation at every step. Writes were always correct, which is why the symptom looked like a hardware property rather than a defect here.

## Tests

Three tests pin the request bytes through the existing injectable transport seam, with the expected checksums computed by hand from the specification rather than from the code under test:

- a read request is sealed over both addresses
- a write request is sealed over both addresses
- neither path seals with a seed of its own, recovering each seed from the bytes so a future divergence fails whatever shape it takes

The read test fails at 0xFD against the expected 0xAC before the change, a difference of exactly 0x51.

Engine suite 2,573 tests in 203 suites, app suite 637 tests in 66 suites, all passing.

## Hardware verification

Run on both attached panels through this branch's own code path, with the app quit so nothing else drove the bus, and HDR off.

| Check | MSI MAG 341C OLED | Dell U2725QE (control) |
|---|---|---|
| VCP 0xDF | 513, previously zeros | 513, unchanged |
| VCP 0xC0 | 1318, previously zeros | 315 |
| VCP 0xC8 | 18, previously zeros | not applicable |
| VCP 0xC6 | 111, previously zeros | not applicable |
| Capability string | full string, parses; previously unknown | unchanged, still parses |
| Volume verdict | supported; previously unknown | unsupported, unchanged |
| Brightness readback | 62 of 100; previously unreadable | 100 of 100 |
| Brightness write | 62 to 40 and back, confirmed by readback | 100 to 80 and back, confirmed |

The three MSI constants are the values its firmware is known to return for those registers, so they are checkable rather than merely plausible. The Dell did not regress on any check and both panels were restored to their original brightness.

## Follow-on work, deliberately not in this branch

- Brightness for the MSI panel is tracked as a last-written value because readback was assumed impossible. It is readable now, so that tracking can be revisited.
- The diagnostics copy describing a display that takes commands but never answers a read stays as written. It remains correct for a panel that genuinely does not answer; the MSI simply will not be classified that way any more.
