### PR TITLE
Keep excluded displays on the checkup pick page, let a stored run be deleted, end a field with Escape, stop the sweep on close, fit Setup to four displays, and speak both flows to VoiceOver

### DIFF
--- a/Candela/App/StatusItemController.swift
+++ b/Candela/App/StatusItemController.swift
@@ -805,6 +805,7 @@ final class StatusItemController: NSObject, NSApplicationDelegate, NSMenuDelegat
             "checkup report could not be saved: \(String(describing: error), privacy: .public)")
         }
       },
+      actions: settingsActions,
       care: model.oledCare)
     checkupWindow = controller
     return controller

--- a/Candela/Checkup/CheckupCopy.swift
+++ b/Candela/Checkup/CheckupCopy.swift
@@ -132,6 +132,8 @@ enum CheckupCopy {
   static let refreshTitle = "The refresh sweep"
   static let hdrTitle = "HDR"
   static let running = "Running this check on the display."
+  static let modeChangeWarning =
+    "The next test may make your display flicker or go dark briefly. Your original resolution and refresh rate will be restored after the refresh test."
   static let refusalNote =
     "A refusal is recorded with its reason and the run carries on. Nothing here ends a checkup except you."
 
@@ -456,7 +458,7 @@ enum CheckupCopy {
     [preparingTitle, preparingBody,
      scenarioTitle, scenarioSubtitle, scenarioNew, scenarioUsed, scenarioRecheck, pickTitle,
      pickSubtitle, pickEmpty, planTitle, planSubtitle, planModeSweep, identityTitle, capabilitiesTitle,
-     nativeModeTitle, refreshTitle, hdrTitle, running, refusalNote, plantDisclosureTitle,
+     nativeModeTitle, refreshTitle, hdrTitle, running, modeChangeWarning, refusalNote, plantDisclosureTitle,
      plantDisclosure, plantMissedTwice, showAgain, showAgainCap, start, continueLabel, back,
      answerPrompt, recordedPrefix, answerNothing, answerOne, answerMore, answerRound,
      answerNotRound, tapHint, secondDotTitle, secondDotPrompt, onlyDisplayStrip, summaryTitle,

--- a/Candela/Checkup/CheckupCopy.swift
+++ b/Candela/Checkup/CheckupCopy.swift
@@ -79,6 +79,31 @@ enum CheckupCopy {
   static let fieldNotShown =
     "This field could not be shown: \(noScreenReason). The usual cause is mirroring, since a mirrored display has no screen of its own to draw on. Nothing was recorded for it."
 
+  // MARK: - Displays no checkup can run on
+
+  static let excludedTitle = "Not available for a checkup"
+
+  /// Neither reason is a verdict on the panel. Each says what the exclusion
+  /// costs the checkup, and the one with a way out names it.
+  static let excludedMirroring =
+    "This display is mirroring another one, so macOS gives it no screen of its own and no test field can be shown on it. Stop mirroring it to check it here."
+  static let excludedVirtual =
+    "This is a virtual display made in software rather than a panel, so there is no glass to look at and nothing to check."
+
+  static func excludedReason(_ reason: CheckupExcludedDisplay.Reason) -> String {
+    switch reason {
+    case .mirroring: excludedMirroring
+    case .virtual: excludedVirtual
+    }
+  }
+
+  /// The row is not a button, so this one element is all VoiceOver gets: every
+  /// line the row draws, refusal before reason.
+  static func excludedRowLabel(_ display: CheckupExcludedDisplay) -> String {
+    "\(display.name), \(pixelSizeLine(width: display.pixelWidth, height: display.pixelHeight)). "
+      + "\(excludedTitle). " + excludedReason(display.reason)
+  }
+
   // MARK: - Plan
 
   static let planTitle = "What will run"
@@ -171,6 +196,18 @@ enum CheckupCopy {
     "The \(fieldName(kind))"
   }
 
+  /// The field as the thing on the glass. Not `fieldTitle`, which is a page
+  /// heading the cursor lands on a moment after the announcement is spoken.
+  static func fieldSubject(_ kind: CheckupFieldKind) -> String {
+    switch kind {
+    // Ramp and witness are not flat fills. Every kind is listed rather than
+    // defaulted, so a new non-flat field cannot inherit "solid".
+    case .ramp, .witness: "a \(shortFieldName(kind))"
+    case .black, .red, .green, .blue, .gray7, .gray50, .white:
+      "solid \(shortFieldName(kind))"
+    }
+  }
+
   static let answerNothing = "Nothing"
   static let answerOne = "One mark"
   static let answerMore = "More than one"
@@ -195,6 +232,67 @@ enum CheckupCopy {
 
   static func secondsLeft(_ seconds: Int) -> String {
     seconds == 1 ? "1 second left" : "\(seconds) seconds left"
+  }
+
+  /// Returns `secondsLeft` itself, so the strip, the page and VoiceOver cannot
+  /// say three different numbers. Nil where the cadence rule says nothing.
+  static func secondsLeftAnnouncement(seconds: Int, cap: Int) -> String? {
+    guard AnnouncementThresholds.speaks(at: seconds, cap: cap) else { return nil }
+    return secondsLeft(seconds)
+  }
+
+  /// What VoiceOver says when the checkup lands on a new page.
+  ///
+  /// Not `CheckupPage.name`, which gives a field's three pages one name. No arm
+  /// contains its page's heading: the cursor lands there a moment later, and a
+  /// test pairs every page with the title its view draws.
+  static func pageAnnouncement(_ page: CheckupPage) -> String {
+    switch page {
+    case .scenario:
+      "Choose why you are running this checkup: \(scenarioChoiceWords)."
+    case .displayPick:
+      "Pick the display this run will cover, from the ones a test field can be drawn on."
+    case .plan:
+      "The list of checks, and how long they take."
+    case .identity:
+      "The display's EDID: the serial number, the manufacture date, and the native size "
+        + "and refresh it claims."
+    case .capabilities:
+      "Brightness, contrast and volume, asked for over DDC and read back."
+    case .nativeMode:
+      "Setting the display to the size it was manufactured at, then reading back what it "
+        + "is showing."
+    case .refresh:
+      "Every refresh rate at the native size, one at a time. The display goes dark for a "
+        + "moment at each."
+    case .witness:
+      // `.witness` IS the witness card's instruction page, so it routes to the
+      // same arm rather than getting a second wording.
+      pageAnnouncement(.fieldInstruction(.witness))
+    case .plantDisclosure:
+      "Why a mark is put on the screen on purpose, before the color fields begin."
+    case .fieldInstruction(let kind):
+      "What to look for on \(fieldSubject(kind)), and how to put it on the display when "
+        + "you are ready."
+    case .fieldShowing(let kind):
+      "The display is showing \(fieldSubject(kind)) now, with the answers below it."
+    case .fieldConfirmSecondDot(let kind):
+      "Showing \(fieldSubject(kind)) again, with nothing planted on it this time."
+    case .hdr:
+      "What the panel advertises for high dynamic range, and whether switching it on and "
+        + "back off settles."
+    case .summary:
+      "The run is over. Its report is on this page, and it can be exported or copied."
+    }
+  }
+
+  /// Built from the cases so a fourth cannot ship unspoken. The short subject
+  /// words, not the rows' full-sentence labels.
+  private static var scenarioChoiceWords: String {
+    let words = CheckupScenario.allCases.map(scenarioWords)
+    guard let last = words.last else { return "" }
+    guard words.count > 1 else { return last }
+    return words.dropLast().joined(separator: ", ") + " or " + last
   }
 
   static let tapHint = "Tap the mark on the field itself before answering, so the report can record where it was."
@@ -365,6 +463,9 @@ enum CheckupCopy {
      headerSentence, plantMissed(size: 4), planWorstCase(seconds: 600), secondsLeft(1),
      secondsLeft(20), summaryIncomplete(reason: closedReason), closedReason, fieldWindowTitle,
      detectedAt(pixels: 4), hdrEngagedLine, noScreenReason, fieldNotShown,
+     excludedTitle, excludedMirroring, excludedVirtual,
+     excludedRowLabel(CheckupExcludedDisplay(
+       id: 1, name: "Display", pixelWidth: 3440, pixelHeight: 1440, reason: .mirroring)),
      pixelSizeLine(width: 3840, height: 2160),
      occlusionLine(fieldIDs: [CheckupCheckID.field(.black), CheckupCheckID.field(.gray7)]) ?? "",
      CheckupScenario.allCases.map(scenarioWords).joined(separator: " ")]
@@ -380,5 +481,13 @@ enum CheckupCopy {
          CheckupCheckID.capabilityContrast, CheckupCheckID.capabilityVolume,
          CheckupCheckID.nativeMode, CheckupCheckID.refreshSweep, CheckupCheckID.hdrFlags,
          CheckupCheckID.hdrSettle, CheckupCheckID.refresh(hz: 120)].map { claimLabel(id: $0) }
+      // An announcement is the one string nobody can proofread on screen, so
+      // the em-dash and no-verdict sweep has to reach it too.
+      + [CheckupPage.scenario, .displayPick, .plan, .identity, .capabilities, .nativeMode,
+         .refresh, .witness, .plantDisclosure, .hdr, .summary].map(pageAnnouncement)
+      + CheckupFieldKind.allCases.flatMap {
+        [pageAnnouncement(.fieldInstruction($0)), pageAnnouncement(.fieldShowing($0)),
+         pageAnnouncement(.fieldConfirmSecondDot($0))]
+      }
   }
 }

--- a/Candela/Checkup/CheckupEnvironment.swift
+++ b/Candela/Checkup/CheckupEnvironment.swift
@@ -26,6 +26,21 @@ struct CheckupDisplayEntry: Equatable, Sendable, Identifiable {
   var isOnlyDisplay: Bool
 }
 
+/// A display no checkup can run on, with the reason, so the pick page can show
+/// it rather than leave a person hunting for a display that vanished.
+///
+/// A list of its own, not a flag on `CheckupDisplayEntry`: `isOnlyDisplay`
+/// counts entries, so an excluded display among them would tell the field
+/// window there is somewhere else to put the instructions.
+struct CheckupExcludedDisplay: Equatable, Sendable, Identifiable {
+  enum Reason: Equatable, Sendable { case mirroring, virtual }
+  var id: CGDirectDisplayID
+  var name: String
+  var pixelWidth: Int
+  var pixelHeight: Int
+  var reason: Reason
+}
+
 /// Presents one field on one display and reports when it is down. MainActor
 /// because the live implementation is an AppKit window on the target panel.
 @MainActor
@@ -47,6 +62,9 @@ protocol CheckupCareHolding: AnyObject {
 /// the suite. The model never touches a display, a clock or a store directly.
 struct CheckupEnvironment {
   var displays: [CheckupDisplayEntry]
+  /// What `displays` left out, with reasons. Defaulted so a fake environment
+  /// states only what its own test is about.
+  var excluded: [CheckupExcludedDisplay] = []
   var macOSBuild: String
   var appBuild: String
   var runners: (CheckupDisplayEntry) -> CheckupRunnerSet

--- a/Candela/Checkup/CheckupFieldWindow.swift
+++ b/Candela/Checkup/CheckupFieldWindow.swift
@@ -11,6 +11,10 @@ final class CheckupFieldWindow: CheckupFieldPresenting {
   /// run this strip is the whole of the flow's controls.
   static let stripHeight: CGFloat = 104
 
+  /// Never key: borderless (`OverlayWindow.styleMask`), so Escape reaches its
+  /// owner through a local event monitor. It has to stay that way. A
+  /// shielding-level overlay that took key status would pull focus off another
+  /// display and put the flow window's Return shortcut out of reach.
   private var window: NSWindow?
   /// False in tests: ordering front is the one step with a visible consequence,
   /// and it is the step that puts the pointer away.
@@ -25,6 +29,7 @@ final class CheckupFieldWindow: CheckupFieldPresenting {
   private var timerLabel: NSTextField?
   private var instructionLabel: NSTextField?
   private var answerTarget: AnswerTarget?
+  private var keyMonitor: Any?
 
   /// Written through to a strip already on screen: the confirmation re-show
   /// changes the question without taking the field down.
@@ -40,6 +45,10 @@ final class CheckupFieldWindow: CheckupFieldPresenting {
   /// answer with `lastTap` before handing both to the flow.
   var onAnswer: ((CheckupFieldAnswer) -> Void)?
 
+  /// Escape while a field is up. The window cannot take key status, so this
+  /// arrives from a local event monitor, not the responder chain.
+  var onEscape: (() -> Void)?
+
   /// Cleared whenever a field goes up: a tap from the previous showing would be
   /// graded against a control that is no longer there.
   private(set) var lastTap: (x: Int, y: Int)?
@@ -53,6 +62,7 @@ final class CheckupFieldWindow: CheckupFieldPresenting {
   }
 
   var windowForTest: NSWindow? { window }
+  var keyMonitorForTest: Any? { keyMonitor }
 
   /// False when the display has no `NSScreen`, which is how a mirroring display looks from here.
   func show(kind: CheckupFieldKind, plant: CheckupPlant?, on display: CheckupDisplayEntry) -> Bool {
@@ -103,6 +113,7 @@ final class CheckupFieldWindow: CheckupFieldPresenting {
 
     self.window = window
     isShowing = true
+    installKeyMonitor()
     if orderFront {
       // Not `NSCursor.hide()`: the pointer must still reach the mark and the
       // strip. This needs no unhide, so an unexpected exit cannot strand it.
@@ -119,12 +130,14 @@ final class CheckupFieldWindow: CheckupFieldPresenting {
   }
 
   func hide() {
-    // Ahead of the `isShowing` guard: exit paths call hide twice, and a hold
-    // left standing pauses the display's care for the rest of the session.
+    // Ahead of the `isShowing` guard: exit paths call hide twice. A hold left
+    // standing pauses the display's care for the session; a monitor left
+    // standing swallows Escape everywhere else in the app.
     if let heldKey {
       self.heldKey = nil
       care?.endCheckupField(identityKey: heldKey)
     }
+    removeKeyMonitor()
     guard isShowing else { return }
     window?.orderOut(nil)
     isShowing = false
@@ -137,6 +150,30 @@ final class CheckupFieldWindow: CheckupFieldPresenting {
     if let heldKey { care?.endCheckupField(identityKey: heldKey) }
     heldKey = key
     care?.beginCheckupField(identityKey: key)
+  }
+
+  private static let escapeKeyCode: UInt16 = 53
+
+  /// A local monitor sees key events anywhere in this app, so one mechanism
+  /// covers both runs: the flow window is key behind the field on a one-display
+  /// run and key beside it on a multi-display one. Installed once per showing.
+  private func installKeyMonitor() {
+    guard keyMonitor == nil else { return }
+    keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+      // Only `hide()` removes this monitor, so one can outlive its window, and
+      // a released window consuming Escape would take it from the whole app.
+      guard let self, event.keyCode == Self.escapeKeyCode else { return event }
+      MainActor.assumeIsolated { self.onEscape?() }
+      // Consumed, so Escape does not also reach the flow window behind the field.
+      return nil
+    }
+  }
+
+  /// Idempotent: hide runs twice on the exit paths.
+  private func removeKeyMonitor() {
+    guard let keyMonitor else { return }
+    self.keyMonitor = nil
+    NSEvent.removeMonitor(keyMonitor)
   }
 
   /// Built by hand rather than hosted from SwiftUI so it stays a plain subview

--- a/Candela/Checkup/CheckupFlowModel.swift
+++ b/Candela/Checkup/CheckupFlowModel.swift
@@ -2,6 +2,7 @@ import CandelaKit
 import CoreGraphics
 import Foundation
 import Observation
+import os
 
 /// The checkup state machine: owns the report under construction and
 /// every verdict in it, including the planted control's grading. Only the
@@ -11,6 +12,8 @@ import Observation
 @MainActor
 @Observable
 final class CheckupFlowModel {
+  private static let log = Logger(subsystem: "com.rydersel.Candela", category: "checkup")
+
   private(set) var page: CheckupPage = .scenario
   /// Recorded on the report and shown in the flow; no check branches on it.
   var scenario: CheckupScenario = .newMonitor
@@ -37,6 +40,14 @@ final class CheckupFlowModel {
   /// The close seam: the window is the AppKit island, so Done asks rather than
   /// performs.
   var onClose: () -> Void = {}
+  /// Called once the mode restore has answered: whether to tell a person the
+  /// display was left off its starting mode, and which display. Fires on every
+  /// outcome.
+  ///
+  /// A seam, not a property: both routes that end a run release this model
+  /// before the restore answers. The key rides along because the surface that
+  /// shows the notice is scoped to one display.
+  var onRestoreSettled: (_ needsNotice: Bool, _ identityKey: String?) -> Void = { _, _ in }
 
   /// The one field the control is planted on. Optional only because `first(where:)` is.
   static let plantedField = CheckupFieldKind.protocolOrder.first { $0.carriesPlant }
@@ -72,11 +83,14 @@ final class CheckupFlowModel {
     self.environment = environment
   }
 
-  /// A virtual display is never a checkup target, and neither is one
-  /// mirroring another, which has no screen of its own to draw a field on.
-  var selectableDisplays: [CheckupDisplayEntry] {
-    environment.displays.filter { !$0.isVirtual && !$0.isMirroring }
-  }
+  /// Everything the environment offers, unfiltered. The exclusion rule lives
+  /// one layer up, where every reason is visible; a copy here would silently
+  /// drop a display excluded for a reason this list has never heard of.
+  var selectableDisplays: [CheckupDisplayEntry] { environment.displays }
+
+  /// The displays the pick page shows but cannot offer, so the page decides
+  /// nothing.
+  var excludedDisplays: [CheckupExcludedDisplay] { environment.excluded }
 
   var canShowAgain: Bool {
     guard let kind = currentFieldKind else { return false }
@@ -110,7 +124,11 @@ final class CheckupFlowModel {
       page = .displayPick
 
     case .displayPick:
-      guard let display = selectedDisplay, !display.isVirtual, !display.isMirroring else { return }
+      // Selectable is whatever the environment offered, never a re-test of the
+      // reasons this file happens to know.
+      guard let display = selectedDisplay,
+        selectableDisplays.contains(where: { $0.id == display.id })
+      else { return }
       begin(with: display)
       page = .plan
 
@@ -302,6 +320,16 @@ final class CheckupFlowModel {
     // A cap that ran out is a full showing of light, so it books the full cap;
     // the field itself stays unanswered until the user says something.
     endShowing(kind: kind, elapsed: kind.capSeconds)
+    page = instructionPage(for: kind)
+  }
+
+  /// The timeout's pair, booking the seconds the field was really up rather
+  /// than the cap. Never the answer path: an escaped field attested to nothing.
+  func escapeShowing() {
+    // Same derivation the end-of-run path books light with; two copies could
+    // disagree about which pages have a field up.
+    guard let kind = showingFieldKind else { return }
+    endShowing(kind: kind, elapsed: elapsedSeconds(of: kind))
     page = instructionPage(for: kind)
   }
 
@@ -567,15 +595,19 @@ final class CheckupFlowModel {
   // MARK: - Exits
 
   func abandon(reason: String) {
-    endRun(reason: reason)
+    endRun(reason: reason, displayGone: false)
   }
 
   func displayDisconnected(_ id: CGDirectDisplayID) {
     guard let display = selectedDisplay, display.id == id else { return }
-    endRun(reason: "the display disconnected during \((legInFlight ?? page).name)")
+    endRun(
+      reason: "the display disconnected during \((legInFlight ?? page).name)",
+      displayGone: true)
   }
 
-  private func endRun(reason: String) {
+  /// `displayGone` is passed rather than read back out of `reason`: a reason is
+  /// prose, and a string match on it breaks the first time somebody rewords it.
+  private func endRun(reason: String, displayGone: Bool) {
     guard !finished else { return }
     // A field on the panel is light that was emitted, so it books on the way
     // out exactly once; anything else just makes sure nothing is left up.
@@ -587,11 +619,36 @@ final class CheckupFlowModel {
     }
     running = false
     if let mode = runners?.mode {
+      // Cancel before queueing the restore: it serializes behind whatever the
+      // runner is doing, so a sweep still running would put the display back
+      // and then keep moving it.
+      mode.cancel()
+      // Read out and captured strongly: this model is released the moment the
+      // window closes, and a weak capture would drop the restore's answer.
+      let settled = onRestoreSettled
+      // Read out for the same reason. The notice names one display, and
+      // runners exist only after a target was picked, so there is one here.
+      let target = selectedDisplay?.identityKey
+      // A display that has left cannot be put back, and saying so would blame
+      // the app for an unplug.
+      let notify = !displayGone
       // The mode goes back on every exit path. Its outcome cannot change
       // a completion the user or the cable already decided, so it is not awaited.
-      Task { _ = await mode.restore() }
+      Task {
+        let restored = await mode.restore()
+        if !restored { Self.logRestoreNotAchieved() }
+        settled(!restored && notify, target)
+      }
     }
     finish(.incomplete(reason: reason))
+  }
+
+  /// `.error` and not `.debug`: macOS does not persist debug records, and this
+  /// is the only record the quit route leaves.
+  private static func logRestoreNotAchieved() {
+    log.error(
+      "checkup run ended early and the display is not on the resolution and refresh rate it started in"
+    )
   }
 
   private func finish(_ completion: CheckupCompletion) {

--- a/Candela/Checkup/CheckupFlowView.swift
+++ b/Candela/Checkup/CheckupFlowView.swift
@@ -21,8 +21,38 @@ struct CheckupFlowView: View {
       chrome
     }
     .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: model.page)
+    // Default priority: a page change must not cut off a sentence VoiceOver is
+    // part-way through, and the listener cannot ask for it back. `onChange`
+    // skips the first render, which keeps the opening page silent while the
+    // window becoming key speaks its own title.
+    .onChange(of: model.page) { _, page in
+      GuidedFlowAnnouncement.queued(CheckupCopy.pageAnnouncement(page))
+    }
+    // High priority: a deadline is the one case where interrupting is the
+    // point. Posted from here, not the field window, because this view is what
+    // stays alive through the showing.
+    .onChange(of: model.secondsRemaining) { _, seconds in
+      guard let kind = countdownFieldKind,
+        let text = CheckupCopy.secondsLeftAnnouncement(seconds: seconds, cap: kind.capSeconds)
+      else { return }
+      GuidedFlowAnnouncement.interrupting(text)
+    }
     .frame(minWidth: 720, minHeight: 560)
     .preferredColorScheme(.dark)
+  }
+
+  /// The field the seconds are counting down from, nil when nothing is on the
+  /// glass. The cap matters: the white field's is 10, so its opening value must
+  /// not be read as the 10-second threshold.
+  private var countdownFieldKind: CheckupFieldKind? {
+    switch model.page {
+    case .fieldShowing(let kind), .fieldConfirmSecondDot(let kind): kind
+    // Written out rather than defaulted: a later page with a field on it would
+    // take the default and count down in silence.
+    case .scenario, .displayPick, .plan, .identity, .capabilities, .nativeMode, .refresh,
+      .witness, .plantDisclosure, .fieldInstruction, .hdr, .summary:
+      nil
+    }
   }
 
   @ViewBuilder

--- a/Candela/Checkup/CheckupLiveEnvironment.swift
+++ b/Candela/Checkup/CheckupLiveEnvironment.swift
@@ -129,6 +129,25 @@ enum CheckupLiveEnvironment {
       writers: writers,
       hdr: hdr)
     let entries = entries(from: sources)
+    // Virtual displays have no brightness controller. Use the online topology
+    // for exclusions only, so these rows never become field or DDC targets.
+    let controlledIDs = Set(sources.map(\.id))
+    let ownedVirtualIDs = model.virtualDisplays.ownedDisplayIDs
+    let uncontrolled = model.mirrorTopology.topology().displays
+      .filter { !controlledIDs.contains($0.id) }
+      .map { display in
+        let mode = CGDisplayCopyDisplayMode(display.id)
+        return Source(
+          id: display.id, identityKey: display.identity.key,
+          name: OverlayWindow.screen(for: display.id)?.localizedName ?? display.name,
+          isBuiltIn: display.isBuiltIn,
+          isVirtual: ownedVirtualIDs.contains(display.id)
+            || VirtualDisplayDetection.isVirtual(display.id) == true,
+          isMirroring: display.isMirrorSlave,
+          capabilities: nil, hasDDCService: false, hdrEngaged: false,
+          pixelWidth: mode?.pixelWidth ?? 0, pixelHeight: mode?.pixelHeight ?? 0,
+          pointHeight: Double(CGDisplayBounds(display.id).height))
+      }
     let capabilities = Dictionary(
       sources.map { ($0.identityKey, $0.capabilities) }, uniquingKeysWith: { first, _ in first })
     let pixels = Dictionary(
@@ -137,7 +156,7 @@ enum CheckupLiveEnvironment {
 
     return CheckupEnvironment(
       displays: entries,
-      excluded: excluded(from: sources),
+      excluded: excluded(from: sources + uncontrolled),
       macOSBuild: ProcessInfo.processInfo.operatingSystemVersionString,
       appBuild: AppInfo.version,
       runners: { [weak model] entry in

--- a/Candela/Checkup/CheckupLiveEnvironment.swift
+++ b/Candela/Checkup/CheckupLiveEnvironment.swift
@@ -36,7 +36,7 @@ enum CheckupLiveEnvironment {
   /// so both drop here rather than at every surface. `isOnlyDisplay` counts what
   /// survives: a display the flow cannot target cannot host the window either.
   static func entries(from sources: [Source]) -> [CheckupDisplayEntry] {
-    let real = sources.filter { !$0.isVirtual && !$0.isMirroring }
+    let real = sources.filter { exclusion(for: $0) == nil }
     return real.map { source in
       CheckupDisplayEntry(
         id: source.id,
@@ -55,6 +55,26 @@ enum CheckupLiveEnvironment {
         pointHeight: source.pointHeight,
         isOnlyDisplay: real.count == 1)
     }
+  }
+
+  /// The complement of `entries(from:)` over the same sources, each row
+  /// carrying why it was dropped.
+  static func excluded(from sources: [Source]) -> [CheckupExcludedDisplay] {
+    sources.compactMap { source in
+      guard let reason = exclusion(for: source) else { return nil }
+      return CheckupExcludedDisplay(
+        id: source.id, name: source.name, pixelWidth: source.pixelWidth,
+        pixelHeight: source.pixelHeight, reason: reason)
+    }
+  }
+
+  /// The one predicate both lists derive from, so no display can be offered and
+  /// excluded at once. Virtual wins a tie: what the thing IS outranks how it is
+  /// wired.
+  private static func exclusion(for source: Source) -> CheckupExcludedDisplay.Reason? {
+    if source.isVirtual { return .virtual }
+    if source.isMirroring { return .mirroring }
+    return nil
   }
 
   /// Reads the live state the plan grades off, BEFORE it grades anything: HDR
@@ -117,6 +137,7 @@ enum CheckupLiveEnvironment {
 
     return CheckupEnvironment(
       displays: entries,
+      excluded: excluded(from: sources),
       macOSBuild: ProcessInfo.processInfo.operatingSystemVersionString,
       appBuild: AppInfo.version,
       runners: { [weak model] entry in

--- a/Candela/Checkup/CheckupPages.swift
+++ b/Candela/Checkup/CheckupPages.swift
@@ -301,6 +301,13 @@ struct CheckupLegPage: View {
             .foregroundStyle(OnboardingStyle.faintColor)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.top, 4)
+          if family == .capabilities || family == .nativeMode {
+            Label(CheckupCopy.modeChangeWarning, systemImage: "exclamationmark.triangle")
+              .font(.callout)
+              .foregroundStyle(OnboardingStyle.bodyColor)
+              .fixedSize(horizontal: false, vertical: true)
+              .padding(.top, 8)
+          }
         }
       }
     } actions: {

--- a/Candela/Checkup/CheckupPages.swift
+++ b/Candela/Checkup/CheckupPages.swift
@@ -193,6 +193,41 @@ struct CheckupDisplayPickPage: View {
           .accessibilityLabel(Text(verbatim: CheckupCopy.displayRowLabel(entry)))
           .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         }
+        if !model.excludedDisplays.isEmpty {
+          Text(CheckupCopy.excludedTitle)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(OnboardingStyle.bodyColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 8)
+            // Each row repeats this line, since a row read alone has to say it
+            // cannot be chosen. A header is skippable, so the repeat is free.
+            .accessibilityAddTraits(.isHeader)
+        }
+        ForEach(model.excludedDisplays) { display in
+          // Never a `Button`: a row that cannot be chosen must not publish
+          // `AXPress`.
+          OnboardingCard {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(verbatim: display.name)  // a display's name, never a lookup key
+                .font(.callout.weight(.medium))
+                .foregroundStyle(OnboardingStyle.bodyColor)
+              Text(
+                verbatim: CheckupCopy.pixelSizeLine(
+                  width: display.pixelWidth, height: display.pixelHeight)
+              )
+              .font(.caption)
+              .foregroundStyle(OnboardingStyle.faintColor)
+              Text(CheckupCopy.excludedReason(display.reason))
+                .font(.caption)
+                .foregroundStyle(OnboardingStyle.faintColor)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+          // Safe to combine here: the rule against combining is about buttons,
+          // whose `AXPress` and `AXFocused` it eats.
+          .accessibilityElement(children: .combine)
+          .accessibilityLabel(Text(verbatim: CheckupCopy.excludedRowLabel(display)))
+        }
       }
     } actions: {
       CheckupAdvanceButton(

--- a/Candela/Checkup/CheckupWindowController.swift
+++ b/Candela/Checkup/CheckupWindowController.swift
@@ -11,6 +11,9 @@ import SwiftUI
 final class CheckupWindowController: NSObject, NSWindowDelegate {
   private let environment: () async -> CheckupEnvironment
   private let onSaved: (CheckupReportEnvelope) -> Void
+  /// Where a failed restore is published. The run's window is closing by the
+  /// time the restore answers.
+  private let actions: SettingsActions
   private var window: NSWindow?
   private var model: CheckupFlowModel?
   /// Held while an environment is being built, so a second click during the
@@ -23,10 +26,12 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
   init(
     environment: @escaping () async -> CheckupEnvironment,
     onSaved: @escaping (CheckupReportEnvelope) -> Void,
+    actions: SettingsActions,
     care: (any CheckupCareHolding)? = nil
   ) {
     self.environment = environment
     self.onSaved = onSaved
+    self.actions = actions
     // The window takes the hold, not this controller: `windowWillClose` hides
     // it directly, so a hold owned a layer up would outlive a close mid-field.
     self.fieldWindow = CheckupFieldWindow(care: care)
@@ -79,6 +84,7 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
     // `windowShouldClose` does not abandon on the summary, so the saved report
     // is untouched.
     model.onClose = { [weak window] in window?.performClose(nil) }
+    Self.publishRestoreOutcome(of: model, to: actions)
     self.model = model
 
     fieldWindow.onAnswer = { [weak self] answer in
@@ -90,6 +96,10 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
       // asking a new question the moment this returns.
       self.syncFieldWindow()
     }
+
+    // Ends the showing without answering it, so nothing is recorded about the
+    // field.
+    fieldWindow.onEscape = { [weak self] in self?.model?.escapeShowing() }
 
     window.contentView = NSHostingView(
       rootView: CheckupFlowView(
@@ -180,11 +190,31 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
     return true
   }
 
+  /// The flow model is released with its window, so a failed restore publishes
+  /// on an object that outlives both and the Checkup pane renders it. Named
+  /// rather than inline so the suite drives the wiring the app installs.
+  static func publishRestoreOutcome(of model: CheckupFlowModel, to actions: SettingsActions) {
+    // A new run supersedes whatever the last one left standing. The token comes
+    // back from the same call, so a restore still in flight from an earlier run
+    // cannot publish over the run that followed it.
+    let generation = actions.beginCheckupRun()
+    model.onRestoreSettled = { needsNotice, identityKey in
+      guard needsNotice, let identityKey else { return }
+      actions.publishCheckupRestoreFailure(
+        CheckupRestoreNotice(text: CheckupPaneCopy.restoreNotAchieved, identityKey: identityKey),
+        generation: generation)
+    }
+  }
+
   /// The quit-time `windowShouldClose`: `NSApplication.terminate` closes no
   /// windows, so a run in flight at quit would otherwise save no report and
   /// book no field time.
   func abandonForTermination() {
     if model?.page != .summary {
+      // A notice published while quitting would greet the next launch
+      // describing a run nobody remembers. The `.error` log line is the whole
+      // record this route leaves.
+      model?.onRestoreSettled = { _, _ in }
       model?.abandon(reason: CheckupCopy.closedReason)
     }
     // `abandon` hides through the presenter; this covers a run that already
@@ -199,6 +229,7 @@ final class CheckupWindowController: NSObject, NSWindowDelegate {
     // field is left on a panel with no window left to take it down.
     fieldWindow.hide()
     fieldWindow.onAnswer = nil
+    fieldWindow.onEscape = nil
     model = nil
   }
 

--- a/Candela/Onboarding/OnboardingAnnouncements.swift
+++ b/Candela/Onboarding/OnboardingAnnouncements.swift
@@ -1,0 +1,99 @@
+import AppKit
+import SwiftUI
+
+/// The two priorities the guided flows post announcements at, so a call site
+/// only picks one and says why. Lives here because the checkup flow already
+/// draws with `OnboardingHeading` and `OnboardingStyle`.
+@MainActor
+enum GuidedFlowAnnouncement {
+  /// Default priority: VoiceOver finishes what it is saying first. Cutting a
+  /// sentence off loses it, and the listener cannot ask for it back.
+  static func queued(_ text: String) {
+    AccessibilityNotification.Announcement(text).post()
+  }
+
+  /// High priority, so it cuts in: a deadline heard after it expired is not a
+  /// deadline. The AppKit route because `AccessibilityNotification.Announcement`
+  /// carries no priority argument.
+  static func interrupting(_ text: String) {
+    NSAccessibility.post(
+      element: NSApp as Any,
+      notification: .announcementRequested,
+      userInfo: [
+        .announcement: text,
+        .priority: NSAccessibilityPriorityLevel.high.rawValue,
+      ]
+    )
+  }
+}
+
+/// When a countdown speaks. Shared by both flows so the two cannot settle on
+/// different cadences.
+enum AnnouncementThresholds {
+  /// 10 and 3 seconds, and never the value the count OPENED on: the white field
+  /// caps at 10, so an unguarded threshold would announce "10 seconds left" at
+  /// the instant the count starts.
+  static func speaks(at seconds: Int, cap: Int) -> Bool {
+    (seconds == 10 || seconds == 3) && seconds < cap
+  }
+}
+
+/// What VoiceOver says when the setup flow lands on a new page.
+///
+/// No arm contains the heading of the page it announces: the cursor lands on
+/// that heading a moment later. A test pairs every page with the title its view
+/// draws and holds this.
+enum OnboardingAnnouncements {
+  /// `displayName` tells consecutive size pages apart. The caller passes a name
+  /// only when it has one, never `OnboardingPage.id` or a persistence key.
+  static func pageAnnouncement(
+    _ page: OnboardingPage, step: Int, of total: Int, displayName: String? = nil
+  ) -> String {
+    "\(purpose(page, displayName: displayName)) Step \(step) of \(total)."
+  }
+
+  private static func purpose(_ page: OnboardingPage, displayName: String?) -> String {
+    switch page {
+    case .welcome:
+      "The start of setup: what \(AppInfo.productName) does for an external display, and "
+        + "what the next few pages ask."
+    case .accessibility:
+      "Accessibility access, so the brightness, volume and mute keys reach \(AppInfo.productName)."
+    case .detection:
+      // Spoken on arrival, while the scan still runs, and never re-announced
+      // when the heading flips to a count. So: no past tense, no number.
+      "The displays attached to this Mac, with their names, as \(AppInfo.productName) finds them."
+    case .noDisplays:
+      "No external display is attached yet."
+    case .size:
+      "The size \(AppInfo.productName) recommends for \(displayName ?? "this display"), and "
+        + "the other sizes it can use."
+    case .oledSelect:
+      "Which of these displays are OLED."
+    case .oledCare:
+      "Burn-in protection for the displays marked as OLED."
+    case .finish:
+      "Setup is done, with a summary of what changed."
+    }
+  }
+}
+
+/// The title each setup page draws, shared with the announcement test. A
+/// heading re-typed there would let a retitled page pass with its old words
+/// still being checked.
+enum OnboardingTitles {
+  static let welcome = "Welcome to \(AppInfo.productName)"
+  static let accessibility = "Your keyboard, everywhere"
+  /// The detection page draws two titles: this one while the scan runs, the
+  /// count below once the cards resolve.
+  static let detectionScanning = "Looking at your displays"
+  static func detectionFound(count: Int) -> String {
+    count == 1 ? "Found your display" : "Found \(count) displays"
+  }
+  static let noDisplays = "No external displays yet"
+  /// Several size pages can follow each other, so this one names its display.
+  static func size(displayName: String) -> String { "A better size for \(displayName)" }
+  static let oledSelect = "Any OLEDs here?"
+  static let oledCare = "Protect your OLED"
+  static let finish = "You're all set"
+}

--- a/Candela/Onboarding/OnboardingDetectionPage.swift
+++ b/Candela/Onboarding/OnboardingDetectionPage.swift
@@ -7,6 +7,10 @@ struct OnboardingDetectionPage: View {
   @Bindable var model: OnboardingFlowModel
   let accent: Color
 
+  /// The grid's columns share this cap, so a row of one or two draws exactly
+  /// where it always has.
+  private static let cardMaxWidth: CGFloat = 300
+
   /// 0 = sweeping, then one step per display outline, then cards.
   @State private var phase = 0
   @State private var sweep: CGFloat = -0.2
@@ -20,30 +24,32 @@ struct OnboardingDetectionPage: View {
   private var cardsShown: Bool { phase > displays.count }
 
   var body: some View {
-    VStack(spacing: 0) {
-      Spacer(minLength: 18)
-      OnboardingHeading(
-        title: cardsShown ? foundTitle : "Looking at your displays",
-        subtitle: cardsShown
-          ? "Names can be edited here. Anything else that looks wrong can be adjusted later in Settings."
-          : nil
-      )
-      .animation(.easeInOut(duration: 0.4), value: cardsShown)
-      Spacer(minLength: 16)
-      glyphRow
-      Spacer(minLength: 16)
-      if cardsShown {
-        cards
-          .transition(.opacity.combined(with: .move(edge: .bottom)))
+    OnboardingScrollColumn {
+      VStack(spacing: 0) {
+        Spacer(minLength: 18)
+        OnboardingHeading(
+          title: cardsShown ? foundTitle : OnboardingTitles.detectionScanning,
+          subtitle: cardsShown
+            ? "Names can be edited here. Anything else that looks wrong can be adjusted later in Settings."
+            : nil
+        )
+        .animation(.easeInOut(duration: 0.4), value: cardsShown)
         Spacer(minLength: 16)
-        VStack(spacing: 10) {
-          Button("Continue") { model.advance() }
-            .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))
-            .keyboardShortcut(.defaultAction)
-          OnboardingSkipLink(model: model)
+        glyphRow
+        Spacer(minLength: 16)
+        if cardsShown {
+          cards
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+          Spacer(minLength: 16)
+          VStack(spacing: 10) {
+            Button("Continue") { model.advance() }
+              .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))
+              .keyboardShortcut(.defaultAction)
+            OnboardingSkipLink(model: model)
+          }
         }
+        Spacer(minLength: 22)
       }
-      Spacer(minLength: 22)
     }
     .contentShape(Rectangle())
     .onTapGesture { skipScan() }
@@ -52,38 +58,43 @@ struct OnboardingDetectionPage: View {
   }
 
   private var foundTitle: String {
-    displays.count == 1 ? "Found your display" : "Found \(displays.count) displays"
+    OnboardingTitles.detectionFound(count: displays.count)
   }
 
+  /// The row is full width so the sweep band travels all the way across, but the
+  /// panels fit the narrower content width, keeping the outermost one off the
+  /// window edge.
   private var glyphRow: some View {
-    ZStack {
-      HStack(alignment: .bottom, spacing: 34) {
-        ForEach(Array(displays.enumerated()), id: \.element.id) { pair in
-          DisplayGlyph(
-            aspect: pair.element.drawnAspect,
-            accent: accent,
-            trace: phase > pair.offset ? 1 : 0,
-            lit: cardsShown ? 1 : 0.35
-          )
-          .frame(height: cardsShown ? 110 : 150)
-          .frame(width: glyphWidth(for: pair.element, tall: !cardsShown))
+    GeometryReader { proxy in
+      let metrics = OnboardingCardGrid.glyphMetrics(
+        aspects: displays.map { CGFloat($0.drawnAspect) },
+        availableWidth: proxy.size.width - OnboardingCardGrid.rowInset * 2,
+        baseHeight: cardsShown ? 110 : 150)
+      ZStack {
+        HStack(alignment: .bottom, spacing: metrics.spacing) {
+          ForEach(Array(displays.enumerated()), id: \.element.id) { pair in
+            DisplayGlyph(
+              aspect: pair.element.drawnAspect,
+              accent: accent,
+              trace: phase > pair.offset ? 1 : 0,
+              lit: cardsShown ? 1 : 0.35
+            )
+            .frame(height: metrics.height)
+            .frame(
+              width: OnboardingCardGrid.glyphWidth(
+                aspect: CGFloat(pair.element.drawnAspect), height: metrics.height))
+          }
+        }
+        .animation(.spring(duration: 0.7), value: cardsShown)
+        .animation(.easeInOut(duration: 0.55), value: phase)
+        if !cardsShown, !reduceMotion {
+          sweepBand
         }
       }
-      .animation(.spring(duration: 0.7), value: cardsShown)
-      .animation(.easeInOut(duration: 0.55), value: phase)
-      if !cardsShown, !reduceMotion {
-        sweepBand
-      }
+      .frame(width: proxy.size.width, height: proxy.size.height)
     }
-    .frame(maxWidth: .infinity)
     .frame(height: cardsShown ? 120 : 170)
     .clipped()
-  }
-
-  private func glyphWidth(for display: OnboardingDisplayEntry, tall: Bool) -> CGFloat {
-    let height: CGFloat = tall ? 150 : 110
-    let faceHeight = height * 0.7
-    return max(70, faceHeight * display.drawnAspect + 20)
   }
 
   /// The traveling light pass over the dark rig.
@@ -102,12 +113,15 @@ struct OnboardingDetectionPage: View {
   }
 
   private var cards: some View {
-    HStack(alignment: .top, spacing: 14) {
+    LazyVGrid(
+      columns: OnboardingCardGrid.gridColumns(for: displays.count, maxCardWidth: Self.cardMaxWidth),
+      spacing: OnboardingCardGrid.cardSpacing
+    ) {
       ForEach(displays) { display in
         card(for: display)
       }
     }
-    .padding(.horizontal, 30)
+    .padding(.horizontal, OnboardingCardGrid.rowInset)
   }
 
   private func card(for display: OnboardingDisplayEntry) -> some View {
@@ -128,7 +142,7 @@ struct OnboardingDetectionPage: View {
         factRow(symbol: "slider.horizontal.3", text: controlLine(for: display))
       }
     }
-    .frame(maxWidth: 300)
+    .frame(maxWidth: Self.cardMaxWidth)
   }
 
   private func factRow(symbol: String, text: String) -> some View {

--- a/Candela/Onboarding/OnboardingFixtures.swift
+++ b/Candela/Onboarding/OnboardingFixtures.swift
@@ -4,6 +4,10 @@
   /// The real rig as a committed snapshot, so the mock flow is clickable end to
   /// end with no pref writes and no display changes. Update it when the
   /// rig changes, or the mock stops matching what a run actually shows.
+  ///
+  /// The wider rigs below are stand-ins, not snapshots: no desk here has three
+  /// or four externals, and the per-display pages need that count from
+  /// somewhere.
   enum OnboardingFixtures {
     static var rig: OnboardingEnvironment {
       OnboardingEnvironment(
@@ -57,5 +61,53 @@
         ]
       )
     }
+
+    /// Three externals: the card row still fits across, and the page is the
+    /// part that outgrows the window.
+    static var threeExternals: OnboardingEnvironment {
+      var environment = rig
+      environment.displays.append(sixteenByNine)
+      return environment
+    }
+
+    /// Four cards, which wrap two by two, and the widest glyph row the flow can
+    /// be asked to draw.
+    static var fourExternals: OnboardingEnvironment {
+      var environment = threeExternals
+      environment.displays.append(superUltrawide)
+      return environment
+    }
+
+    private static let sixteenByNine = OnboardingDisplayEntry(
+      persistenceKey: "fixture-16x9",
+      name: "Test Panel 27",
+      productName: "Test Panel 27",
+      nativePixelWidth: 2560,
+      nativePixelHeight: 1440,
+      rotationDegrees: 0,
+      diagonalInches: 27,
+      currentLooksLikeWidth: 2560,
+      currentLooksLikeHeight: 1440,
+      refreshHz: 144,
+      volume: .works,
+      sizeSuggestion: nil,
+      enrolledInCare: false
+    )
+
+    private static let superUltrawide = OnboardingDisplayEntry(
+      persistenceKey: "fixture-superwide",
+      name: "Test Panel 49",
+      productName: "Test Panel 49",
+      nativePixelWidth: 5120,
+      nativePixelHeight: 1440,
+      rotationDegrees: 0,
+      diagonalInches: 49,
+      currentLooksLikeWidth: 5120,
+      currentLooksLikeHeight: 1440,
+      refreshHz: 120,
+      volume: .unknown,
+      sizeSuggestion: nil,
+      enrolledInCare: false
+    )
   }
 #endif

--- a/Candela/Onboarding/OnboardingFlowModel.swift
+++ b/Candela/Onboarding/OnboardingFlowModel.swift
@@ -230,6 +230,12 @@ final class OnboardingFlowModel {
     installFixtureSizeApplier()
   }
 
+  /// False until the flow first moves off the page it opened on. The welcome
+  /// heading gives up its VoiceOver focus landing only then: on the opening
+  /// frame the window becoming key is already speaking its own title. Coming
+  /// back to welcome later lands like any other page.
+  private(set) var hasNavigated = false
+
   var currentPage: OnboardingPage { pages[min(index, pages.count - 1)] }
   var canGoBack: Bool { index > 0 }
   var isLastPage: Bool { index >= pages.count - 1 }
@@ -262,6 +268,7 @@ final class OnboardingFlowModel {
       onClose()
     } else {
       index += 1
+      hasNavigated = true
       resetApplyState()
     }
   }
@@ -270,6 +277,7 @@ final class OnboardingFlowModel {
     guard canGoBack else { return }
     if case .counting = applyState { revertSize() }
     index -= 1
+    hasNavigated = true
     resetApplyState()
   }
 

--- a/Candela/Onboarding/OnboardingFlowView.swift
+++ b/Candela/Onboarding/OnboardingFlowView.swift
@@ -20,8 +20,28 @@ struct OnboardingFlowView: View {
       chrome
     }
     .animation(reduceMotion ? .easeInOut(duration: 0.3) : .spring(duration: 0.55), value: model.currentPage)
+    // Default priority: a page change must not cut off a sentence VoiceOver is
+    // part-way through, and the listener cannot ask for it back. `onChange`
+    // skips the first render, which keeps the opening page silent while the
+    // window becoming key speaks its own title.
+    .onChange(of: model.currentPage) { _, page in
+      GuidedFlowAnnouncement.queued(
+        OnboardingAnnouncements.pageAnnouncement(
+          page, step: model.index + 1, of: model.pages.count,
+          displayName: sizePageDisplayName(page)))
+    }
     .frame(minWidth: 760, minHeight: 560)
     .preferredColorScheme(.dark)
+  }
+
+  /// Nil for every page but a size page, and for a size page whose display has
+  /// gone: `displayName(forKey:)` falls back to the key itself, and a key is
+  /// storage, never something to read out.
+  private func sizePageDisplayName(_ page: OnboardingPage) -> String? {
+    guard case let .size(displayKey) = page, model.display(forKey: displayKey) != nil else {
+      return nil
+    }
+    return model.displayName(forKey: displayKey)
   }
 
   private var pageTransition: AnyTransition {

--- a/Candela/Onboarding/OnboardingOledPages.swift
+++ b/Candela/Onboarding/OnboardingOledPages.swift
@@ -9,36 +9,46 @@ struct OnboardingOledSelectPage: View {
   @Bindable var model: OnboardingFlowModel
   let accent: Color
 
+  /// The grid's columns share this cap, so a row of one or two draws exactly
+  /// where it always has.
+  private static let cardMaxWidth: CGFloat = 280
+
   var body: some View {
-    VStack(spacing: 0) {
-      Spacer(minLength: 22)
-      OnboardingHeading(
-        title: "Any OLEDs here?",
-        subtitle: "OLED displays age where bright, static content sits. \(AppInfo.productName) can protect them from burn-in."
-      )
-      Spacer(minLength: 18)
-      HStack(alignment: .top, spacing: 14) {
-        ForEach(model.environment.displays) { display in
-          selectCard(for: display)
+    OnboardingScrollColumn {
+      VStack(spacing: 0) {
+        Spacer(minLength: 22)
+        OnboardingHeading(
+          title: OnboardingTitles.oledSelect,
+          subtitle: "OLED displays age where bright, static content sits. \(AppInfo.productName) can protect them from burn-in."
+        )
+        Spacer(minLength: 18)
+        LazyVGrid(
+          columns: OnboardingCardGrid.gridColumns(
+            for: model.environment.displays.count, maxCardWidth: Self.cardMaxWidth),
+          spacing: OnboardingCardGrid.cardSpacing
+        ) {
+          ForEach(model.environment.displays) { display in
+            selectCard(for: display)
+          }
         }
-      }
-      .padding(.horizontal, 30)
-      if hasNameGuess {
-        Text("Candela's OLED detection can make mistakes. Deselect a display if it got one wrong.")
-          .font(.caption)
-          .foregroundStyle(OnboardingStyle.faintColor)
-          .padding(.top, 12)
-      }
-      Spacer(minLength: 20)
-      VStack(spacing: 10) {
-        Button(model.designatedOleds.isEmpty ? "None of These Are OLEDs" : "Continue") {
-          model.advance()
+        .padding(.horizontal, OnboardingCardGrid.rowInset)
+        if hasNameGuess {
+          Text("Candela's OLED detection can make mistakes. Deselect a display if it got one wrong.")
+            .font(.caption)
+            .foregroundStyle(OnboardingStyle.faintColor)
+            .padding(.top, 12)
         }
-        .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))
-        .keyboardShortcut(.defaultAction)
-        OnboardingSkipLink(model: model)
+        Spacer(minLength: 20)
+        VStack(spacing: 10) {
+          Button(model.designatedOleds.isEmpty ? "None of These Are OLEDs" : "Continue") {
+            model.advance()
+          }
+          .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))
+          .keyboardShortcut(.defaultAction)
+          OnboardingSkipLink(model: model)
+        }
+        Spacer(minLength: 24)
       }
-      Spacer(minLength: 24)
     }
   }
 
@@ -88,7 +98,7 @@ struct OnboardingOledSelectPage: View {
           }
         }
       }
-      .frame(maxWidth: 280)
+      .frame(maxWidth: Self.cardMaxWidth)
     }
     .buttonStyle(.plain)
     .accessibilityLabel(
@@ -111,7 +121,7 @@ struct OnboardingOledCarePage: View {
     VStack(spacing: 0) {
       Spacer(minLength: 18)
       OnboardingHeading(
-        title: "Protect your OLED",
+        title: OnboardingTitles.oledCare,
         subtitle: "When you step away, \(AppInfo.productName) eases brightness down and shields the areas that never change, then puts everything back the moment you return."
       )
       Spacer(minLength: 14)

--- a/Candela/Onboarding/OnboardingPagesCore.swift
+++ b/Candela/Onboarding/OnboardingPagesCore.swift
@@ -19,8 +19,12 @@ struct OnboardingWelcomePage: View {
         .opacity(appeared ? 1 : 0)
       Spacer(minLength: 18)
       OnboardingHeading(
-        title: "Welcome to \(AppInfo.productName)",
-        subtitle: "\(AppInfo.productName) looks after your external displays: health, burn-in protection, and the everyday controls, done carefully."
+        title: OnboardingTitles.welcome,
+        subtitle: "\(AppInfo.productName) looks after your external displays: health, burn-in protection, and the everyday controls, done carefully.",
+        // Only the flow's opening frame gives the landing up, because the
+        // window becoming key is speaking its own title there. Navigating back
+        // to welcome lands on the heading like every other page.
+        landsAccessibilityFocus: model.hasNavigated
       )
       .opacity(appeared ? 1 : 0)
       .offset(y: appeared ? 0 : 10)
@@ -62,7 +66,7 @@ struct OnboardingAccessibilityPage: View {
       VStack(spacing: 18) {
         keycaps
         OnboardingHeading(
-          title: "Your keyboard, everywhere",
+          title: OnboardingTitles.accessibility,
           subtitle: "macOS delivers the brightness, volume and mute keys through Accessibility. \(AppInfo.productName) needs that access to see those key presses, and it reads nothing else."
         )
       }
@@ -155,7 +159,7 @@ struct OnboardingNoDisplaysPage: View {
         .frame(width: 240, height: 170)
       Spacer(minLength: 20)
       OnboardingHeading(
-        title: "No external displays yet",
+        title: OnboardingTitles.noDisplays,
         subtitle: "Plug one in anytime. \(AppInfo.productName) picks it up automatically and offers the right size for it in Settings."
       )
       Spacer(minLength: 24)
@@ -187,7 +191,7 @@ struct OnboardingFinishPage: View {
       VStack(spacing: 14) {
         AnimatedCheckmark(accent: accent)
           .frame(width: 68, height: 68)
-        OnboardingHeading(title: "You're all set")
+        OnboardingHeading(title: OnboardingTitles.finish)
       }
       Spacer(minLength: 18)
       VStack(alignment: .leading, spacing: 10) {

--- a/Candela/Onboarding/OnboardingSizePage.swift
+++ b/Candela/Onboarding/OnboardingSizePage.swift
@@ -1,3 +1,4 @@
+import CandelaKit
 import SwiftUI
 
 /// The recommended size for one display. The copy rule: renders at a higher
@@ -11,6 +12,10 @@ struct OnboardingSizePage: View {
 
   @State private var showsAlternatives = false
   @State private var showsFullList = false
+  /// The bar is a timed decision, so it lands the cursor on its answer the way
+  /// the settings mode banner does. Everywhere else the heading takes it.
+  @AccessibilityFocusState private var keepFocused: Bool
+  @AccessibilityFocusState private var revertFocused: Bool
 
   private var display: OnboardingDisplayEntry? { model.display(forKey: displayKey) }
 
@@ -29,7 +34,7 @@ struct OnboardingSizePage: View {
     VStack(spacing: 0) {
       Spacer(minLength: 20)
       OnboardingHeading(
-        title: "A better size for \(model.displayName(forKey: displayKey))",
+        title: OnboardingTitles.size(displayName: model.displayName(forKey: displayKey)),
         subtitle: "Everything stays sharp: the display renders at a higher resolution and scales the result. Text and controls get the size this display was made for."
       )
       Spacer(minLength: 14)
@@ -61,6 +66,12 @@ struct OnboardingSizePage: View {
     // Keyed to the seam state so ticks, the choices/countdown swap and the
     // revert's return all animate; a plain VStack animates both directions.
     .animation(.spring(duration: 0.45), value: model.applyState)
+    // The tick this page already re-renders on, never a timer of its own. The
+    // applier publishes the seconds and the achieved size in one update, so
+    // both halves are observed together.
+    .onChange(of: countdownTick) { previous, current in
+      speakCountdown(divergedThisTick: previous.achieved == nil && current.achieved != nil)
+    }
     .onDisappear {
       // An unanswered countdown must not outlive its page (the commit-on-advance
       // rule keeps only
@@ -219,6 +230,53 @@ struct OnboardingSizePage: View {
       : "Reverting to the previous size in \(seconds)s"
   }
 
+  /// Returns `countdownCaption` itself, so a listener and a reader get the same
+  /// sentence. Nil where the cadence rule says nothing.
+  ///
+  /// Also nil on `divergedThisTick`: the seconds and a divergence arrive in one
+  /// update, and this announcement interrupts, so it would cut off the recovery
+  /// text that is the only route back out of a diverged commit. The deadline
+  /// stays on the bar as a caption.
+  static func countdownAnnouncement(
+    seconds: Int, canKeep: Bool, cap: Int, divergedThisTick: Bool = false
+  ) -> String? {
+    guard !divergedThisTick else { return nil }
+    guard AnnouncementThresholds.speaks(at: seconds, cap: cap) else { return nil }
+    return countdownCaption(seconds: seconds, canKeep: canKeep)
+  }
+
+  /// The bar's own title when a commit diverged. Drawn and spoken from one
+  /// place: a listener whose cursor is on Revert hears it only here.
+  static let divergedTitle = "Size preview could not be verified"
+
+  /// The achieved size said out loud. Not `achievedCaption`, which is display
+  /// text down to the times sign and shortened Hz; both are read inconsistently.
+  static func spokenAchievedSize(_ achieved: OnboardingAchievedSize) -> String {
+    switch achieved {
+    case let .size(width, height, refreshHz):
+      "The display is showing "
+        + ModeSpeech.spoken(logicalWidth: width, logicalHeight: height, refreshHz: refreshHz) + "."
+    case .unreadable:
+      DisplayModeCopy.unreadableAchievedGeometry(dialect: .size)
+    }
+  }
+
+  /// What happened, the way out, and what the display is showing instead. The
+  /// cursor is on Revert, so the sentences above the buttons reach a listener
+  /// nowhere else.
+  static func divergenceAnnouncement(_ achieved: OnboardingAchievedSize) -> String {
+    "\(divergedTitle). \(DisplayModeCopy.recoveryInstruction(dialect: .size)) "
+      + spokenAchievedSize(achieved)
+  }
+
+  /// The deadline the caption gives a reader, plus the recovery text when the
+  /// commit had already diverged before the bar appeared.
+  static func barAnnouncement(seconds: Int, achieved: OnboardingAchievedSize?) -> String {
+    let caption = countdownCaption(seconds: seconds, canKeep: achieved == nil)
+    guard let achieved else { return caption }
+    return "\(divergenceAnnouncement(achieved)) \(caption)"
+  }
+
   private func countdownBar(seconds: Int) -> some View {
     VStack(spacing: 12) {
       Text(verbatim: Self.countdownCaption(
@@ -228,7 +286,7 @@ struct OnboardingSizePage: View {
         .monospacedDigit()
         .contentTransition(.numericText())
       if let achieved = model.pendingAchievedSize(forKey: displayKey) {
-        Text("Size preview could not be verified")
+        Text(verbatim: Self.divergedTitle)
           .font(.callout.weight(.semibold))
           .foregroundStyle(OnboardingStyle.bodyColor)
         Text(verbatim: DisplayModeCopy.recoveryInstruction(dialect: .size))
@@ -247,11 +305,61 @@ struct OnboardingSizePage: View {
           Button("Keep") { model.keepSize() }
             .buttonStyle(OnboardingPrimaryButtonStyle(accent: accent))
             .keyboardShortcut(.defaultAction)
+            .accessibilityFocused($keepFocused)
         }
         Button("Revert") { model.revertSize() }
           .buttonStyle(OnboardingSecondaryButtonStyle())
           .keyboardShortcut(.cancelAction)
+          .accessibilityFocused($revertFocused)
       }
     }
+    // Revert takes the cursor when Keep is gone: a recovery control is never the
+    // one the cursor cannot find. The caption goes with the landing, since a
+    // deadline nobody speaks is a deadline nobody hears.
+    .onAppear {
+      landFocus()
+      GuidedFlowAnnouncement.queued(
+        Self.barAnnouncement(
+          seconds: seconds, achieved: model.pendingAchievedSize(forKey: displayKey)))
+    }
+    // Divergence can land after the bar is up, taking Keep out from under the
+    // cursor. The recovery text moves with it, since those sentences are on
+    // screen only.
+    .onChange(of: model.pendingAchievedSize(forKey: displayKey)) { _, achieved in
+      landFocus()
+      guard let achieved else { return }
+      GuidedFlowAnnouncement.queued(Self.divergenceAnnouncement(achieved))
+    }
+  }
+
+  /// Observed as a pair, so the divergence and the seconds it arrived with
+  /// cannot be read from different updates.
+  private struct CountdownTick: Equatable {
+    var state: OnboardingApplyState
+    var achieved: OnboardingAchievedSize?
+  }
+
+  private var countdownTick: CountdownTick {
+    CountdownTick(
+      state: model.applyState, achieved: model.pendingAchievedSize(forKey: displayKey))
+  }
+
+  private func landFocus() {
+    let canKeep = model.pendingAchievedSize(forKey: displayKey) == nil
+    keepFocused = canKeep
+    revertFocused = !canKeep
+  }
+
+  /// High priority, so it interrupts: a deadline heard after it expired is not
+  /// a deadline.
+  private func speakCountdown(divergedThisTick: Bool) {
+    guard let seconds = model.applyCountdownSecondsRemaining(forKey: displayKey) else { return }
+    guard let text = Self.countdownAnnouncement(
+      seconds: seconds,
+      canKeep: model.pendingAchievedSize(forKey: displayKey) == nil,
+      cap: model.applierCountdownSeconds,
+      divergedThisTick: divergedThisTick
+    ) else { return }
+    GuidedFlowAnnouncement.interrupting(text)
   }
 }

--- a/Candela/Onboarding/OnboardingStyle.swift
+++ b/Candela/Onboarding/OnboardingStyle.swift
@@ -134,6 +134,128 @@ struct OnboardingCard<Content: View>: View {
   }
 }
 
+/// Layout arithmetic for the two pages that draw one item per display, derived
+/// from the count and the available width so it can be checked without laying
+/// a view out.
+enum OnboardingCardGrid {
+  static let cardSpacing: CGFloat = 14
+  static let rowInset: CGFloat = 30
+
+  static let baseGlyphSpacing: CGFloat = 34
+  static let minimumGlyphSpacing: CGFloat = 12
+  static let minimumGlyphHeight: CGFloat = 60
+
+  /// `DisplayGlyph` gives the stand 12% of its height and the reflection 18%,
+  /// leaving 70% for the face, which is the part the aspect ratio widens.
+  private static let faceHeightFraction: CGFloat = 0.7
+  /// Room either side of the face, and the width a portrait panel never goes
+  /// under.
+  private static let glyphPadding: CGFloat = 20
+  private static let minimumGlyphWidth: CGFloat = 70
+
+  /// One row up to three cards. A fourth wraps two by two rather than stranding
+  /// one, and anything wider still wraps at three, the widest row that stays
+  /// readable at this window width.
+  static func columns(for count: Int) -> Int {
+    guard count > 3 else { return max(1, count) }
+    return count == 4 ? 2 : 3
+  }
+
+  static func gridColumns(for count: Int, maxCardWidth: CGFloat) -> [GridItem] {
+    Array(
+      repeating: GridItem(.flexible(maximum: maxCardWidth), spacing: cardSpacing, alignment: .top),
+      count: columns(for: count))
+  }
+
+  static func glyphWidth(aspect: CGFloat, height: CGFloat) -> CGFloat {
+    max(minimumGlyphWidth, height * faceHeightFraction * aspect + glyphPadding)
+  }
+
+  static func totalWidth(height: CGFloat, spacing: CGFloat, aspects: [CGFloat]) -> CGFloat {
+    guard !aspects.isEmpty else { return 0 }
+    let glyphs = aspects.reduce(0) { $0 + glyphWidth(aspect: $1, height: height) }
+    return glyphs + spacing * CGFloat(aspects.count - 1)
+  }
+
+  /// The height and spacing the glyph row draws at so the whole rig fits the
+  /// width it has. Spacing gives way first, then the panels shrink.
+  ///
+  /// The row's clip is there to contain the sweep band, and this keeps it from
+  /// doubling as the thing hiding a panel: at a fixed height four ultrawides ask
+  /// for about 918 pt inside a 760 pt window, and the two outermost were being
+  /// cut with nothing on screen saying so.
+  ///
+  /// A rig wide enough to overflow both base heights fits the scan and the cards
+  /// states to the same height, so the row loses its scan-to-cards size change.
+  /// Four ultrawide panels already do it.
+  static func glyphMetrics(aspects: [CGFloat], availableWidth: CGFloat, baseHeight: CGFloat)
+    -> (height: CGFloat, spacing: CGFloat)
+  {
+    guard !aspects.isEmpty, availableWidth > 0 else { return (baseHeight, baseGlyphSpacing) }
+    if totalWidth(height: baseHeight, spacing: baseGlyphSpacing, aspects: aspects)
+      <= availableWidth
+    {
+      return (baseHeight, baseGlyphSpacing)
+    }
+    // Crowding the panels costs less than shrinking them, so spacing is spent
+    // first and only what it cannot cover comes off the height.
+    let gaps = CGFloat(aspects.count - 1)
+    if gaps > 0 {
+      let closer = (availableWidth - totalWidth(height: baseHeight, spacing: 0, aspects: aspects))
+        / gaps
+      if closer >= minimumGlyphSpacing {
+        return (baseHeight, closer.rounded(.down))
+      }
+    }
+    // A narrower panel is never wider, so the fit is monotonic in the height and
+    // a halving search finds the tallest one that clears. Closed form would miss
+    // the width floor a portrait panel sits on.
+    //
+    // The floor is never tested, so past a certain count it wins rather than
+    // clears: the search returns a floor that still overflows and the clip cuts
+    // the ends again. Left alone on purpose, since a row that deep is unreadable
+    // at the floor whatever it does with the overflow.
+    var tooShort = minimumGlyphHeight
+    var tooTall = baseHeight
+    // Twelve halvings land inside a twentieth of a point, finer than the whole
+    // points the height is rounded to.
+    for _ in 0..<12 {
+      let middle = (tooShort + tooTall) / 2
+      if totalWidth(height: middle, spacing: minimumGlyphSpacing, aspects: aspects)
+        <= availableWidth
+      {
+        tooShort = middle
+      } else {
+        tooTall = middle
+      }
+    }
+    // Rounding down can only narrow the row, so the fit cannot be lost to it.
+    return (tooShort.rounded(.down), minimumGlyphSpacing)
+  }
+}
+
+/// The vertical container for a page whose content can outgrow the window: a
+/// wide rig makes both display pages taller than the fixed 760 by 560.
+///
+/// The floor is the whole point. A scroll view proposes an unbounded height,
+/// and these `Spacer`-built pages answer it with their minimum: a column that
+/// fills 400 pt collapses to 70 pt [MEASURED 2026-09-10]. Handing the visible
+/// height back as a minimum leaves a page that fits looking as it did before.
+struct OnboardingScrollColumn<Content: View>: View {
+  @ViewBuilder var content: Content
+
+  var body: some View {
+    GeometryReader { proxy in
+      ScrollView {
+        content
+          .frame(minWidth: proxy.size.width, minHeight: proxy.size.height)
+      }
+      // Without this a page that already fits rubber-bands.
+      .scrollBounceBehavior(.basedOnSize)
+    }
+  }
+}
+
 /// Rendered under every page's primary action, so the exit is always in the
 /// same place.
 @MainActor
@@ -190,10 +312,20 @@ extension View {
   }
 }
 
-/// Title and subtitle lockup every page opens with.
+/// Title and subtitle lockup every page opens with, in both guided flows.
+///
+/// On appearance the title takes the VoiceOver cursor, so arriving on a page
+/// reads out what the page is about rather than whatever control comes first.
+/// The settings window's mode banner lands on Keep instead, but that banner has
+/// no title and IS the decision.
 struct OnboardingHeading: View {
   var title: String
   var subtitle: String?
+  /// Off on a flow's opening frame only: the window becoming key announces its
+  /// own title there, and a landing part-way through interrupts it.
+  var landsAccessibilityFocus = true
+
+  @AccessibilityFocusState private var titleFocused: Bool
 
   var body: some View {
     VStack(spacing: 8) {
@@ -201,6 +333,7 @@ struct OnboardingHeading: View {
         .font(.system(size: 30, weight: .bold, design: .rounded))
         .foregroundStyle(OnboardingStyle.titleColor)
         .multilineTextAlignment(.center)
+        .accessibilityFocused($titleFocused)
       if let subtitle {
         Text(subtitle)
           .font(.callout)
@@ -210,5 +343,6 @@ struct OnboardingHeading: View {
           .frame(maxWidth: 460)
       }
     }
+    .onAppear { titleFocused = landsAccessibilityFocus }
   }
 }

--- a/Candela/Settings/CheckupPane.swift
+++ b/Candela/Settings/CheckupPane.swift
@@ -19,6 +19,12 @@ enum CheckupPaneCopy {
     + "its native mode, its refresh rates and its HDR support, then a set of color fields you "
     + "look at yourself. The run opens in its own window, and you can stop it at any point."
 
+  /// Shown when a run ended before the display was put back. No verdict on the
+  /// panel, since nothing here was measured about it, and both ways back are
+  /// named rather than leaving a stranger on a changed screen.
+  static let restoreNotAchieved =
+    "The run ended before the display was put back, and it is not on the resolution and refresh rate it started in. Set it back in System Settings, or on this display's own page in \(AppInfo.productName)."
+
   static let historyTitle = "Past checkups"
   static let emptyHistory = "No checkups recorded for this display yet."
   static let historyNote =
@@ -31,6 +37,28 @@ enum CheckupPaneCopy {
   static let hideDetails = "Hide details"
   static let exportFailed = "The report could not be saved."
   static let acknowledge = "OK"
+  static let deleteRun = "Delete…"
+  static let deleteTitle = "Delete this checkup?"
+  static let deleteConfirm = "Delete"
+  static let deleteCancel = "Cancel"
+  static let deleteConsequences =
+    "This run's file is removed from this Mac. Other runs on this display are kept, and a report "
+    + "you already exported somewhere else is untouched.\n\nA provenance record bundles every checkup "
+    + "stored for the display, so a record exported after this delete leaves this run out and carries "
+    + "a different hash from one exported before it. If you want to keep a record that includes "
+    + "this run, export it first."
+
+  /// The title cannot name the run and a display can have several, so the
+  /// message opens with the row's own subject line.
+  static func deleteMessage(for report: CheckupReport) -> String {
+    "\(CheckupCopy.subjectLine(for: report))\n\n\(deleteConsequences)"
+  }
+
+  /// Every row's button reads "Delete…", so the spoken label is the only thing
+  /// that can say which run is about to go.
+  static func deleteRunLabel(for report: CheckupReport) -> String {
+    "Delete the run from \(CheckupCopy.subjectLine(for: report))"
+  }
 
   static let verifyTitle = "A report from somebody else"
   static let verify = "Verify a report"
@@ -41,12 +69,26 @@ enum CheckupPaneCopy {
     "This report does not validate: its contents have changed since it was written."
   static let unreadable = "That file could not be read as a checkup report."
 
-  /// The fixed strings, so the copy rules can be asserted over the surface
-  /// rather than over a reviewer's memory.
+  /// A run for the sweep to render the strings that name one. Fixed, so the
+  /// sweep reads the same sentence every time.
+  private static let sampleReport = CheckupReport(
+    scenario: .newMonitor,
+    identity: CheckupDisplayIdentity(
+      identityKey: "sample", vendorID: 0, modelID: 0, serial: nil, manufactureWeek: nil,
+      manufactureYear: nil, nativePixelWidth: 3840, nativePixelHeight: 2160, maxRefreshHz: nil,
+      supportsPQEOTF: false, supportsHDRGammaEOTF: false, productName: "Display"),
+    panelClass: .readsDDC, macOSBuild: "26.0", appBuild: "1",
+    startedAt: Date(timeIntervalSinceReferenceDate: 800_000_000), endedAt: nil,
+    completion: .complete, claims: [], plant: nil, showings: [:], exposureBookingID: nil)
+
+  /// The fixed strings plus one sample of each parameterised one, so the copy
+  /// rules can be asserted over the surface rather than over a reviewer's memory.
   static var allStringsForTest: [String] {
-    [title, subtitle, runTitle, run, runNote, historyTitle, emptyHistory, historyNote, export,
-     copySummary, copied, showDetails, hideDetails, exportFailed, acknowledge, verifyTitle,
-     verify, verifyNote, valid, invalid, unreadable]
+    [title, subtitle, runTitle, run, runNote, restoreNotAchieved, historyTitle, emptyHistory,
+     historyNote, export, copySummary, copied, showDetails, hideDetails, exportFailed,
+     acknowledge, deleteRun, deleteTitle, deleteConfirm, deleteCancel, deleteConsequences,
+     verifyTitle, verify, verifyNote, valid, invalid, unreadable,
+     deleteRunLabel(for: sampleReport)]
   }
 }
 
@@ -106,6 +148,7 @@ struct CheckupPane: View {
     SettingsPageScaffold {
       SettingsPageHeader(title: CheckupPaneCopy.title, subtitle: CheckupPaneCopy.subtitle)
       runSection
+      restoreNotice
       historySection
       verifySection
     }
@@ -144,6 +187,39 @@ struct CheckupPane: View {
       }
       .padding(.vertical, 2)
     }
+  }
+
+  /// The only place a failed restore can be read: the run's window is gone by
+  /// the time it answers. Scoped to the display the run moved, dismissed by
+  /// hand, superseded when the next run starts.
+  @ViewBuilder private var restoreNotice: some View {
+    if let notice = actions.checkupRestoreFailure,
+      CheckupPane.showsRestoreNotice(notice, scopedKey: scoped?.display.persistenceKey) {
+      SettingsNotice {
+        Text(verbatim: notice.text)
+          .font(.callout.weight(.medium))
+          .fixedSize(horizontal: false, vertical: true)
+        Button(CheckupPaneCopy.acknowledge) { CheckupPane.dismissRestoreNotice(actions) }
+          .buttonStyle(SettingsSecondaryButtonStyle())
+          .accessibilityLabel(Text(verbatim: CheckupPaneCopy.acknowledge))
+      }
+      // Queued, not interrupting: the pane can already be open behind the run,
+      // so nothing on screen has moved the cursor.
+      .onAppear { GuidedFlowAnnouncement.queued(notice.text) }
+    }
+  }
+
+  /// The notice is app-global and its sentence names no display, so it belongs
+  /// only under the scope of the display the run moved.
+  static func showsRestoreNotice(_ notice: CheckupRestoreNotice?, scopedKey: String?) -> Bool {
+    guard let notice, let scopedKey else { return false }
+    return notice.identityKey == scopedKey
+  }
+
+  /// The OK's whole job. Named rather than inline because an accessibility press
+  /// runs no SwiftUI action, so this is the only seam the suite can drive.
+  static func dismissRestoreNotice(_ actions: SettingsActions) {
+    actions.checkupRestoreFailure = nil
   }
 
   // MARK: - Scope
@@ -191,6 +267,13 @@ struct CheckupPane: View {
     runs = (try? store.list(identityKey: key)) ?? []
   }
 
+  /// Re-reading through `reload()` keeps one code path for what the history
+  /// shows: a delete that did not happen leaves its row standing.
+  private func delete(_ run: CheckupStoredRun) {
+    try? store.delete(url: run.url)
+    reload()
+  }
+
   // MARK: - History
 
   private var historySection: some View {
@@ -229,7 +312,7 @@ struct CheckupPane: View {
             // on the same day still has its own row.
             ForEach(Array(runs.enumerated()), id: \.element.url) { pair in
               if pair.offset > 0 { SettingsCardDivider() }
-              CheckupHistoryRow(run: pair.element)
+              CheckupHistoryRow(run: pair.element, onDelete: { delete(pair.element) })
             }
           }
         }
@@ -321,8 +404,10 @@ struct CheckupPane: View {
 @MainActor
 private struct CheckupHistoryRow: View {
   let run: CheckupStoredRun
+  let onDelete: () -> Void
 
   @State private var showingDetails = false
+  @State private var confirmingDelete = false
   @State private var justCopied = false
   /// Cancelled and replaced on every copy, so a second click restarts the two
   /// seconds instead of letting the first click's timer clear the label early.
@@ -358,6 +443,14 @@ private struct CheckupHistoryRow: View {
         Button(detailsTitle) { showingDetails.toggle() }
           .buttonStyle(SettingsSecondaryButtonStyle())
           .accessibilityLabel(Text(verbatim: detailsTitle))
+        // Trailing ellipsis: the click opens the confirmation, and `.destructive`
+        // belongs on the button that removes the file. Ahead of the copied label
+        // so it never slides sideways under the pointer.
+        Button(CheckupPaneCopy.deleteRun, role: .destructive) { confirmingDelete = true }
+          .buttonStyle(SettingsDangerButtonStyle())
+          // The visible label is the same on every row, so the spoken one names
+          // the run this button would delete.
+          .accessibilityLabel(Text(verbatim: CheckupPaneCopy.deleteRunLabel(for: report)))
         if justCopied {
           Text(verbatim: CheckupPaneCopy.copied)
             .font(.caption)
@@ -385,6 +478,21 @@ private struct CheckupHistoryRow: View {
       Button(CheckupPaneCopy.acknowledge) { saveError = nil }
     } message: {
       Text(verbatim: saveError ?? "")
+    }
+    .confirmationDialog(
+      CheckupPaneCopy.deleteTitle, isPresented: $confirmingDelete, titleVisibility: .visible
+    ) {
+      Button(CheckupPaneCopy.deleteConfirm, role: .destructive) { onDelete() }
+      // The shortcut puts the default action on Cancel, so Return cannot delete
+      // a run. What the dialog would do without it is a rig check nobody has
+      // run; the heat map's own delete dialog leaves it alone.
+      Button(CheckupPaneCopy.deleteCancel, role: .cancel) {}
+        .keyboardShortcut(.defaultAction)
+    } message: {
+      // The run this is about, then the provenance consequence: the record is
+      // assembled at export time out of whatever is stored then, so this is the
+      // last moment to keep one that includes this run.
+      Text(verbatim: CheckupPaneCopy.deleteMessage(for: report))
     }
   }
 

--- a/Candela/Settings/SettingsActions.swift
+++ b/Candela/Settings/SettingsActions.swift
@@ -2,6 +2,15 @@ import CandelaKit
 import Foundation
 import Observation
 
+/// A checkup's failed restore, with the display it happened to. The sentence
+/// says "the display" and names none, and the pane is scoped to one display at
+/// a time, so the key travels with the text.
+struct CheckupRestoreNotice: Equatable {
+  let text: String
+  /// The persistence key of the display the run moved.
+  let identityKey: String
+}
+
 /// App-side fan-out for the propagation seam. `StatusItemController`
 /// wires the closures; the Settings scene environment carries it so every pane
 /// writes through ONE door.
@@ -42,10 +51,35 @@ final class SettingsActions {
   /// another pane's cross-link, so Health is never on screen when it is set and
   /// a fresh appearance always reads it.
   @ObservationIgnored var pendingHealthScope: String?
+  /// A checkup ended early and left its display off the mode it started in.
+  /// Published here, not on the run's flow model: both early-exit routes close
+  /// the run's window before the restore answers, and this object outlives it.
+  ///
+  /// Observed, unlike `pendingHealthScope`: the settings window can already be
+  /// open behind the run, so the pane has to redraw when this lands.
+  var checkupRestoreFailure: CheckupRestoreNotice?
+  /// Which run the standing notice belongs to. A restore answers after its own
+  /// window has gone, so an earlier run's answer can arrive during a later one.
+  @ObservationIgnored private var checkupRunGeneration = 0
   @ObservationIgnored private weak var model: AppModel?
 
   init(model: AppModel) {
     self.model = model
+  }
+
+  /// Clears whatever the last run left and hands back the token this run's
+  /// restore has to present. Called as a run is wired.
+  func beginCheckupRun() -> Int {
+    checkupRunGeneration += 1
+    checkupRestoreFailure = nil
+    return checkupRunGeneration
+  }
+
+  /// Ignores an answer from a superseded run: a late one would put a notice back
+  /// on a display the newer run has since restored cleanly.
+  func publishCheckupRestoreFailure(_ notice: CheckupRestoreNotice, generation: Int) {
+    guard generation == checkupRunGeneration else { return }
+    checkupRestoreFailure = notice
   }
 
   /// Call after EVERY pref write. `persistenceKey` scopes the dimming re-apply

--- a/CandelaAppTests/CheckupAXLabelTests.swift
+++ b/CandelaAppTests/CheckupAXLabelTests.swift
@@ -7,6 +7,11 @@ import Testing
 
 /// Reads the accessibility tree SwiftUI publishes, not the source, so a label
 /// on the wrong view or swallowed by a parent element fails here.
+///
+/// Announcements are not in this tree and cannot be: they are posted
+/// notifications, not elements. Their decision surface is
+/// `GuidedFlowAnnouncementTests`; whether VoiceOver speaks them is a person's
+/// check with VoiceOver on.
 @MainActor
 @Suite("Checkup accessibility labels")
 struct CheckupAXLabelTests {
@@ -225,6 +230,7 @@ enum CheckupFixture {
     func runNativeMode() async -> [CheckupClaim] { [] }
     func runRefreshSweep() async -> [CheckupClaim] { [] }
     func restore() async -> Bool { true }
+    func cancel() {}
   }
 
   struct StubHDR: CheckupHDRRunning {

--- a/CandelaAppTests/CheckupCopyTests.swift
+++ b/CandelaAppTests/CheckupCopyTests.swift
@@ -97,6 +97,35 @@ struct CheckupCopyTests {
     #expect(CheckupCopy.planModeSweep.contains("put back"))
   }
 
+  /// A reason a stranger cannot act on is not a reason: each names what the
+  /// exclusion costs the checkup, and the one with a way out names it.
+  @Test func everyExclusionReasonNamesTheConsequenceForTheCheckup() {
+    #expect(CheckupCopy.excludedReason(.mirroring).contains("no test field can be shown"))
+    #expect(CheckupCopy.excludedReason(.virtual).contains("software"))
+    #expect(CheckupCopy.excludedReason(.mirroring).contains("Stop mirroring"))
+    // The em-dash and verdict sweep below reads `allStringsForTest`, so copy
+    // left out of it is copy nothing checks.
+    for text in [
+      CheckupCopy.excludedTitle, CheckupCopy.excludedReason(.mirroring),
+      CheckupCopy.excludedReason(.virtual),
+    ] {
+      #expect(CheckupCopy.allStringsForTest.contains(text))
+    }
+  }
+
+  /// The row is not a button, so its one combined element is everything
+  /// VoiceOver gets: it has to carry every line the row draws.
+  @Test func theExcludedRowLabelSpeaksTheNameTheSizeAndTheReason() {
+    let display = CheckupExcludedDisplay(
+      id: 2, name: "MAG 341C", pixelWidth: 3440, pixelHeight: 1440, reason: .mirroring)
+    let label = CheckupCopy.excludedRowLabel(display)
+    #expect(
+      label.contains("MAG") && label.contains("Not available")
+        && label.contains(CheckupCopy.excludedReason(.mirroring)))
+    // Grouped, so VoiceOver reads a number rather than four digits in a row.
+    #expect(label.contains("3,440 by 1,440 pixels"))
+  }
+
   @Test func noCopyCarriesAnEmDashOrAVerdictOnTheDisplay() {
     for s in CheckupCopy.allStringsForTest {
       #expect(!s.contains("—"))

--- a/CandelaAppTests/CheckupFieldWindowTests.swift
+++ b/CandelaAppTests/CheckupFieldWindowTests.swift
@@ -37,6 +37,9 @@ struct CheckupFieldWindowTests {
     // at all. This is the assertion that can fail.
     #expect(window.styleMask == OverlayWindow.styleMask)
     #expect(window.ignoresMouseEvents == false)
+    // Borderless, so it cannot take key status, which is why Escape arrives
+    // through an event monitor rather than through this window.
+    #expect(window.canBecomeKey == false)
     // The content view is what the dimming recipe's alpha lands on, and a field
     // at alpha 0 is an invisible field.
     #expect(window.contentView?.alphaValue == 1)
@@ -217,6 +220,38 @@ struct CheckupFieldWindowTests {
     let w = CheckupFieldWindow(orderFront: false, care: care)
     #expect(w.show(kind: .black, plant: nil, on: absent) == false)
     #expect(care.events.isEmpty)
+  }
+
+  /// A monitor that outlives its showing swallows Escape for the rest of the
+  /// session, and nothing left running takes it down.
+  @Test func theKeyMonitorIsGoneAfterHide() {
+    let w = CheckupFieldWindow(orderFront: false)
+    #expect(w.show(kind: .black, plant: nil, on: entry(only: false)))
+    #expect(w.keyMonitorForTest != nil)
+    w.hide()
+    #expect(w.keyMonitorForTest == nil)
+  }
+
+  /// The same double hide the care hold survives: `windowWillClose` hides on top
+  /// of the abandon that already did.
+  @Test func hidingTwiceRemovesTheMonitorExactlyOnce() {
+    let w = CheckupFieldWindow(orderFront: false)
+    w.hide()
+    #expect(w.keyMonitorForTest == nil)
+    #expect(w.show(kind: .black, plant: nil, on: entry(only: false)))
+    w.hide()
+    w.hide()
+    #expect(w.keyMonitorForTest == nil)
+  }
+
+  /// A monitor armed for a field that never reached the glass would consume
+  /// Escape with no showing to end.
+  @Test func aRefusedShowingInstallsNoMonitor() {
+    var absent = entry(only: false)
+    absent.id = 0xFFFF_FFFE
+    let w = CheckupFieldWindow(orderFront: false)
+    #expect(w.show(kind: .black, plant: nil, on: absent) == false)
+    #expect(w.keyMonitorForTest == nil)
   }
 
   /// A re-show without an intervening hide is how the confirmation field goes

--- a/CandelaAppTests/CheckupFlowModelTests.swift
+++ b/CandelaAppTests/CheckupFlowModelTests.swift
@@ -2,6 +2,7 @@ import CandelaKit
 import Foundation
 import CoreGraphics
 import Testing
+import os
 
 /// The checkup state machine over fakes: no panel, no window, no wire.
 @MainActor
@@ -51,6 +52,7 @@ struct CheckupFlowModelTests {
     func runNativeMode() async -> [CheckupClaim] { [CheckupClaim(family: .nativeMode, id: CheckupCheckID.nativeMode, verdict: .observed("achieved"))] }
     func runRefreshSweep() async -> [CheckupClaim] { [CheckupClaim(family: .refresh, id: "refresh.60", verdict: .observed("60 Hz achieved, as macOS reports it"))] }
     func restore() async -> Bool { true }
+    func cancel() {}
   }
   struct FakeHDR: CheckupHDRRunning {
     func run() async -> [CheckupClaim] { [CheckupClaim(family: .hdr, id: CheckupCheckID.hdrFlags, verdict: .observed("no flags"))] }
@@ -70,11 +72,11 @@ struct CheckupFlowModelTests {
                            supportsPQEOTF: false, supportsHDRGammaEOTF: false, productName: "DELL")
   }
 
-  private func environment(presenter: FakePresenter, entry: CheckupDisplayEntry, booked: @escaping (CheckupFieldKind, TimeInterval) -> Void = { _, _ in }, capabilities: any CheckupCapabilitiesRunning = FakeCaps()) -> CheckupEnvironment {
+  private func environment(presenter: FakePresenter, entry: CheckupDisplayEntry, booked: @escaping (CheckupFieldKind, TimeInterval) -> Void = { _, _ in }, capabilities: any CheckupCapabilitiesRunning = FakeCaps(), mode: any CheckupModeRunning = FakeMode(), excluded: [CheckupExcludedDisplay] = []) -> CheckupEnvironment {
     let identity = identity()
     return CheckupEnvironment(
-      displays: [entry], macOSBuild: "b", appBuild: "3",
-      runners: { _ in CheckupRunnerSet(identity: { identity }, capabilities: capabilities, mode: FakeMode(), hdr: FakeHDR()) },
+      displays: [entry], excluded: excluded, macOSBuild: "b", appBuild: "3",
+      runners: { _ in CheckupRunnerSet(identity: { identity }, capabilities: capabilities, mode: mode, hdr: FakeHDR()) },
       presenter: presenter, bookShowing: { _, kind, s in booked(kind, s) },
       now: { Date(timeIntervalSinceReferenceDate: 800_000_000) },
       makeRNG: { SeededGenerator(seed: 1) })
@@ -233,6 +235,63 @@ struct CheckupFlowModelTests {
     #expect(flow.claims.contains { $0.id == "field.black" && $0.verdict.text.contains("defect reported at") })
   }
 
+  /// Escape ends the showing the way the cap does, without answering it: the
+  /// field stays unanswered and the run is back on the page offering it again.
+  @Test func escapingAShowingRecordsNoObservationAndReturnsToTheInstructionPage() async {
+    let presenter = FakePresenter()
+    let flow = CheckupFlowModel(environment: environment(presenter: presenter, entry: entry()))
+    await toFirstField(flow); flow.startShowing(); flow.answer(.roundAndUncut, tappedRegion: nil); await flow.advance()
+    flow.startShowing()
+    flow.escapeShowing()
+    #expect(flow.page == .fieldInstruction(.black))
+    #expect(flow.claims.contains { $0.id == CheckupCheckID.field(.black) } == false)
+    #expect(presenter.hides == presenter.shown.count)
+  }
+
+  /// Light that reached the panel is booked whatever ended the showing, and only
+  /// the seconds it was actually up.
+  @Test func escapingBooksTheSecondsTheFieldWasActuallyUp() async {
+    var booked: [(CheckupFieldKind, TimeInterval)] = []
+    let flow = CheckupFlowModel(environment: environment(
+      presenter: FakePresenter(), entry: entry(), booked: { booked.append(($0, $1)) }))
+    await toFirstField(flow); flow.startShowing(); flow.answer(.roundAndUncut, tappedRegion: nil); await flow.advance()
+    flow.startShowing()
+    for _ in 0..<5 { flow.timeoutTick() }
+    flow.escapeShowing()
+    #expect(booked.filter { $0.0 == .black }.map(\.1) == [5])
+
+    // A field escaped the moment it went up still emitted light, so it books a
+    // second and never zero.
+    flow.showAgain()
+    flow.escapeShowing()
+    #expect(booked.filter { $0.0 == .black }.map(\.1) == [5, 1])
+  }
+
+  /// The confirmation re-show has recorded nothing yet, so escaping it must not
+  /// leave a verdict behind either.
+  @Test func escapingTheConfirmationReShowRecordsNothing() async {
+    let flow = CheckupFlowModel(environment: environment(presenter: FakePresenter(), entry: entry()))
+    await toFirstField(flow); flow.startShowing(); flow.answer(.roundAndUncut, tappedRegion: nil); await flow.advance()
+    flow.startShowing()
+    flow.answer(.moreThanOne, tappedRegion: flow.plantRegionForTest)
+    #expect(flow.page == .fieldConfirmSecondDot(.black))
+    flow.escapeShowing()
+    #expect(flow.page == .fieldInstruction(.black))
+    #expect(flow.claims.contains { $0.id == CheckupCheckID.field(.black) } == false)
+  }
+
+  /// The control for the three above: a suite where escaping records nothing
+  /// because nothing ever records is not a suite.
+  @Test func answeringStillRecordsAfterAnEscape() async {
+    let flow = CheckupFlowModel(environment: environment(presenter: FakePresenter(), entry: entry()))
+    await toFirstField(flow); flow.startShowing(); flow.answer(.roundAndUncut, tappedRegion: nil); await flow.advance()
+    flow.startShowing()
+    flow.escapeShowing()
+    flow.startShowing()
+    flow.answer(.oneMark, tappedRegion: flow.plantRegionForTest)
+    #expect(flow.claims.contains { $0.id == CheckupCheckID.field(.black) })
+  }
+
   @Test func showAgainIsCappedAndEveryShowingIsBooked() async {
     var booked: [(CheckupFieldKind, TimeInterval)] = []
     let flow = CheckupFlowModel(environment: environment(presenter: FakePresenter(), entry: entry(), booked: { booked.append(($0, $1)) }))
@@ -285,6 +344,137 @@ struct CheckupFlowModelTests {
     #expect(unpicked.report?.identity.identityKey == "")
   }
 
+  /// The restore is queued on the runner, so it lands a hop after the abandon.
+  /// Bounded, so a condition that never comes true fails instead of hanging.
+  private func settle(until done: () -> Bool) async {
+    var spins = 0
+    while !done(), spins < 200 {
+      await Task.yield()
+      spins += 1
+    }
+  }
+
+  private func pickedFlow(mode: any CheckupModeRunning) async -> CheckupFlowModel {
+    let flow = CheckupFlowModel(environment: environment(
+      presenter: FakePresenter(), entry: entry(), mode: mode))
+    await flow.advance()
+    flow.selectedDisplay = flow.environment.displays[0]
+    await flow.advance()                      // displayPick -> plan, which builds the runners
+    return flow
+  }
+
+  /// A restore queued behind a running sweep is serviced only after the sweep
+  /// returns, so the cancel has to come first. Order is the mechanism, so order
+  /// is what the test reads.
+  @Test func abandoningCancelsTheSweepBeforeItAsksForARestore() async {
+    let mode = CancelRecordingMode(restores: true)
+    let flow = await pickedFlow(mode: mode)
+    flow.abandon(reason: "closed")
+    await settle(until: { mode.events.count == 2 })
+    #expect(mode.events == ["cancel", "restore"])
+  }
+
+  /// The barrier an event count cannot give: `restore()` records off the main
+  /// actor, so a count of two can retire before the decision that follows it.
+  /// Wraps the app's own wiring, so this drives what the controller installs.
+  private func barrier(on flow: CheckupFlowModel) -> OSAllocatedUnfairLock<Bool> {
+    let settled = OSAllocatedUnfairLock<Bool>(initialState: false)
+    let published = flow.onRestoreSettled
+    flow.onRestoreSettled = { needsNotice, identityKey in
+      published(needsNotice, identityKey)
+      settled.withLock { $0 = true }
+    }
+    return settled
+  }
+
+  /// Both routes that end a run early take the run's window with them and the
+  /// restore answers after that, so the notice needs a surface that outlives the
+  /// run. The model is released here the way `windowWillClose` releases it.
+  @Test func aFailedRestoreReachesThePaneEvenOnceTheFlowModelIsGone() async {
+    let failing = CancelRecordingMode(restores: false)
+    var flow: CheckupFlowModel? = await pickedFlow(mode: failing)
+    let actions = SettingsActions(model: TestFixtures.appModel())
+    CheckupWindowController.publishRestoreOutcome(of: flow!, to: actions)
+    let settled = barrier(on: flow!)
+    flow?.abandon(reason: "closed")
+    // The close, in the order the window controller does it: abandon, then drop
+    // the model. The restore is still out on the runner at this point.
+    flow = nil
+    await settle(until: { settled.withLock { $0 } })
+    #expect(actions.checkupRestoreFailure?.text == CheckupPaneCopy.restoreNotAchieved)
+    // The display it happened to travels with it: the pane is scoped to one
+    // display and the sentence names none.
+    #expect(actions.checkupRestoreFailure?.identityKey == entry().identityKey)
+
+    // The control: the same abandon over a restore that achieved the mode
+    // leaves the pane with nothing to say.
+    let achieving = CancelRecordingMode(restores: true)
+    let clean = await pickedFlow(mode: achieving)
+    let cleanActions = SettingsActions(model: TestFixtures.appModel())
+    CheckupWindowController.publishRestoreOutcome(of: clean, to: cleanActions)
+    let cleanSettled = barrier(on: clean)
+    clean.abandon(reason: "closed")
+    await settle(until: { cleanSettled.withLock { $0 } })
+    #expect(cleanActions.checkupRestoreFailure == nil)
+  }
+
+  /// A display that has left cannot be put back, and a notice there would blame
+  /// the app for an unplug. The restore is still attempted.
+  @Test func aDisconnectDoesNotBlameTheAppForAnUnpluggedDisplay() async {
+    let failing = CancelRecordingMode(restores: false)
+    let flow = await pickedFlow(mode: failing)
+    let actions = SettingsActions(model: TestFixtures.appModel())
+    CheckupWindowController.publishRestoreOutcome(of: flow, to: actions)
+    let settled = barrier(on: flow)
+    flow.displayDisconnected(7)
+    await settle(until: { settled.withLock { $0 } })
+    #expect(failing.events == ["cancel", "restore"])
+    #expect(actions.checkupRestoreFailure == nil)
+  }
+
+  /// A standing notice describes a run that is over, and the run being wired now
+  /// reports its own outcome. No display is picked yet, so this is not about the
+  /// same display twice.
+  @Test func startingAnotherCheckupClearsTheLastRunsNotice() async {
+    let actions = SettingsActions(model: TestFixtures.appModel())
+    actions.checkupRestoreFailure = CheckupRestoreNotice(
+      text: CheckupPaneCopy.restoreNotAchieved, identityKey: entry().identityKey)
+    let next = await pickedFlow(mode: CancelRecordingMode(restores: true))
+    CheckupWindowController.publishRestoreOutcome(of: next, to: actions)
+    #expect(actions.checkupRestoreFailure == nil)
+  }
+
+  /// The stale-completion sequence: run 1's restore answers after run 2 has put
+  /// its own display back cleanly. Without a generation on the publish, that
+  /// late answer posts a notice over a run that never failed.
+  @Test func aRestoreFromAnEarlierRunCannotPublishOverTheRunThatFollowedIt() async {
+    let actions = SettingsActions(model: TestFixtures.appModel())
+    let stale = await pickedFlow(mode: CancelRecordingMode(restores: false))
+    CheckupWindowController.publishRestoreOutcome(of: stale, to: actions)
+    // The seam run 1's own task captured, before run 2 replaces the wiring.
+    let staleSettled = stale.onRestoreSettled
+
+    let next = await pickedFlow(mode: CancelRecordingMode(restores: true))
+    CheckupWindowController.publishRestoreOutcome(of: next, to: actions)
+    let nextSettled = barrier(on: next)
+    next.abandon(reason: "closed")
+    await settle(until: { nextSettled.withLock { $0 } })
+    #expect(actions.checkupRestoreFailure == nil)
+
+    // Run 1 answering late, with the failure it really had.
+    staleSettled(true, entry().identityKey)
+    #expect(actions.checkupRestoreFailure == nil)
+
+    // The control: the newest run's own answer still publishes, so the token
+    // silences the stale completion rather than the mechanism.
+    let third = await pickedFlow(mode: CancelRecordingMode(restores: false))
+    CheckupWindowController.publishRestoreOutcome(of: third, to: actions)
+    let thirdSettled = barrier(on: third)
+    third.abandon(reason: "closed")
+    await settle(until: { thirdSettled.withLock { $0 } })
+    #expect(actions.checkupRestoreFailure?.text == CheckupPaneCopy.restoreNotAchieved)
+  }
+
   /// Left to the panel class, a Dell whose cached string never arrived would be
   /// pre-graded write-only: false about the panel, and it lands in a saved report.
   @Test func anHDREngagedRunPregradesTheCapabilityRowsAndNeverRunsTheLeg() async {
@@ -335,12 +525,15 @@ struct CheckupFlowModelTests {
     #expect(flow.showFailureReason == nil)
   }
 
-  @Test func theDisplayPickNeverOffersAMirroringDisplay() {
-    var mirroring = entry()
-    mirroring.isMirroring = true
+  /// The pick offers exactly what the environment handed it. The exclusion rule
+  /// lives one layer up and is asserted there over live sources; a copy here
+  /// would drop a display excluded for a reason this model never heard of.
+  @Test func theDisplayPickOffersWhatTheEnvironmentHandedIt() {
+    let target = entry()
     let flow = CheckupFlowModel(
-      environment: environment(presenter: FakePresenter(), entry: mirroring))
-    #expect(flow.selectableDisplays.isEmpty)
+      environment: environment(presenter: FakePresenter(), entry: target))
+    #expect(flow.selectableDisplays.map(\.id) == [target.id])
+    #expect(flow.selectableDisplays.map(\.id) == flow.environment.displays.map(\.id))
   }
 
   /// The strip is 104 pt of the field's own lower edge on a one-display run, so
@@ -418,10 +611,18 @@ struct CheckupFlowModelTests {
     #expect(elsewhere.partiallyOccludedFields.isEmpty)
   }
 
-  @Test func theSelectedDisplayNeverIncludesVirtualOnes() {
-    var v = entry(); v.isVirtual = true
-    let flow = CheckupFlowModel(environment: environment(presenter: FakePresenter(), entry: v))
-    #expect(flow.selectableDisplays.isEmpty)
+  /// A display the flow cannot target is on the page with its reason rather
+  /// than silently absent, and is not among the ones that can be chosen.
+  @Test func anExcludedDisplayIsVisibleButNotSelectable() {
+    let target = entry()
+    let flow = CheckupFlowModel(environment: environment(
+      presenter: FakePresenter(), entry: target,
+      excluded: [CheckupExcludedDisplay(
+        id: 9, name: "MIRROR", pixelWidth: 1920, pixelHeight: 1080, reason: .mirroring)]))
+    #expect(flow.selectableDisplays.map(\.id) == [target.id])
+    #expect(flow.excludedDisplays.count == 1)
+    #expect(flow.excludedDisplays[0].reason == .mirroring)
+    #expect(!flow.selectableDisplays.contains { $0.id == flow.excludedDisplays[0].id })
   }
 
   /// A leg in flight when the cable goes is the one way a saved report could be
@@ -615,6 +816,29 @@ actor CheckupLegGate {
     for continuation in waiting { continuation.resume() }
     waiting.removeAll()
   }
+}
+
+/// Records the order the flow drives it in. `restore()` is nonisolated and can
+/// run off the main actor, so the events go behind a lock. A class, because a
+/// struct would lose the recording.
+final class CancelRecordingMode: CheckupModeRunning {
+  private let recorded = OSAllocatedUnfairLock<[String]>(initialState: [])
+  /// Whether the display comes back on its pre-run mode.
+  let restores: Bool
+
+  init(restores: Bool) { self.restores = restores }
+
+  var events: [String] { recorded.withLock { $0 } }
+
+  func runNativeMode() async -> [CheckupClaim] { [] }
+  func runRefreshSweep() async -> [CheckupClaim] { [] }
+
+  func restore() async -> Bool {
+    recorded.withLock { $0.append("restore") }
+    return restores
+  }
+
+  func cancel() { recorded.withLock { $0.append("cancel") } }
 }
 
 /// So "the leg never ran" is an assertion, not an absence.

--- a/CandelaAppTests/CheckupLiveEnvironmentTests.swift
+++ b/CandelaAppTests/CheckupLiveEnvironmentTests.swift
@@ -6,6 +6,23 @@ import Testing
 /// own objects and is covered by the hardware pass.
 @Suite("Checkup live environment")
 struct CheckupLiveEnvironmentTests {
+  @Test @MainActor func theLiveBuilderNamesAnExcludedDisplayWithoutABrightnessController() async {
+    let model = AppModel(safeMode: true)
+    model.mirrorTopology.update(MirrorTopology([
+      ConfiguredDisplay(
+        id: 900001,
+        identity: DisplayConfigIdentity(vendor: 1, model: 2, serial: 3, isBuiltIn: false),
+        name: "Mirrored display without DDC", isBuiltIn: false, mirrorsDisplay: 900002)
+    ]))
+    let environment = await CheckupLiveEnvironment.current(
+      model: model, presenter: CheckupFlowModelTests.FakePresenter(),
+      coordinator: OledCareCoordinator())
+    #expect(environment.displays.isEmpty)
+    #expect(environment.excluded.map(\.id) == [900001])
+    #expect(environment.excluded.map(\.reason) == [.mirroring])
+    #expect(environment.excluded.map(\.name) == ["Mirrored display without DDC"])
+  }
+
   @Test func entriesExcludeVirtualDisplaysAndMarkTheOnlyDisplay() {
     let sources = [
       source(id: 1, key: "a", name: "Built-in", isBuiltIn: true, pixelWidth: 3024, pixelHeight: 1964),

--- a/CandelaAppTests/CheckupLiveEnvironmentTests.swift
+++ b/CandelaAppTests/CheckupLiveEnvironmentTests.swift
@@ -7,13 +7,17 @@ import Testing
 @Suite("Checkup live environment")
 struct CheckupLiveEnvironmentTests {
   @Test func entriesExcludeVirtualDisplaysAndMarkTheOnlyDisplay() {
-    let entries = CheckupLiveEnvironment.entries(from: [
+    let sources = [
       source(id: 1, key: "a", name: "Built-in", isBuiltIn: true, pixelWidth: 3024, pixelHeight: 1964),
       source(id: 2, key: "v", name: "Virtual", isVirtual: true, pixelWidth: 1920, pixelHeight: 1080),
-    ])
+    ]
+    let entries = CheckupLiveEnvironment.entries(from: sources)
     #expect(entries.map(\.id) == [1])
     #expect(entries[0].isOnlyDisplay)
     #expect(entries[0].panelClass == .noDDC)
+    // Still out of entries, and now on the pick page carrying its reason.
+    #expect(CheckupLiveEnvironment.excluded(from: sources).map(\.id) == [2])
+    #expect(CheckupLiveEnvironment.excluded(from: sources).map(\.reason) == [.virtual])
   }
 
   @Test func twoRealDisplaysAreNeitherTheOnlyOne() {
@@ -67,14 +71,68 @@ struct CheckupLiveEnvironmentTests {
   /// A display mirroring another has no `NSScreen`, so no field can be drawn on
   /// it: a run there books emission and grades attestations for a blank panel.
   @Test func entriesExcludeAMirroringDisplay() {
-    let entries = CheckupLiveEnvironment.entries(from: [
+    let sources = [
       source(id: 1, key: "a", name: "Built-in", isBuiltIn: true, pixelWidth: 1, pixelHeight: 1),
       source(id: 2, key: "m", name: "MAG", isMirroring: true, pixelWidth: 1, pixelHeight: 1),
-    ])
+    ]
+    let entries = CheckupLiveEnvironment.entries(from: sources)
     #expect(entries.map(\.id) == [1])
     // The survivor is the only display, which is what the strip and the plant's
     // exclusion band both key on.
     #expect(entries[0].isOnlyDisplay)
+    // Still out of entries, and now on the pick page carrying its reason.
+    #expect(CheckupLiveEnvironment.excluded(from: sources).map(\.id) == [2])
+    #expect(CheckupLiveEnvironment.excluded(from: sources).map(\.reason) == [.mirroring])
+  }
+
+  // MARK: - The excluded list
+
+  /// The two lists partition the input, so a display can never be both hidden
+  /// and offered, nor silently dropped from both.
+  @Test func everySourceLandsInExactlyOneOfTheTwoLists() {
+    let sources = [
+      source(id: 1, key: "a", name: "Built-in", isBuiltIn: true, pixelWidth: 3024, pixelHeight: 1964),
+      source(id: 2, key: "m", name: "MAG", isMirroring: true, pixelWidth: 3440, pixelHeight: 1440),
+      source(id: 3, key: "v", name: "Virtual", isVirtual: true, pixelWidth: 1920, pixelHeight: 1080),
+    ]
+    let entries = CheckupLiveEnvironment.entries(from: sources)
+    let excluded = CheckupLiveEnvironment.excluded(from: sources)
+    #expect(Set(entries.map(\.id)).union(excluded.map(\.id)) == Set(sources.map(\.id)))
+    #expect(Set(entries.map(\.id)).isDisjoint(with: excluded.map(\.id)))
+  }
+
+  @Test func aMirroringDisplayIsExcludedWithTheMirroringReason() {
+    let sources = [
+      source(id: 1, key: "a", name: "Built-in", isBuiltIn: true, pixelWidth: 1, pixelHeight: 1),
+      source(id: 2, key: "m", name: "MAG", isMirroring: true, pixelWidth: 3440, pixelHeight: 1440),
+    ]
+    #expect(CheckupLiveEnvironment.excluded(from: sources).map(\.reason) == [.mirroring])
+  }
+
+  @Test func aVirtualDisplayIsExcludedWithTheVirtualReason() {
+    let sources = [
+      source(id: 1, key: "a", name: "Built-in", isBuiltIn: true, pixelWidth: 1, pixelHeight: 1),
+      source(id: 2, key: "v", name: "Virtual", isVirtual: true, pixelWidth: 1920, pixelHeight: 1080),
+    ]
+    #expect(CheckupLiveEnvironment.excluded(from: sources).map(\.reason) == [.virtual])
+
+    // No rig here can be both at once, so the tie-break is pinned rather than
+    // left to the order of two ifs: what the thing IS outranks how it is wired.
+    var both = sources[1]
+    both.isMirroring = true
+    #expect(CheckupLiveEnvironment.excluded(from: [both]).map(\.reason) == [.virtual])
+  }
+
+  /// The row has to name the display a person is looking at, not just say that
+  /// something was left out.
+  @Test func exclusionCarriesTheDisplaysOwnNameAndPixelSize() throws {
+    let excluded = try #require(
+      CheckupLiveEnvironment.excluded(from: [
+        source(id: 2, key: "m", name: "MAG", isMirroring: true, pixelWidth: 3440, pixelHeight: 1440)
+      ]).first)
+    #expect(excluded.name == "MAG" && excluded.pixelWidth == 3440)
+    #expect(excluded.pixelHeight == 1440)
+    #expect(excluded.id == 2)
   }
 
   /// The plan and the pick page both read this off the entry.

--- a/CandelaAppTests/CheckupPaneTests.swift
+++ b/CandelaAppTests/CheckupPaneTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CandelaKit
 import CoreGraphics
 import Foundation
@@ -144,6 +145,51 @@ struct CheckupPaneTests {
     #expect(ProvenanceCopy.intact.contains("record"))
   }
 
+  /// The sentence is the whole reason the delete dialog runs to two paragraphs,
+  /// so it is asserted rather than trusted to survive the next copy edit.
+  @Test func theDeleteMessageNamesTheProvenanceHashAndSuggestsExportingFirst() {
+    let message = CheckupPaneCopy.deleteMessage(
+      for: report(identityVerdict: .observed("EDID parsed")))
+    // "hash" and not "checksum": every other string on this pane about this one
+    // value says hash, and ProvenanceCopy.checkNote says it on the same screen.
+    #expect(message.contains("hash"))
+    #expect(message.contains("export it first"))
+  }
+
+  /// Every row's button reads "Delete…" and the title cannot name the run, so
+  /// the message's first line and the spoken label are the only places that can.
+  @Test func theDeleteDialogAndItsButtonNameTheRun() {
+    let subject = report(identityVerdict: .observed("EDID parsed"))
+    let line = CheckupCopy.subjectLine(for: subject)
+    let message = CheckupPaneCopy.deleteMessage(for: subject)
+    #expect(message.split(separator: "\n").first.map(String.init) == line)
+    // The control: the consequences still follow it, so leading with the run
+    // did not displace what the dialog is for.
+    #expect(message.contains(CheckupPaneCopy.deleteConsequences))
+    #expect(CheckupPaneCopy.deleteRunLabel(for: subject).contains(line))
+    #expect(CheckupPaneCopy.deleteRunLabel(for: subject) != CheckupPaneCopy.deleteRun)
+  }
+
+  /// No "this app" in user copy: the product has a name, and each display has a
+  /// page under it.
+  @Test func theRestoreNoticeNamesTheProductAndTheDisplaysOwnPage() {
+    #expect(!CheckupPaneCopy.restoreNotAchieved.contains("this app"))
+    #expect(CheckupPaneCopy.restoreNotAchieved.contains(AppInfo.productName))
+    // Both ways back, which is what keeps a stranger off a changed screen.
+    #expect(CheckupPaneCopy.restoreNotAchieved.contains("System Settings"))
+  }
+
+  /// The notice is app-global and names no display, while the pane is scoped to
+  /// one, so it belongs to exactly one scope.
+  @Test @MainActor func aRestoreNoticeBelongsToTheDisplayTheRunMoved() {
+    let notice = CheckupRestoreNotice(
+      text: CheckupPaneCopy.restoreNotAchieved, identityKey: "ran-here")
+    #expect(CheckupPane.showsRestoreNotice(notice, scopedKey: "ran-here"))
+    #expect(!CheckupPane.showsRestoreNotice(notice, scopedKey: "another-display"))
+    #expect(!CheckupPane.showsRestoreNotice(notice, scopedKey: nil))
+    #expect(!CheckupPane.showsRestoreNotice(nil, scopedKey: "ran-here"))
+  }
+
   /// The no-verdict rule over the whole pane: nothing hands the display a result.
   @Test func noPaneCopyCarriesAnEmDashOrAVerdictOnTheDisplay() {
     for sentence in CheckupPaneCopy.allStringsForTest {
@@ -172,5 +218,110 @@ struct CheckupPaneTests {
     #expect(image != nil)
     #expect((image?.width ?? 0) > 20)
     #expect((image?.height ?? 0) > 20)
+  }
+
+  /// Reachability, which no model-level test can assert: a failed restore is
+  /// published after the run's own window has gone, so what proves it reaches a
+  /// person is the tree this pane publishes with that state set.
+  ///
+  /// A walk and not a render: `ImageRenderer` draws a `ScrollView` as an empty
+  /// rectangle [measured 2026-09-10, a plain `Text` rendering 75 distinct byte
+  /// values against this pane's 1], and every settings page is one, so a pixel
+  /// comparison could not fail.
+  @Test @MainActor func theRestoreNoticeReachesThePaneOnlyWhenThereIsOneToShow() async throws {
+    let model = TestFixtures.appModel(discovery: ScriptedDiscovery([
+      (id: 424_244, key: "checkup-notice-fixture", name: "Checkup Notice Fixture"),
+    ]))
+    await model.refresh()
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("checkup-notice-\(UUID().uuidString)", isDirectory: true)
+    func pane(_ actions: SettingsActions) -> some View {
+      CheckupPane(directory: directory)
+        .environment(model)
+        .environment(actions)
+        .environment(\.settingsAccent, SettingsRegistry.descriptor(for: .checkup).accent)
+    }
+    func notice(for key: String) -> SettingsActions {
+      let actions = SettingsActions(model: model)
+      actions.checkupRestoreFailure = CheckupRestoreNotice(
+        text: CheckupPaneCopy.restoreNotAchieved, identityKey: key)
+      return actions
+    }
+
+    // Every window stays bound: a released host tears its SwiftUI graph down and
+    // the elements collected from it answer nothing.
+    let quiet = Self.hosted(pane(SettingsActions(model: model)))
+    // The control: the walk reaches this pane's content either way, so an absent
+    // notice below means the pane drew none, not that the walk read nothing.
+    #expect(Self.labels(quiet.elements).contains(CheckupPaneCopy.run))
+    #expect(!Self.labels(quiet.elements).contains(CheckupPaneCopy.acknowledge))
+    #expect(!Self.labels(quiet.elements).contains("Warning"))
+
+    // A notice about a display that is not here belongs to no scope this pane
+    // can resolve, so it draws nowhere.
+    let foreign = Self.hosted(pane(notice(for: "a-display-that-is-not-attached")))
+    #expect(Self.labels(foreign.elements).contains(CheckupPaneCopy.run))
+    #expect(!Self.labels(foreign.elements).contains("Warning"))
+
+    // And under exactly one scope: the run's own. Which display the pane opens
+    // on is not asserted, since whether this Mac contributes a built-in is a
+    // property of the machine running the suite.
+    var rendering: [(window: NSWindow, elements: [AnyObject])] = []
+    for state in model.allControlledStates {
+      let hosted = Self.hosted(pane(notice(for: state.display.persistenceKey)))
+      if Self.labels(hosted.elements).contains("Warning") { rendering.append(hosted) }
+    }
+    #expect(rendering.count == 1)
+    let noticed = try #require(rendering.first)
+    #expect(Self.labels(noticed.elements).contains(CheckupPaneCopy.run))
+    // The notice's symbol, its way out, and one more line of text than the quiet
+    // pane. The sentence cannot be read here: SwiftUI publishes body text as an
+    // `AXStaticText` with neither label nor value under a hosting view
+    // [measured 2026-09-10], so the copy rules are asserted over
+    // `allStringsForTest` instead.
+    #expect(Self.labels(noticed.elements).filter { $0 == CheckupPaneCopy.acknowledge }.count == 1)
+    #expect(Self.staticTexts(noticed.elements) == Self.staticTexts(quiet.elements) + 1)
+
+    // What that OK does. Called rather than pressed: `accessibilityPerformPress`
+    // on a SwiftUI button runs no action in this bundle [measured 2026-09-10,
+    // against this same element], so the action is named and driven directly.
+    let dismissing = notice(for: "checkup-notice-fixture")
+    CheckupPane.dismissRestoreNotice(dismissing)
+    #expect(dismissing.checkupRestoreFailure == nil)
+  }
+
+  /// Every element the hosted view publishes, in tree order, with the window
+  /// that keeps it alive. SwiftUI builds no accessibility nodes until an
+  /// assistive client attaches, so without the flag the walk finds an empty tree.
+  @MainActor private static func hosted(
+    _ view: some View
+  ) -> (window: NSWindow, elements: [AnyObject]) {
+    _ = NSApplication.shared
+    (NSApp as NSObject).accessibilitySetValue(
+      true, forAttribute: NSAccessibility.Attribute(rawValue: "AXEnhancedUserInterface"))
+    let host = NSHostingView(rootView: view.transaction { $0.disablesAnimations = true })
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 720, height: 1400),
+      styleMask: [.titled], backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    window.contentView = host
+    host.layoutSubtreeIfNeeded()
+    var found: [AnyObject] = []
+    func walk(_ element: Any, depth: Int) {
+      guard depth < 30 else { return }
+      let object = element as AnyObject
+      found.append(object)
+      for child in (object.accessibilityChildren?() ?? nil) ?? [] { walk(child, depth: depth + 1) }
+    }
+    walk(host, depth: 0)
+    return (window, found)
+  }
+
+  private static func labels(_ elements: [AnyObject]) -> [String] {
+    elements.compactMap { $0.accessibilityLabel?() ?? nil }
+  }
+
+  private static func staticTexts(_ elements: [AnyObject]) -> Int {
+    elements.filter { ($0.accessibilityRole?() ?? nil) == .staticText }.count
   }
 }

--- a/CandelaAppTests/GuidedFlowAnnouncementTests.swift
+++ b/CandelaAppTests/GuidedFlowAnnouncementTests.swift
@@ -1,0 +1,293 @@
+import CandelaKit
+import Foundation
+import Testing
+
+/// The testable surface of a VoiceOver announcement is the DECISION, never the
+/// utterance: what text, on which transition, at which threshold. Nothing here
+/// can assert that a posted announcement was spoken, so that stays a person's
+/// check with VoiceOver on.
+@MainActor
+@Suite("Guided flow announcements")
+struct GuidedFlowAnnouncementTests {
+
+  /// Associated values rule out `CaseIterable`, so this list is hand-maintained
+  /// and a new page has to be added here too. What it proves is that each arm of
+  /// `pageAnnouncement` produces something a person can hear.
+  private static let checkupPages: [CheckupPage] = {
+    var pages: [CheckupPage] = [
+      .scenario, .displayPick, .plan, .identity, .capabilities, .nativeMode, .refresh,
+      .witness, .plantDisclosure, .hdr, .summary,
+    ]
+    for kind in CheckupFieldKind.allCases {
+      pages += [.fieldInstruction(kind), .fieldShowing(kind), .fieldConfirmSecondDot(kind)]
+    }
+    return pages
+  }()
+
+  private static let setupPages: [OnboardingPage] = [
+    .welcome, .accessibility, .detection, .noDisplays, .size(displayKey: sizePageKey),
+    .oledSelect, .oledCare, .finish,
+  ]
+  /// Shaped like a real persistence key, so an announcement that leaked one
+  /// would be caught by the same assertion that catches a bare display id.
+  private static let sizePageKey = "DIS-3669-3dd0-0"
+
+  @Test func everyCheckupPageHasAnAnnouncementAndNoneOfThemSpeaksAStorageKey() {
+    for page in Self.checkupPages {
+      let text = CheckupCopy.pageAnnouncement(page)
+      #expect(!text.isEmpty, "\(page)")
+      #expect(!text.contains("—"), "\(page)")
+      // Raw values that are ordinary words ("black") are skipped, the same
+      // exemption `CheckupPage.name` is tested under; `gray7` is not one.
+      for kind in CheckupFieldKind.allCases
+      where !CheckupCopy.fieldName(kind).contains(kind.rawValue) {
+        #expect(!text.contains(kind.rawValue), "\(page) speaks \(kind.rawValue)")
+      }
+    }
+  }
+
+  /// A field passes through three pages and a person has to hear which one they
+  /// landed on. `CheckupPage.name` gives all three the same words.
+  @Test func theThreeStagesOfAFieldDoNotShareOneAnnouncement() {
+    for kind in CheckupFieldKind.allCases {
+      let stages = [
+        CheckupCopy.pageAnnouncement(.fieldInstruction(kind)),
+        CheckupCopy.pageAnnouncement(.fieldShowing(kind)),
+        CheckupCopy.pageAnnouncement(.fieldConfirmSecondDot(kind)),
+      ]
+      #expect(Set(stages).count == 3, "\(kind)")
+      // The control: the three DO all name the field, so distinctness above
+      // cannot be met by dropping the subject.
+      for stage in stages {
+        #expect(stage.contains(CheckupCopy.shortFieldName(kind)), "\(kind)")
+      }
+    }
+  }
+
+  @Test func everySetupPageHasAnAnnouncementCarryingItsStepPosition() {
+    let total = Self.setupPages.count
+    for (offset, page) in Self.setupPages.enumerated() {
+      let text = OnboardingAnnouncements.pageAnnouncement(page, step: offset + 1, of: total)
+      #expect(!text.isEmpty, "\(page)")
+      #expect(!text.contains("—"), "\(page)")
+      #expect(text.contains("Step \(offset + 1) of \(total)"), "\(page)")
+      #expect(!text.contains(Self.sizePageKey), "\(page) speaks a persistence key")
+      // `OnboardingPage.id` is storage, and the camel-cased ones are unmistakable
+      // as keys: nothing written for a person spells "oledSelect".
+      if page.id.rangeOfCharacter(from: .uppercaseLetters) != nil {
+        #expect(!text.contains(page.id), "\(page) speaks its id")
+      }
+    }
+    #expect(
+      OnboardingAnnouncements.pageAnnouncement(.oledSelect, step: 3, of: 7)
+        .contains("Step 3 of 7"))
+  }
+
+  /// A size page names the display it is about, because several of them can
+  /// follow each other and "this display" would not tell them apart.
+  @Test func aSizePageSpeaksTheDisplaysNameWhenItHasOne() {
+    let named = OnboardingAnnouncements.pageAnnouncement(
+      .size(displayKey: Self.sizePageKey), step: 3, of: 8, displayName: "MAG 341C OLED")
+    #expect(named.contains("MAG 341C OLED"))
+    #expect(!named.contains(Self.sizePageKey))
+    let unnamed = OnboardingAnnouncements.pageAnnouncement(
+      .size(displayKey: Self.sizePageKey), step: 3, of: 8)
+    #expect(!unnamed.isEmpty)
+    #expect(!unnamed.contains(Self.sizePageKey))
+  }
+
+  @Test func theCountdownSpeaksAtTenAndThreeAndNowhereElse() {
+    #expect((0...30).filter { AnnouncementThresholds.speaks(at: $0, cap: 30) } == [3, 10])
+  }
+
+  @Test func theWhiteFieldDoesNotAnnounceItsOwnStartingValue() {
+    let whiteCap = CheckupFieldKind.white.capSeconds
+    #expect(whiteCap == 10, "the trap this guard exists for has moved")
+    #expect(AnnouncementThresholds.speaks(at: whiteCap, cap: whiteCap) == false)
+    #expect(AnnouncementThresholds.speaks(at: 3, cap: whiteCap))
+    // The control: every other field opens at 20, so 10 is a real threshold
+    // there and the guard must not swallow it.
+    #expect(AnnouncementThresholds.speaks(at: 10, cap: CheckupFieldKind.black.capSeconds))
+    // Same for the setup countdown, whose cap is the model's own.
+    #expect(AnnouncementThresholds.speaks(at: 10, cap: OnboardingFlowModel.applyCountdownSeconds))
+  }
+
+  /// The spoken countdown IS the drawn countdown. Two spellings of one number
+  /// would be two things to keep true.
+  @Test func theSpokenCountdownIsTheDrawnCountdown() {
+    #expect(
+      OnboardingSizePage.countdownAnnouncement(seconds: 3, canKeep: true, cap: 15)
+        == OnboardingSizePage.countdownCaption(seconds: 3, canKeep: true))
+    #expect(
+      OnboardingSizePage.countdownAnnouncement(seconds: 10, canKeep: false, cap: 15)
+        == OnboardingSizePage.countdownCaption(seconds: 10, canKeep: false))
+    #expect(OnboardingSizePage.countdownAnnouncement(seconds: 9, canKeep: true, cap: 15) == nil)
+    #expect(OnboardingSizePage.countdownAnnouncement(seconds: 10, canKeep: true, cap: 10) == nil)
+
+    #expect(CheckupCopy.secondsLeftAnnouncement(seconds: 3, cap: 20) == CheckupCopy.secondsLeft(3))
+    #expect(CheckupCopy.secondsLeftAnnouncement(seconds: 10, cap: 20) == CheckupCopy.secondsLeft(10))
+    #expect(CheckupCopy.secondsLeftAnnouncement(seconds: 9, cap: 20) == nil)
+    #expect(CheckupCopy.secondsLeftAnnouncement(seconds: 10, cap: 10) == nil)
+  }
+
+  /// The keep and revert bar is the one place in either flow where the cursor
+  /// lands on a button instead of a heading, so everything it draws has to be
+  /// spoken or a listener gets "Keep, button" and no deadline. Which transition
+  /// calls which of these is the view's own arms, and only a person with
+  /// VoiceOver can confirm that wiring.
+  @Test func theBarSpeaksItsCountdownWhenItArrives() {
+    #expect(
+      OnboardingSizePage.barAnnouncement(seconds: 15, achieved: nil)
+        == OnboardingSizePage.countdownCaption(seconds: 15, canKeep: true))
+    #expect(!OnboardingSizePage.barAnnouncement(seconds: 15, achieved: nil).contains("\u{2014}"))
+  }
+
+  /// A diverged commit takes Keep away, and the recovery instruction and the
+  /// achieved size are the only route out. Neither reaches a cursor on Revert.
+  @Test func aDivergedCommitSpeaksTheRecoveryTextAndTheAchievedSize() {
+    let achieved = OnboardingAchievedSize.size(width: 2560, height: 1440, refreshHz: 60)
+    let text = OnboardingSizePage.divergenceAnnouncement(achieved)
+    #expect(text.contains(DisplayModeCopy.recoveryInstruction(dialect: .size)))
+    #expect(text.contains(ModeSpeech.spoken(logicalWidth: 2560, logicalHeight: 1440, refreshHz: 60)))
+    // The drawn caption's times sign and "Hz" are read inconsistently, which is
+    // why the spoken sentence is not the drawn one here.
+    #expect(!text.contains("2560 x 1440"))
+    #expect(!text.contains("\u{2014}"))
+    #expect(
+      OnboardingSizePage.divergenceAnnouncement(.unreadable)
+        .contains(DisplayModeCopy.unreadableAchievedGeometry(dialect: .size)))
+
+    // Divergence can also be there before the bar is, and then one announcement
+    // carries both the recovery text and the deadline.
+    let arriving = OnboardingSizePage.barAnnouncement(seconds: 12, achieved: achieved)
+    #expect(arriving.contains(OnboardingSizePage.divergenceAnnouncement(achieved)))
+    #expect(arriving.contains(OnboardingSizePage.countdownCaption(seconds: 12, canKeep: false)))
+  }
+
+  /// The cursor lands on the page heading a moment after the announcement, so an
+  /// announcement made of the heading's words says the transition twice and the
+  /// page's purpose once. Every page, not a sample: most arms opened with their
+  /// own heading.
+  @Test func noCheckupAnnouncementIsBuiltFromItsPagesHeading() {
+    for page in Self.checkupPages {
+      let text = CheckupCopy.pageAnnouncement(page)
+      let heading = Self.checkupHeading(page)
+      #expect(!text.hasPrefix(heading), "\(page) opens with its heading")
+      #expect(!text.contains(heading), "\(page) speaks its heading")
+      // The control: a sentence, not a stub. Dropping the heading is easy to
+      // satisfy by saying almost nothing.
+      #expect(text.count > 20, "\(page)")
+    }
+  }
+
+  /// The title each page hands `CheckupPageScaffold`. Written out because the
+  /// pairing lives in the views and a host-free test cannot ask one what it
+  /// drew; the page list above keeps this exhaustive.
+  private static func checkupHeading(_ page: CheckupPage) -> String {
+    switch page {
+    case .scenario: CheckupCopy.scenarioTitle
+    case .displayPick: CheckupCopy.pickTitle
+    case .plan: CheckupCopy.planTitle
+    case .identity: CheckupCopy.identityTitle
+    case .capabilities: CheckupCopy.capabilitiesTitle
+    case .nativeMode: CheckupCopy.nativeModeTitle
+    case .refresh: CheckupCopy.refreshTitle
+    // The witness card's instruction page, which is `.witness` rather than
+    // `.fieldInstruction(.witness)`, draws the same heading as one.
+    case .witness: CheckupCopy.fieldTitle(.witness)
+    case .plantDisclosure: CheckupCopy.plantDisclosureTitle
+    case .fieldInstruction(let kind), .fieldShowing(let kind): CheckupCopy.fieldTitle(kind)
+    case .fieldConfirmSecondDot: CheckupCopy.secondDotTitle
+    case .hdr: CheckupCopy.hdrTitle
+    case .summary: CheckupCopy.summaryTitle
+    }
+  }
+
+  /// The same rule on the setup side, where the welcome and size pages opened
+  /// with their headings.
+  @Test func noSetupAnnouncementIsBuiltFromItsPagesHeading() {
+    let total = Self.setupPages.count
+    for (offset, page) in Self.setupPages.enumerated() {
+      let text = OnboardingAnnouncements.pageAnnouncement(
+        page, step: offset + 1, of: total, displayName: Self.sizePageDisplayName)
+      for heading in Self.setupHeadings(page) {
+        #expect(!text.hasPrefix(heading), "\(page) opens with \(heading)")
+        #expect(!text.contains(heading), "\(page) speaks \(heading)")
+      }
+      #expect(text.count > 20, "\(page)")
+    }
+  }
+
+  /// Every title a setup page can draw. The pages draw these same constants, so
+  /// a retitled page moves its heading here rather than leaving this list stale.
+  private static func setupHeadings(_ page: OnboardingPage) -> [String] {
+    switch page {
+    case .welcome: [OnboardingTitles.welcome]
+    case .accessibility: [OnboardingTitles.accessibility]
+    // One page, three headings: the scan's, then the count it flips to once the
+    // cards resolve, in both its singular and plural shapes.
+    case .detection:
+      [OnboardingTitles.detectionScanning, OnboardingTitles.detectionFound(count: 1),
+       OnboardingTitles.detectionFound(count: 2)]
+    case .noDisplays: [OnboardingTitles.noDisplays]
+    case .size: [OnboardingTitles.size(displayName: sizePageDisplayName)]
+    case .oledSelect: [OnboardingTitles.oledSelect]
+    case .oledCare: [OnboardingTitles.oledCare]
+    case .finish: [OnboardingTitles.finish]
+    }
+  }
+
+  private static let sizePageDisplayName = "MAG 341C OLED"
+
+  /// A divergence and the seconds arrive in one update, so a commit diverging
+  /// exactly at 10 or 3 would post both. The deadline interrupts and the
+  /// recovery text is the only route out, so that tick says nothing.
+  @Test func aTickThatTakesKeepAwayDoesNotSpeakOverTheRecoveryText() {
+    for seconds in [10, 3] {
+      #expect(
+        OnboardingSizePage.countdownAnnouncement(
+          seconds: seconds, canKeep: false, cap: 15, divergedThisTick: true) == nil)
+      // The control: the same tick over a divergence that was already standing
+      // still speaks its deadline, so the suppression is about the arrival.
+      #expect(
+        OnboardingSizePage.countdownAnnouncement(
+          seconds: seconds, canKeep: false, cap: 15, divergedThisTick: false)
+          == OnboardingSizePage.countdownCaption(seconds: seconds, canKeep: false))
+    }
+  }
+
+  /// The detection page announces on arrival, while the scan still runs, and
+  /// nothing re-announces when the heading flips to a count. The sentence has to
+  /// hold on both sides: no past tense, no number.
+  @Test func theDetectionAnnouncementHoldsBeforeTheScanResolves() {
+    let text = OnboardingAnnouncements.pageAnnouncement(.detection, step: 2, of: 5)
+    let purpose = text.replacingOccurrences(of: " Step 2 of 5.", with: "")
+    #expect(purpose != text, "the step position is spelled the way this test strips it")
+    #expect(purpose.rangeOfCharacter(from: .decimalDigits) == nil)
+    #expect(!purpose.lowercased().contains("were found"))
+    #expect(!purpose.lowercased().contains("was found"))
+  }
+
+  /// The welcome heading gives up the focus landing only on the flow's opening
+  /// frame, where the window becoming key is already speaking its own title.
+  /// Coming BACK to welcome lands on the heading like every other page.
+  @Test func theWelcomeHeadingKeepsItsFocusLandingOnceTheFlowHasMoved() {
+    let model = OnboardingFlowModel(environment: OnboardingFixtures.rig)
+    #expect(model.currentPage == .welcome)
+    #expect(model.hasNavigated == false)
+    model.advance()
+    #expect(model.hasNavigated)
+    model.back()
+    #expect(model.currentPage == .welcome)
+    #expect(model.hasNavigated)
+  }
+
+  /// The em-dash and no-verdict sweep reads `allStringsForTest`, so an
+  /// announcement left out of it is an announcement nothing checks.
+  @Test func theCheckupAnnouncementsAreCoveredByTheCopySweep() {
+    let sweep = Set(CheckupCopy.allStringsForTest)
+    for page in Self.checkupPages {
+      #expect(sweep.contains(CheckupCopy.pageAnnouncement(page)), "\(page)")
+    }
+  }
+}

--- a/CandelaAppTests/OnboardingLayoutTests.swift
+++ b/CandelaAppTests/OnboardingLayoutTests.swift
@@ -1,0 +1,75 @@
+import CoreGraphics
+import SwiftUI
+import Testing
+
+// The arithmetic behind the two setup pages that draw one item per display,
+// checked without laying a view out. The render suite cannot see a clip at all,
+// so the fit a wide rig needs is asserted here or nowhere.
+@Suite("Onboarding layout")
+struct OnboardingLayoutTests {
+  /// The setup window is 760 wide and the glyph row sits inside the page's
+  /// 30 pt gutter, so this is what the panels have to fit into.
+  private static let availableWidth: CGFloat = 700
+  /// The two heights the glyph row draws at: mid-scan, then cards shown.
+  private static let scanHeight: CGFloat = 150
+  private static let cardsShownHeight: CGFloat = 110
+  /// The spacing the row has always drawn at.
+  private static let restingSpacing: CGFloat = 34
+
+  /// The whole table, because the table is the decision: three across is the
+  /// widest readable row, and a fourth card wraps two by two rather than
+  /// stranding one.
+  @Test func theColumnCountWrapsFourCardsTwoByTwo() {
+    #expect((1...8).map(OnboardingCardGrid.columns(for:)) == [1, 2, 3, 2, 3, 3, 3, 3])
+  }
+
+  /// A row of one or two draws where it always has only because every column
+  /// carries the page's card cap. A bare `.flexible()` maxes at `.infinity`, so
+  /// one card would stretch the whole content width, which no render test sees.
+  @Test func everyCardColumnCarriesThePagesCardWidthCap() {
+    let cap: CGFloat = 300
+    for count in 1...8 {
+      let columns = OnboardingCardGrid.gridColumns(for: count, maxCardWidth: cap)
+      #expect(columns.count == OnboardingCardGrid.columns(for: count), "\(count)")
+      for column in columns {
+        guard case .flexible(_, let maximum) = column.size else {
+          Issue.record("a column for \(count) cards is not flexible")
+          continue
+        }
+        #expect(maximum == cap, "\(count)")
+      }
+    }
+  }
+
+  /// The defect as arithmetic: four ultrawide panels at a fixed height and
+  /// spacing ask for more width than the window has, and the clip swallows the
+  /// outer ones.
+  @Test func theGlyphRowFitsFourUltrawidePanelsInTheWindow() {
+    let aspects = [CGFloat](repeating: 2.39, count: 4)
+    // The positive control. Without it the fit below could be passing against
+    // a row that never overflowed in the first place.
+    #expect(
+      OnboardingCardGrid.totalWidth(
+        height: Self.cardsShownHeight, spacing: Self.restingSpacing, aspects: aspects)
+        > Self.availableWidth)
+
+    let metrics = OnboardingCardGrid.glyphMetrics(
+      aspects: aspects, availableWidth: Self.availableWidth, baseHeight: Self.cardsShownHeight)
+    #expect(
+      OnboardingCardGrid.totalWidth(
+        height: metrics.height, spacing: metrics.spacing, aspects: aspects)
+        <= Self.availableWidth)
+  }
+
+  /// The rig people actually have: the ultrawide and the rotated 4K. Both row
+  /// states stay where they are today, so the fit above costs this page nothing.
+  @Test func theGlyphRowLeavesTwoPanelsWhereTheyAre() {
+    let aspects: [CGFloat] = [3440.0 / 1440.0, 2160.0 / 3840.0]
+    for baseHeight in [Self.scanHeight, Self.cardsShownHeight] {
+      let metrics = OnboardingCardGrid.glyphMetrics(
+        aspects: aspects, availableWidth: Self.availableWidth, baseHeight: baseHeight)
+      #expect(metrics.height == baseHeight)
+      #expect(metrics.spacing == Self.restingSpacing)
+    }
+  }
+}

--- a/CandelaAppTests/RenderSmokeTests.swift
+++ b/CandelaAppTests/RenderSmokeTests.swift
@@ -380,10 +380,10 @@ struct RenderSmokeTests {
     renderFlow(.welcome)
   }
 
-  /// The detection page, which starts a scripted scan on appear. The render is
-  /// whatever frame the scan is on when the renderer runs, and either end of
-  /// that walk is a real state the page has to draw, so nothing here waits for
-  /// or pins a phase.
+  /// The detection page starts a scripted scan on appear and scrolls, so the
+  /// renderer draws it blank: this is evidence about no pixels. It holds that
+  /// the flow builds the page and runs a body without trapping, whichever frame
+  /// of the scan the renderer catches.
   @Test func theOnboardingDetectionPageRenders() {
     renderFlow(.detection)
   }
@@ -398,8 +398,10 @@ struct RenderSmokeTests {
     renderFlow(.accessibility)
   }
 
-  /// The OLED designation page, rendered with both fixture displays selectable
-  /// and the ultrawide designated.
+  /// The OLED designation page, both fixture displays selectable and the
+  /// ultrawide designated. It scrolls too, so the render is blank and this says
+  /// only that the body ran. The cards are a person's check, and the grid's
+  /// arithmetic is the layout suite's.
   @Test func theOnboardingDesignationPageRenders() {
     renderFlow(.oledSelect, designating: ["fixture-mag"])
   }
@@ -420,5 +422,39 @@ struct RenderSmokeTests {
     let empty = OnboardingEnvironment(
       accessibilityGranted: false, loginItemEnabled: false, isFirstRun: true, displays: [])
     renderFlow(.noDisplays, environment: empty)
+  }
+
+  // MARK: - The guided setup flow on a wide rig
+
+  // No desk here has three or four externals, so these run on stand-in
+  // fixtures, and what they prove is narrow. `ImageRenderer` draws a
+  // `ScrollView`'s content as nothing [MEASURED 2026-09-10] and both pages
+  // scroll, so each render is blank and only the size floor survives.
+  //
+  // The page's own body still runs, which is where the wide-rig branches are.
+  // That much was measured the same day, on a probe inside the scroll view;
+  // whether each cell of a grid inside one is evaluated was NOT measured, so a
+  // trap in a card is not covered. Neither is a clipped panel: the fit is
+  // arithmetic in the layout suite, and how it looks needs a person at a
+  // four-display desk.
+
+  @Test func theOnboardingDetectionPageRendersWithThreeExternals() {
+    renderFlow(.detection, environment: OnboardingFixtures.threeExternals)
+  }
+
+  @Test func theOnboardingDetectionPageRendersWithFourExternals() {
+    renderFlow(.detection, environment: OnboardingFixtures.fourExternals)
+  }
+
+  @Test func theOnboardingDesignationPageRendersWithThreeExternals() {
+    renderFlow(
+      .oledSelect, environment: OnboardingFixtures.threeExternals,
+      designating: ["fixture-mag"])
+  }
+
+  @Test func theOnboardingDesignationPageRendersWithFourExternals() {
+    renderFlow(
+      .oledSelect, environment: OnboardingFixtures.fourExternals,
+      designating: ["fixture-mag"])
   }
 }

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupLiveRunners.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupLiveRunners.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import os
 
 /// Per advertised control: read, write the same value back, read again,
 /// quote the round trip. The write's return is discarded; a DDC ACK is evidence
@@ -85,6 +86,11 @@ public actor CheckupLiveModeRunner: CheckupModeRunning {
   let configurator: any DisplayConfiguring
   let displayID: CGDirectDisplayID
   private var before: DisplayMode?
+  /// Outside the actor's isolation on purpose: a sweep holds the actor for its
+  /// whole run with no suspension point, so an isolated `cancel()` would queue
+  /// behind the loop it is meant to stop. Letting the sweep suspend instead
+  /// would let a queued `restore()` land between two rates.
+  private let cancelled = OSAllocatedUnfairLock<Bool>(initialState: false)
 
   /// `.preview` (`kCGConfigureForAppOnly`) reverts on process exit, crash
   /// included, so a run that dies mid-sweep never parks the panel on the last
@@ -138,7 +144,15 @@ public actor CheckupLiveModeRunner: CheckupModeRunning {
     if before == nil { before = configurator.currentMode(for: displayID) }
   }
 
+  public nonisolated func cancel() { cancelled.withLock { $0 = true } }
+
+  private nonisolated var isCancelled: Bool { cancelled.withLock { $0 } }
+
   public func runNativeMode() -> [CheckupClaim] {
+    // Before anything is remembered or applied: a leg that never ran has earned
+    // no claim and left nothing to put back. Past here the apply is committed,
+    // so a cancel during it keeps the claim.
+    guard !isCancelled else { return [] }
     rememberCurrentMode()
     let modes = configurator.modes(for: displayID)
     guard let native = modes.first(where: \.isNative) else {
@@ -177,6 +191,10 @@ public actor CheckupLiveModeRunner: CheckupModeRunning {
   }
 
   public func runRefreshSweep() -> [CheckupClaim] {
+    // Ahead of `rememberCurrentMode`: a sweep that never ran must not latch a
+    // mode to put back, or a later `restore()` becomes a real apply of the mode
+    // the display is already sitting on.
+    guard !isCancelled else { return [] }
     rememberCurrentMode()
     let modes = configurator.modes(for: displayID)
     guard let native = modes.first(where: \.isNative) else {
@@ -197,6 +215,10 @@ public actor CheckupLiveModeRunner: CheckupModeRunning {
     }
     var claims: [CheckupClaim] = []
     for rate in DisplayModeCatalog.distinctRates(atNative).sorted() {
+      // Checked at the top of each rate, so the guarantee is "stops within one
+      // rate step": a CGCompleteDisplayConfiguration already in flight cannot be
+      // interrupted. Rates already measured keep their claims.
+      guard !isCancelled else { return claims }
       guard
         let mode = atNative.first(where: { DisplayMode.quantizedRefresh($0.refreshHz) == rate })
       else { continue }

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupRunners.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupRunners.swift
@@ -13,6 +13,9 @@ public protocol CheckupModeRunning: Sendable {
   /// Puts the display back on its pre-run mode and reports whether it is
   /// ACTUALLY on it afterwards; the apply's own return only says the request was accepted.
   func restore() async -> Bool
+  /// Stops a sweep in progress. Synchronous on purpose: the caller is ending a
+  /// run, and a mode leg that has the runner busy cannot service an await.
+  func cancel()
 }
 
 public protocol CheckupHDRRunning: Sendable {

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupStore.swift
@@ -7,6 +7,14 @@ public struct CheckupStoredRun: Equatable, Sendable {
   public let envelope: CheckupReportEnvelope
 }
 
+public enum CheckupStoreError: Error, Equatable {
+  /// The URL did not sit inside the store's own directory, so nothing was removed.
+  case outsideStore
+  /// Inside the store but not one stored run: an identity folder, a deeper
+  /// path, or a name the store never wrote. Nothing was removed.
+  case notAStoredRun
+}
+
 /// One file per run, keyed by identity, under Application Support. The
 /// identity key is the display's EDID-derived key, never a display id.
 public struct CheckupStore: Sendable {
@@ -72,6 +80,31 @@ public struct CheckupStore: Sendable {
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
     return try decoder.decode(CheckupReportEnvelope.self, from: Data(contentsOf: url))
+  }
+
+  /// Removes exactly one stored run: a `json` file exactly one level under an
+  /// identity folder in this store, which is the shape `save` returns and `list`
+  /// hands back. Anything else throws rather than returning as if it deleted.
+  /// This is the one call that removes a person's measured data, and
+  /// `removeItem` on an identity folder would take a display's whole history.
+  public func delete(url: URL) throws {
+    // Canonicalized on both sides, as `save` and `list` are: an unresolved
+    // `directory` would refuse the store's own files wherever the path runs
+    // through a symlink, which every temp directory does.
+    let target = url.resolvingSymlinksInPath()
+    let root = directory.resolvingSymlinksInPath().pathComponents
+    let components = target.pathComponents
+    // Whole components, never a string prefix, which would admit a sibling
+    // directory whose name merely starts with the store's.
+    guard components.count > root.count, Array(components.prefix(root.count)) == root else {
+      throw CheckupStoreError.outsideStore
+    }
+    // The extension alone would admit a directory named like a run file.
+    let isFolder = (try? target.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+    guard components.count == root.count + 2, target.pathExtension == "json", !isFolder else {
+      throw CheckupStoreError.notAStoredRun
+    }
+    try FileManager.default.removeItem(at: target)
   }
 
   public func list(identityKey: String) throws -> [CheckupStoredRun] {

--- a/CandelaKit/Tests/CandelaKitTests/CheckupLiveRunnersTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CheckupLiveRunnersTests.swift
@@ -228,6 +228,96 @@ struct CheckupLiveRunnersTests {
     #expect(claims[0].family == .refresh)
   }
 
+  private func nativeSizeModes(_ rates: [Double]) -> [DisplayMode] {
+    rates.enumerated().map { index, hz in
+      mode(Int32(index + 1), w: 3840, h: 2160, hz: hz, native: index == 0)
+    }
+  }
+
+  /// The cancel is checked at the top of each rate, so the apply already in
+  /// flight when it lands still finishes: one apply, never zero.
+  @Test func aCancelledSweepStopsWithinOneRateStep() async {
+    let modes = nativeSizeModes([60, 100, 120, 144])
+    // The control. Without it a count of one says only that the fake is broken.
+    let uncancelled = SweepConfigurator(modeList: modes, capAt: 240)
+    _ = await CheckupLiveModeRunner(configurator: uncancelled, displayID: 1).runRefreshSweep()
+    #expect(uncancelled.applies.count == 4)
+
+    let configurator = SweepConfigurator(modeList: modes, capAt: 240)
+    let runner = CheckupLiveModeRunner(configurator: configurator, displayID: 1)
+    configurator.onApply = { _ in runner.cancel() }
+    let claims = await runner.runRefreshSweep()
+    #expect(configurator.applies.count == 1)
+    // The rate that did complete is still graded: it was measured.
+    #expect(claims.count == 1)
+  }
+
+  /// The guard sits above `rememberCurrentMode`, so a sweep that never ran
+  /// latches nothing to put back and the restore below applies nothing.
+  @Test func aCancelBeforeTheSweepAppliesNothingAndLatchesNothingToPutBack() async {
+    let configurator = SweepConfigurator(modeList: nativeSizeModes([60, 120]), capAt: 240)
+    let runner = CheckupLiveModeRunner(configurator: configurator, displayID: 1)
+    runner.cancel()
+    let claims = await runner.runRefreshSweep()
+    #expect(configurator.applies.isEmpty)
+    #expect(claims.isEmpty)
+    #expect(await runner.restore())
+    #expect(configurator.applies.isEmpty)
+
+    // The control: a sweep that DID run remembers a mode and its restore is a
+    // real apply. Without it, an empty apply list proves nothing.
+    let ran = SweepConfigurator(modeList: nativeSizeModes([60, 120]), capAt: 240)
+    let ranRunner = CheckupLiveModeRunner(configurator: ran, displayID: 1)
+    _ = await ranRunner.runRefreshSweep()
+    let swept = ran.applies.count
+    #expect(swept == 2)
+    #expect(await ranRunner.restore())
+    #expect(ran.applies.count == swept + 1)
+  }
+
+  /// The restore is ungated by the cancel, and it still grades on the mode the
+  /// display is achieved on rather than on the apply's return.
+  @Test func restoreStillRunsAfterACancelAndReportsTheAchievedMode() async {
+    let modes = nativeSizeModes([60, 120, 144])
+    let willing = SweepConfigurator(modeList: modes, capAt: 240)
+    let runner = CheckupLiveModeRunner(configurator: willing, displayID: 1)
+    // Cancelled on the SECOND rate, so the sweep leaves the display somewhere
+    // other than where it started. On the first, the sweep's only apply IS the
+    // pre-run mode and the assertion below could not fail.
+    willing.onApply = { count in if count == 2 { runner.cancel() } }
+    _ = await runner.runRefreshSweep()
+    #expect(willing.applies.last == modes[1])
+    #expect(await runner.restore())
+    #expect(willing.applies.last == modes[0])
+
+    // A panel that ACKs the restore and does not move: the achieved-state read
+    // is the only thing that can catch it, cancelled or not.
+    let stubborn = StuckConfigurator(modeList: modes)
+    let stuckRunner = CheckupLiveModeRunner(configurator: stubborn, displayID: 1)
+    _ = await stuckRunner.runRefreshSweep()
+    stuckRunner.cancel()
+    stubborn.stuckOn = modes[1]
+    #expect(await stuckRunner.restore() == false)
+  }
+
+  /// The native-mode check is at the top of the leg, so a cancel that lands
+  /// during its one apply must not throw away the claim that apply earned.
+  @Test func cancellingDoesNotGateTheNativeModeLegAfterItHasApplied() async {
+    let native = mode(1, w: 3840, h: 2160, hz: 60, native: true)
+    let configurator = SweepConfigurator(modeList: [native], capAt: 240)
+    let runner = CheckupLiveModeRunner(configurator: configurator, displayID: 1)
+    configurator.onApply = { _ in runner.cancel() }
+    let claims = await runner.runNativeMode()
+    #expect(claims.first?.verdict.kind == "observed")
+
+    // The control: cancelled before the leg, the same runner claims nothing.
+    let early = SweepConfigurator(modeList: [native], capAt: 240)
+    let earlyRunner = CheckupLiveModeRunner(configurator: early, displayID: 1)
+    earlyRunner.cancel()
+    #expect(await earlyRunner.runNativeMode().isEmpty)
+    #expect(early.applies.isEmpty)
+  }
+
   @Test func restoreReportsWhetherTheDisplayIsActuallyBackOnItsOriginalMode() async {
     let m60 = mode(1, w: 3840, h: 2160, hz: 60, native: true)
     let m120 = mode(2, w: 3840, h: 2160, hz: 120)
@@ -256,6 +346,12 @@ struct CheckupLiveRunnersTests {
     let modeList: [DisplayMode]
     let capAt: Double
     var applied: DisplayMode?
+    /// Every apply in order. A cancelled sweep is graded on how many applies
+    /// actually reached the display, which one `applied` cannot answer.
+    var applies: [DisplayMode] = []
+    /// Called with the number of applies so far. `cancel()` is synchronous, so
+    /// inside an apply is the only place a test can land one mid-sweep.
+    var onApply: ((Int) -> Void)?
 
     init(modeList: [DisplayMode], capAt: Double) {
       self.modeList = modeList
@@ -273,6 +369,8 @@ struct CheckupLiveRunnersTests {
     }
     func apply(_ mode: DisplayMode, to displayID: CGDirectDisplayID, scope: DisplayConfigScope) throws {
       applied = mode
+      applies.append(mode)
+      onApply?(applies.count)
     }
     func applyMirroring(_ changes: [MirrorChange], scope: DisplayConfigScope) throws {}
     var revealsHiddenModes: Bool { true }

--- a/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CheckupStoreTests.swift
@@ -27,6 +27,80 @@ struct CheckupStoreTests {
     #expect(try store.load(url: newer).validate())
   }
 
+  /// The control is the second assertion: a delete that took the whole store
+  /// would satisfy the first one on its own.
+  @Test func deleteRemovesOnlyTheRunItNames() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let store = CheckupStore(directory: dir)
+    let older = try store.save(try CheckupReportEnvelope(report: report(started: 100)))
+    let newer = try store.save(try CheckupReportEnvelope(report: report(started: 200)))
+    _ = try store.save(try CheckupReportEnvelope(report: report(started: 150, key: "other")))
+    try store.delete(url: newer)
+    #expect(try store.list(identityKey: "k1").map(\.url) == [older])
+    #expect(try store.list(identityKey: "other").count == 1)
+  }
+
+  /// Without the second assertion the test cannot tell a refusal from a delete
+  /// that removed the file and threw afterwards.
+  @Test func deleteRefusesAURLOutsideTheStore() throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let store = CheckupStore(directory: root.appendingPathComponent("store", isDirectory: true))
+    let sibling = root.appendingPathComponent("store-elsewhere", isDirectory: true)
+    try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: true)
+    let outside = sibling.appendingPathComponent("not-ours.json")
+    try Data("{}".utf8).write(to: outside)
+    #expect(throws: CheckupStoreError.self) { try store.delete(url: outside) }
+    #expect(FileManager.default.fileExists(atPath: outside.path))
+  }
+
+  /// The identity folder holds a display's whole history and `removeItem` takes
+  /// a directory with everything in it. The surviving run is the real assertion.
+  @Test func deleteRefusesTheIdentityFolder() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let store = CheckupStore(directory: dir)
+    let run = try store.save(try CheckupReportEnvelope(report: report(started: 100)))
+    let folder = run.deletingLastPathComponent()
+    #expect(throws: CheckupStoreError.notAStoredRun) { try store.delete(url: folder) }
+    #expect(try store.list(identityKey: "k1").map(\.url) == [run])
+  }
+
+  /// A run file is a `json` name one level under an identity folder. Other
+  /// shapes are inside the store too, so containment cannot be the whole guard.
+  @Test func deleteRefusesANestedPathThatIsNotARunFile() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let store = CheckupStore(directory: dir)
+    let run = try store.save(try CheckupReportEnvelope(report: report(started: 100)))
+    let folder = run.deletingLastPathComponent()
+    let notes = folder.appendingPathComponent("notes.txt")
+    try Data("keep me".utf8).write(to: notes)
+    let deeper = folder.appendingPathComponent("nested", isDirectory: true)
+      .appendingPathComponent("run.json")
+    try FileManager.default.createDirectory(
+      at: deeper.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: deeper)
+    // At a run's depth and with a run's extension, and still a directory.
+    let folderNamedLikeARun = folder.appendingPathComponent("nested.json", isDirectory: true)
+    try FileManager.default.createDirectory(at: folderNamedLikeARun, withIntermediateDirectories: true)
+    #expect(throws: CheckupStoreError.notAStoredRun) { try store.delete(url: notes) }
+    #expect(throws: CheckupStoreError.notAStoredRun) { try store.delete(url: deeper) }
+    #expect(throws: CheckupStoreError.notAStoredRun) { try store.delete(url: folderNamedLikeARun) }
+    #expect(FileManager.default.fileExists(atPath: notes.path))
+    #expect(FileManager.default.fileExists(atPath: deeper.path))
+    #expect(FileManager.default.fileExists(atPath: folderNamedLikeARun.path))
+    #expect(try store.list(identityKey: "k1").map(\.url) == [run])
+  }
+
+  /// `save` and `list` reach their URLs by different routes, so a guard that
+  /// skipped canonicalizing would refuse the URL the history hands it.
+  @Test func deleteAcceptsTheURLListGaveBack() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let store = CheckupStore(directory: dir)
+    _ = try store.save(try CheckupReportEnvelope(report: report(started: 100)))
+    let run = try #require(try store.list(identityKey: "k1").first)
+    #expect(throws: Never.self) { try store.delete(url: run.url) }
+    #expect(try store.list(identityKey: "k1").isEmpty)
+  }
+
   /// Spaces kept: this is what the save panel offers.
   @Test func exportFileNameCarriesModelAndDate() {
     let name = CheckupStore.exportFileName(for: report(started: 800_000_000))


### PR DESCRIPTION
Addresses #55. The issue stays open for the three- and four-external-display hardware check.

## What changed

**Excluded displays stay visible on the pick page.** A mirrored display, a virtual display, or one whose mode list is empty no longer vanishes from Checkup's pick page. Each appears unselectable with its reason spelled out in words, and Next stays blocked until a selectable display is chosen.

**An abandoned run can be deleted.** A checkup closed before its report was written now appears in the history with a delete control. The store deletes only a file exactly where it writes one, so a folder or a path outside the store is refused and left intact; the row's copy names the value as a hash, matching every other string about it on that pane.

**Escape ends a test field.** During a field, Escape ends it at once and the report records no observation for it, routed away from the answer path rather than into a dead end. The window's local key monitor is what catches it, so nothing global is installed.

**Closing the window stops the refresh sweep.** Closing Checkup mid-sweep cancels the sweep within one rate step and restores the mode it started from. When the restore does not achieve that mode and the display is still attached, the Checkup pane says so in a notice above the history, on a surface that outlives the window and only under the display the run touched; the notice clears on OK or when the next checkup starts, and a restore still settling from an earlier run cannot re-raise it.

**Setup fits three and four external displays.** The detection and OLED designation pages scroll instead of clipping, the display cards wrap into a grid that keeps the one, two and three-card geometry exactly, and the glyph row shrinks its spacing first and then its height under a width budget so four panels fit. The search runs over the width function the view actually lays out with.

**Both guided flows speak to VoiceOver.** Every page change after the first in Setup and in Checkup is announced at default priority, saying what the page is for and, in Setup, the step position; the first page is left to the window title so nothing interrupts it. The keep-or-revert bar announces its caption when it appears, speaks at a few thresholds rather than every second, never announces its own opening value, and reads the recovery instruction if the applied size diverges. Accessibility focus lands on the heading of an ordinary page and on the primary control of a timed decision page, moving to Revert when divergence lands mid-countdown; the flow's first page is left to the window title. The spoken strings come from one exhaustive switch per flow, so a page added later cannot ship silent, and no storage key is ever spoken.

## Hardware verification

Verified locally with the Dell U2725QE and MSI MAG 341C OLED attached, on a signed Release build combining the five pending fixes.

- Mirrored and virtual displays stay visible with an exclusion reason; they cannot be selected. Returning the Dell to extended mode makes it selectable again. The virtual-display check exposed a missing row in the initial implementation; the corrected picker passed the same check.
- An abandoned run can be deleted. Return defaults to Cancel; deletion removes the run after relaunch and from a later provenance export. All 18 original stored reports remained unchanged.
- Escape ends a field promptly. The next field accepts a mouse answer. This also ran with both external panels mirrored to the built-in display to exercise the one-screen instruction strip; these were input-routing checks, not claims about panel quality.
- Closing the refresh sweep stopped it within one rate step. Independent mode sampling confirmed restoration of the Dell's original resolution, framebuffer, refresh rate, rotation, and position. A full sweep separately achieved all six advertised rates and restored the original configuration.
- A warning now appears before the native-mode change and refresh sweep, explaining that the display may flicker or go dark briefly and when its settings return. It is visible in the UI and accessibility tree.
- Clicking the detection page skips the scan before its natural timer finishes. Setup's display labels, selectable OLED markers, step positions, and Checkup's labels were inspected.
- Live VoiceOver testing was deliberately skipped; accessibility labels and focus wiring were checked instead.
- The three- and four-external-display layout check needs hardware beyond this two-external-monitor desk. I am deferring this check until that hardware is available and keeping #55 open with `needs-hardware`.

The PR's engine and app suites passed (2,590 and 685 tests), as did CI and the signed Release checks. Independent final code review found no actionable regressions. Nothing was published as a release.
