### PR TITLE
Read observed updater state on the main actor

### DIFF
--- a/Candela/App/UpdaterModel.swift
+++ b/Candela/App/UpdaterModel.swift
@@ -45,15 +45,13 @@ final class UpdaterModel {
     lastUpdateCheckDate = controller.updater.lastUpdateCheckDate
     canCheckObservation = controller.updater.observe(
       \.canCheckForUpdates, options: [.initial, .new]
-    ) { [weak self] updater, _ in
-      // KVO delivers on the main thread here, but the closure is nonisolated;
-      // hop rather than assume. Re-reading the check date on every flip is what
-      // refreshes "Last checked".
-      let canCheck = updater.canCheckForUpdates
-      let lastCheck = updater.lastUpdateCheckDate
+    ) { [weak self] _, _ in
+      // KVO's closure is nonisolated. Read Sparkle's current state after the
+      // main-actor hop so both reads and the observed writes share its isolation.
       Task { @MainActor [weak self] in
-        self?.canCheckForUpdates = canCheck
-        self?.lastUpdateCheckDate = lastCheck
+        guard let self else { return }
+        self.canCheckForUpdates = self.controller.updater.canCheckForUpdates
+        self.lastUpdateCheckDate = self.controller.updater.lastUpdateCheckDate
       }
     }
   }


### PR DESCRIPTION
The updater observation callback read Sparkle's main-actor properties before switching to the main actor, producing two concurrency warnings. Read `canCheckForUpdates` and `lastUpdateCheckDate` inside the existing main-actor task instead, through the model's controller. The callback continues to hold the model weakly.

A clean Release build reports zero warnings from `UpdaterModel.swift`, compared with the two reported warnings in the previous build. Both test suites pass: 2,632 engine tests and 763 app tests, including the update reminder tests. No monitor checks or local update installation are required for this change.

Fixes #93.
