### PR TITLE
Put the capabilities request behind the transport seam and pin its bytes

### DIFF
--- a/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
+++ b/CandelaKit/Sources/CandelaKit/DDC/Arm64DDC.swift
@@ -189,7 +189,7 @@ public class Arm64DDC: NSObject {
   /// This cannot go through `performDDCCommunication`. That function encodes the
   /// message as `[0x80 | (send.count + 1)][send.count][send…]`, which works only
   /// because Get VCP is op 0x01 with one parameter and Set VCP is op 0x03 with
-  /// three — the op code IS the parameter count, by coincidence. 0xF3 with two
+  /// three: the op code IS the parameter count, by coincidence. 0xF3 with two
   /// offset bytes breaks the coincidence, so the packet is built here.
   ///
   /// Returns the fragment's payload, `[]` for the terminator, or `nil` when the
@@ -203,30 +203,45 @@ public class Arm64DDC: NSObject {
     retrySleepTime: UInt32? = nil
   ) -> [UInt8]? {
     guard service != nil else { return nil }
-    let dataAddress = ARM64_DDC_DATA_ADDRESS
+    return self.runCapabilityRequest(
+      service: service, offset: offset, writeSleepTime: writeSleepTime,
+      readSleepTime: readSleepTime, numOfRetryAttempts: numOfRetryAttempts,
+      retrySleepTime: retrySleepTime, transport: .live
+    )
+  }
+
+  /// The capabilities ladder. Split from the entry point so a nil service is
+  /// refused before any sleep, and so a test can see the hand-built packet.
+  static func runCapabilityRequest(
+    service: IOAVService?,
+    offset: UInt16,
+    writeSleepTime: UInt32?,
+    readSleepTime: UInt32?,
+    numOfRetryAttempts: UInt8,
+    retrySleepTime: UInt32?,
+    transport: I2CTransport
+  ) -> [UInt8]? {
     // [0x80 | messageLength][op][offsetHi][offsetLo][checksum]
     var packet: [UInt8] = [0x80 | 3, 0xF3, UInt8(offset >> 8), UInt8(offset & 0xFF), 0]
     // Neither I2C address travels inside the packet, so both seed the checksum.
     packet[packet.count - 1] = self.checksum(
-      chk: ARM64_DDC_7BIT_ADDRESS << 1 ^ dataAddress, data: &packet, start: 0, end: packet.count - 2
+      chk: ARM64_DDC_7BIT_ADDRESS << 1 ^ ARM64_DDC_DATA_ADDRESS,
+      data: &packet, start: 0, end: packet.count - 2
     )
     // Max frame: source + length byte + (op + 2 offset + 32 payload) + checksum.
     var reply = [UInt8](repeating: 0, count: 38)
     for _ in 0 ... numOfRetryAttempts {
-      usleep(writeSleepTime ?? 10000)
-      guard IOAVServiceWriteI2C(service, UInt32(ARM64_DDC_7BIT_ADDRESS), UInt32(dataAddress),
-                                &packet, UInt32(packet.count)) == 0
-      else {
-        usleep(retrySleepTime ?? 20000)
+      transport.sleep(writeSleepTime ?? 10000)
+      guard transport.write(service, &packet, UInt32(packet.count)) == 0 else {
+        transport.sleep(retrySleepTime ?? 20000)
         continue
       }
-      usleep(readSleepTime ?? 50000)
-      if IOAVServiceReadI2C(service, UInt32(ARM64_DDC_7BIT_ADDRESS), 0,
-                            &reply, UInt32(reply.count)) == 0,
+      transport.sleep(readSleepTime ?? 50000)
+      if transport.read(service, &reply, UInt32(reply.count)) == 0,
         let fragment = CapabilityString.fragment(fromFrame: reply, expectedOffset: offset) {
         return fragment
       }
-      usleep(retrySleepTime ?? 20000)
+      transport.sleep(retrySleepTime ?? 20000)
     }
     return nil
   }

--- a/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/DDCReadOutcomeTests.swift
@@ -645,3 +645,43 @@ private func recoveredSeed(_ packet: [UInt8]) -> UInt8 {
   #expect(recoveredSeed(read) == ddcDestinationAddress ^ ddcSourceAddress)
   #expect(recoveredSeed(write) == recoveredSeed(read))
 }
+
+private func firstCapabilityPacket(offset: UInt16) -> [UInt8]? {
+  let recorder = PacketRecorder()
+  _ = Arm64DDC.runCapabilityRequest(
+    service: nil, offset: offset, writeSleepTime: 0, readSleepTime: 0,
+    numOfRetryAttempts: 0, retrySleepTime: 0, transport: recorder.transport
+  )
+  return recorder.packets.first
+}
+
+/// This packet is built by hand, not by `runTransaction`, so its seal needs its
+/// own pin. Expected byte comes from the spec by hand, not from `checksum`.
+@Test func aCapabilitiesRequestIsSealedOverBothAddresses() {
+  // [0x80 | 3][op 0xF3][offset hi][offset lo][checksum]
+  let lengthByte: UInt8 = 0x83
+  let capabilities: UInt8 = 0xF3
+  let expected = ddcDestinationAddress ^ ddcSourceAddress ^ lengthByte ^ capabilities
+  #expect(expected == 0x4F)
+  #expect(firstCapabilityPacket(offset: 0) == [0x83, 0xF3, 0x00, 0x00, expected])
+}
+
+/// Both offset bytes seed the checksum, so a later fragment cannot reuse the first's seal.
+@Test func aLaterFragmentSealsItsOwnOffset() {
+  let expected = ddcDestinationAddress ^ ddcSourceAddress ^ 0x83 ^ 0xF3 ^ 0x01 ^ 0x20
+  #expect(firstCapabilityPacket(offset: 0x0120) == [0x83, 0xF3, 0x01, 0x20, expected])
+  #expect(firstCapabilityPacket(offset: 0x0120)?.last != firstCapabilityPacket(offset: 0)?.last)
+}
+
+/// Recovered from the bytes rather than the expression, so a capabilities
+/// request drifting from the other two is caught whatever shape the drift takes.
+@Test func theCapabilitiesRequestSharesTheOneSeed() {
+  guard let caps = firstCapabilityPacket(offset: 0),
+        let read = firstPacket(send: [0x10], expectsReply: true)
+  else {
+    Issue.record("no packet reached the bus")
+    return
+  }
+  #expect(recoveredSeed(caps) == ddcDestinationAddress ^ ddcSourceAddress)
+  #expect(recoveredSeed(caps) == recoveredSeed(read))
+}


### PR DESCRIPTION
Closes #102.

The DDC/CI capabilities request builds its own packet, because the generic encoder writes a data length where op 0xF3 needs an op code. It also called the private I2C functions directly, so nothing but a monitor on a desk could see the bytes it put on the wire. Its checksum seed was corrected in #101 and has been held right since by hardware alone; a revert would reach a panel unseen.

This splits it the way the Get and Set VCP path already is: the entry point refuses a nil service and hands over the live transport, and the work moves behind the injectable one. The live transport calls the same two functions with the same I2C addresses and sleeps through the same `usleep`, so the wire is unchanged.

Three tests over the packet:

- the offset zero request byte for byte, `[0x83, 0xF3, 0x00, 0x00, 0x4F]`, with the checksum worked out from the two I2C addresses by hand rather than from our own `checksum` function, so the assertion is not circular
- both offset bytes entering the seal, so a fragment past the first cannot travel carrying the first one's checksum
- the seed recovered from the bytes and matched against the Get VCP path, so a divergence between the two request paths is caught whatever shape it takes

While touching this function, its doc comment lost the one em dash it carried, per the house rule to fix those where you touch them.

## Verification

Both suites pass: 2577 engine tests, 637 app tests.

The check the issue asks for was run: reverting the seed to the value it carried before the source address was added fails all three new tests, and the seed recovered from the wire reads back as 0x6E, the pre-fix value. Restoring it returns the suite to green.

Not run: the hardware confirmation that a panel which answers DDC still returns a capability string that parses. No external display is attached right now, so the probe reports only the built-in panel and there is nothing on the bus to ask. Tracked on the issue with `needs-hardware`.
