### PR TITLE
Explain a write-only grade recorded before the DDC read fix

### DIFF
--- a/Candela/Checkup/CheckupCopy.swift
+++ b/Candela/Checkup/CheckupCopy.swift
@@ -68,6 +68,11 @@ enum CheckupCopy {
     }
   }
 
+  /// Saved reports are never rewritten, so a grade the app would now give
+  /// differently is explained where the report is read.
+  static let panelClassMayBeMisreadNote =
+    "\(AppInfo.productName) before \(CheckupReport.correctedReadPathVersion) sealed its DDC read requests with a checksum that some displays refuse, and recorded a display that refused as write-only. This report comes from an earlier version, so the line above may describe that defect rather than this display. A checkup run on a current version says how it classifies now."
+
   /// DDC is dead in HDR, so the line also says how to get the readback rows to run.
   static let hdrEngagedLine =
     "This display is in HDR mode, which stops DDC: readback checks will be recorded as not observed. Turn HDR off and run the checkup again to have them run."
@@ -364,7 +369,8 @@ enum CheckupCopy {
      completionLine(.complete), completionLine(.incomplete(reason: closedReason)),
      headerSentence, plantMissed(size: 4), planWorstCase(seconds: 600), secondsLeft(1),
      secondsLeft(20), summaryIncomplete(reason: closedReason), closedReason, fieldWindowTitle,
-     detectedAt(pixels: 4), hdrEngagedLine, noScreenReason, fieldNotShown,
+     detectedAt(pixels: 4), hdrEngagedLine, panelClassMayBeMisreadNote, noScreenReason,
+     fieldNotShown,
      pixelSizeLine(width: 3840, height: 2160),
      occlusionLine(fieldIDs: [CheckupCheckID.field(.black), CheckupCheckID.field(.gray7)]) ?? "",
      CheckupScenario.allCases.map(scenarioWords).joined(separator: " ")]

--- a/Candela/Checkup/CheckupSummaryText.swift
+++ b/Candela/Checkup/CheckupSummaryText.swift
@@ -55,13 +55,11 @@ enum CheckupSummaryText {
     lines.append("\(AppInfo.productName): \(report.appBuild)")
     // Its own paragraph: this sentence is why a "not observed" below is about
     // DDC, not the picture.
-    // Derived from the capability rows rather than stored twice: the pre-graded
-    // reason is the record that HDR was engaged.
-    let hdrEngaged = report.claims.contains {
-      $0.family == .capabilities
-        && $0.verdict == .notObserved(CheckupPlan.hdrEngagedCapabilityText)
-    }
-    lines += ["", CheckupCopy.panelClassLine(report.panelClass, hdrEngaged: hdrEngaged)]
+    lines += [
+      "", CheckupCopy.panelClassLine(report.panelClass, hdrEngaged: report.hdrEngagedAtRun),
+    ]
+    // No blank line: the note qualifies the line above.
+    if report.panelClassMayBeMisread { lines.append(CheckupCopy.panelClassMayBeMisreadNote) }
     return lines
   }
 

--- a/CandelaAppTests/CheckupPaneTests.swift
+++ b/CandelaAppTests/CheckupPaneTests.swift
@@ -127,6 +127,19 @@ struct CheckupPaneTests {
       plant: nil, showings: [:], exposureBookingID: nil)
   }
 
+  @Test func aWriteOnlyGradeFromAnOlderVersionIsExplainedInTheDocument() {
+    var stale = report(identityVerdict: .observed("EDID parsed"))
+    stale.appBuild = "1.0.0 (4)"
+    let text = CheckupSummaryText.render(stale)
+    #expect(text.contains(CheckupCopy.panelClassLine(.writeOnlyDDC, hdrEngaged: false)))
+    #expect(text.contains(CheckupCopy.panelClassMayBeMisreadNote))
+    #expect(!text.contains("—"))
+
+    var current = stale
+    current.appBuild = CheckupReport.correctedReadPathVersion
+    #expect(!CheckupSummaryText.render(current).contains(CheckupCopy.panelClassMayBeMisreadNote))
+  }
+
   @Test func thePaneNamesTheRunButtonAndNeverAVerdict() {
     #expect(CheckupPaneCopy.run == "Run a checkup")
     #expect(CheckupPaneCopy.verify == "Verify a report")

--- a/CandelaKit/Sources/CandelaKit/Checkup/CheckupReport.swift
+++ b/CandelaKit/Sources/CandelaKit/Checkup/CheckupReport.swift
@@ -192,6 +192,40 @@ public struct CheckupReport: Codable, Equatable, Sendable {
   }
 
   public var demonstratedSomething: Bool { summary.demonstratedSomething }
+
+  /// HDR stops DDC, so a run that began in it pre-grades the capability rows.
+  /// Derived from that reason rather than stored twice, which could disagree.
+  public var hdrEngagedAtRun: Bool {
+    claims.contains {
+      $0.family == .capabilities
+        && $0.verdict == .notObserved(CheckupPlan.hdrEngagedCapabilityText)
+    }
+  }
+
+  /// The release that ships the read-checksum fix. Earlier seals omitted the
+  /// source address, so displays that check it were graded write-only.
+  public static let correctedReadPathVersion = "1.0.4"
+
+  /// True when a write-only grade could be the pre-fix checksum, not the display.
+  /// The defect only silenced answering panels; an HDR run has its own line.
+  public var panelClassMayBeMisread: Bool {
+    guard panelClass == .writeOnlyDDC, !hdrEngagedAtRun else { return false }
+    return Self.precedesCorrectedReadPath(appBuild)
+  }
+
+  /// Compares the leading dotted-numeric run, so `1.0.0 (4)` reads as `1.0.0`.
+  /// An unreadable version counts as older and gets the note.
+  static func precedesCorrectedReadPath(_ version: String) -> Bool {
+    let numbers = Self.versionNumbers(version)
+    guard numbers.count >= 2 else { return true }
+    let corrected = Self.versionNumbers(correctedReadPathVersion)
+    for (n, c) in zip(numbers, corrected) where n != c { return n < c }
+    return numbers.count < corrected.count
+  }
+
+  static func versionNumbers(_ version: String) -> [Int] {
+    version.prefix { $0.isNumber || $0 == "." }.split(separator: ".").compactMap { Int($0) }
+  }
 }
 
 /// The exported file. The hash covers the canonical body, so a hand edit

