### PR TITLE
Show an error when a saved checkup cannot be deleted

### DIFF
--- a/Candela/Settings/CheckupPane.swift
+++ b/Candela/Settings/CheckupPane.swift
@@ -41,6 +41,7 @@ enum CheckupPaneCopy {
   static let deleteTitle = "Delete this checkup?"
   static let deleteConfirm = "Delete"
   static let deleteCancel = "Cancel"
+  static let deleteFailed = "The checkup could not be deleted."
   static let deleteConsequences =
     "This run's file is removed from this Mac. Other runs on this display are kept, and a report "
     + "you already exported somewhere else is untouched.\n\nA provenance record bundles every checkup "
@@ -86,7 +87,7 @@ enum CheckupPaneCopy {
   static var allStringsForTest: [String] {
     [title, subtitle, runTitle, run, runNote, restoreNotAchieved, historyTitle, emptyHistory,
      historyNote, export, copySummary, copied, showDetails, hideDetails, exportFailed,
-     acknowledge, deleteRun, deleteTitle, deleteConfirm, deleteCancel, deleteConsequences,
+     acknowledge, deleteRun, deleteTitle, deleteConfirm, deleteCancel, deleteFailed, deleteConsequences,
      verifyTitle, verify, verifyNote, valid, invalid, unreadable,
      deleteRunLabel(for: sampleReport)]
   }
@@ -132,6 +133,7 @@ struct CheckupPane: View {
   /// while the pane is open moves the history to its display.
   @State private var chosenByHand = false
   @State private var runs: [CheckupStoredRun] = []
+  @State private var deleteError: String?
   @State private var verification: String?
   /// Held apart from the summary: the verdict is a sentence, the summary a document.
   @State private var provenanceVerdict: String?
@@ -153,6 +155,14 @@ struct CheckupPane: View {
       verifySection
     }
     .onAppear { refresh() }
+    .alert(
+      CheckupPaneCopy.deleteFailed,
+      isPresented: Binding(get: { deleteError != nil }, set: { if !$0 { deleteError = nil } })
+    ) {
+      Button(CheckupPaneCopy.acknowledge) { deleteError = nil }
+    } message: {
+      Text(verbatim: deleteError ?? "")
+    }
     // Keyed on the RESOLVED display, so a departure and a picker change hit one
     // observer. The verification line goes too: it answered under another display.
     .onChange(of: scoped?.display.persistenceKey) {
@@ -270,8 +280,17 @@ struct CheckupPane: View {
   /// Re-reading through `reload()` keeps one code path for what the history
   /// shows: a delete that did not happen leaves its row standing.
   private func delete(_ run: CheckupStoredRun) {
-    try? store.delete(url: run.url)
+    deleteError = Self.delete(run, from: store)
     reload()
+  }
+
+  static func delete(_ run: CheckupStoredRun, from store: CheckupStore) -> String? {
+    do {
+      try store.delete(url: run.url)
+      return nil
+    } catch {
+      return error.localizedDescription
+    }
   }
 
   // MARK: - History

--- a/CandelaAppTests/CheckupPaneTests.swift
+++ b/CandelaAppTests/CheckupPaneTests.swift
@@ -183,6 +183,31 @@ struct CheckupPaneTests {
     #expect(CheckupPaneCopy.deleteRunLabel(for: subject) != CheckupPaneCopy.deleteRun)
   }
 
+  @Test @MainActor func aRefusedDeleteReportsItsErrorAndCanBeRetried() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("checkup-delete-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let store = CheckupStore(directory: directory)
+    let envelope = try CheckupReportEnvelope(report: report(identityVerdict: .observed("EDID parsed")))
+    let url = try store.save(envelope)
+    let run = try #require(store.list(identityKey: "k").first)
+    let folder = url.deletingLastPathComponent()
+    try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: folder.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: folder.path)
+    }
+
+    let message = CheckupPane.delete(run, from: store)
+    #expect(message?.isEmpty == false)
+    #expect(try store.load(url: url) == envelope)
+    #expect(try store.list(identityKey: "k").map(\.url) == [url])
+
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: folder.path)
+    #expect(CheckupPane.delete(run, from: store) == nil)
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+    #expect(try store.list(identityKey: "k").isEmpty)
+  }
+
   /// No "this app" in user copy: the product has a name, and each display has a
   /// page under it.
   @Test func theRestoreNoticeNamesTheProductAndTheDisplaysOwnPage() {


### PR DESCRIPTION
A refused delete now shows "The checkup could not be deleted." with the underlying error. The report remains in history, and deleting it succeeds after the file restriction is removed. Export keeps its existing error alert.

Verification:
- A regression test uses a real read-only report folder, confirms that the error is returned and the report stays intact, then restores permissions and retries successfully. It failed on the previous silent-error behavior.
- All 2,632 engine tests and 763 app tests pass. Required CI, the Release build, signing verification, and the debug-marker gate pass.
- In the locally installed signed build, a protected disposable report produces the delete error, stays in history, and disappears without an error after removing the restriction and retrying. The same failure was silent in the previous build.
- Export to a restricted temporary destination still shows its own save-error alert after dismissing the delete error. Temporary files and restrictions were removed, and all 18 pre-existing reports retain their original hashes.

Fixes #106.