--- a/CandelaKit/Tests/CandelaKitTests/CheckupReportTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/CheckupReportTests.swift
@@ -191,4 +191,44 @@ struct CheckupReportTests {
     #expect(!text.lowercased().contains("hostname"))
     #expect(!text.contains(NSUserName()))
   }
+
+  private func report(
+    panelClass: CheckupPanelClass, appBuild: String, claims: [CheckupClaim]? = nil
+  ) -> CheckupReport {
+    var report = sample()
+    report.panelClass = panelClass
+    report.appBuild = appBuild
+    if let claims { report.claims = claims }
+    return report
+  }
+
+  @Test func aWriteOnlyGradeFromBeforeTheReadPathFixCarriesItsExplanation() {
+    #expect(report(panelClass: .writeOnlyDDC, appBuild: "1.0.0 (4)").panelClassMayBeMisread)
+    #expect(!report(panelClass: .writeOnlyDDC, appBuild: CheckupReport.correctedReadPathVersion)
+      .panelClassMayBeMisread)
+  }
+
+  @Test func theGradesTheDefectCouldNotProduceAreLeftAlone() {
+    #expect(!report(panelClass: .readsDDC, appBuild: "1.0.0 (4)").panelClassMayBeMisread)
+    #expect(!report(panelClass: .noDDC, appBuild: "1.0.0 (4)").panelClassMayBeMisread)
+  }
+
+  /// HDR stops DDC, so write-only here is not evidence of an unanswered read.
+  @Test func aRunThatStartedInHDRIsNotSecondGuessed() {
+    let hdr = [CheckupClaim(family: .capabilities, id: CheckupCheckID.capabilityBrightness,
+                            verdict: .notObserved(CheckupPlan.hdrEngagedCapabilityText))]
+    let inHDR = report(panelClass: .writeOnlyDDC, appBuild: "1.0.0 (4)", claims: hdr)
+    #expect(inHDR.hdrEngagedAtRun)
+    #expect(!inHDR.panelClassMayBeMisread)
+  }
+
+  /// Reports on disk carry both the retired `1.0.0 (4)` form and a bare version.
+  @Test func versionOrderingReadsEveryBuildStringThisAppHasWritten() {
+    for older in ["0.1.0 (3)", "1.0.0 (4)", "1.0.0", "1.0.3", "1.0", "3", "", "?"] {
+      #expect(CheckupReport.precedesCorrectedReadPath(older), "\(older) should read as older")
+    }
+    for newer in ["1.0.4", "1.0.4 (9)", "1.0.10", "1.1.0", "2.0"] {
+      #expect(!CheckupReport.precedesCorrectedReadPath(newer), "\(newer) should read as current")
+    }
+  }
 }


### PR DESCRIPTION
Closes #103.

Candela sealed its DDC read requests with a checksum that omitted the source address. A display that validates the seal answered nothing, and the app recorded it as write-only, pre-grading the three capability rows as not observed. With the seal corrected, that display grades as readable and those rows run for real, so a saved report and a fresh one can grade the same display two different ways with nothing on the page saying why.

Nothing here migrates or rewrites a stored report. A saved report is a record of what was observed, so the discontinuity is explained where the report is read: a write-only grade that predates the correction now carries a line naming the defect and pointing at a fresh run for how the display classifies today.

Only that one grade is second-guessed. The defect could silence a panel that answers; it could never make a silent one speak, so a readable or no-DDC grade is left alone. A run that began in HDR is left alone too, because HDR stops DDC and that line already says the grade was not taken from a live read.

Vintage is read from the build string the report already carries, compared on its leading dotted-numeric run so the retired `1.0.0 (4)` form orders as `1.0.0`. A string that yields no major and minor counts as older, so an unrecognised vintage carries the explanation rather than silent trust. No new key is written to the report: the envelope validates a body against the exact set of keys it was written with, so a key added here would make every new report fail verification on an older build, which is precisely the cross-version case that feature exists for.

`correctedReadPathVersion` is a literal that names the release shipping the read-checksum fix. It has to move by hand if that fix slips a release.

## Verification

Both suites pass: 2574 engine tests, 638 app tests. Each new test was proved able to fail by neutering the predicate and watching the engine and app suites go red.

Targeting was checked against the real reports saved on this machine rather than fixtures alone. Of 17 stored runs, the note lands on 4: the write-only runs for the OLED panel that were not taken in HDR. The 5 HDR runs for the same panel keep the HDR line, and all 6 runs for the display that answers DDC, plus both built-in runs, are untouched.

Left for the hardware pass, since it needs the read fix deployed: a fresh checkup on that panel showing the capability rows graded for real, read side by side with an older report, and the older file unchanged on disk.
