### PR TITLE
Clear layout save refusal when the blocking operation ends

### DIFF
--- a/Candela/App/ArrangementCoordinator.swift
+++ b/Candela/App/ArrangementCoordinator.swift
@@ -73,6 +73,7 @@ final class ArrangementCoordinator {
   /// notice and takes the save away with nothing saved. The refusal travels as a
   /// caption under the button instead.
   private(set) var saveRefusedBy: ReconfigurationClaimant?
+  @ObservationIgnored private var saveRefusalTask: Task<Void, Never>?
 
   @ObservationIgnored weak var confirmation: (any ArrangementConfirmationPresenting)?
   /// Called after a commit actually wrote `savedArrangements`, so the propagation
@@ -226,6 +227,7 @@ final class ArrangementCoordinator {
   deinit {
     countdown.stop()
     queue.cancel()
+    saveRefusalTask?.cancel()
   }
 
   // MARK: - Sampling
@@ -377,7 +379,20 @@ final class ArrangementCoordinator {
   /// notice's save button, so it has to leave with the notice.
   private func setRestoreNotice(_ notice: ArrangementReapplyNotice?) {
     restoreNotice = notice
-    if notice == nil { saveRefusedBy = nil }
+    if notice == nil { setSaveRefusal(nil) }
+  }
+
+  private func setSaveRefusal(_ holder: ReconfigurationClaimant?) {
+    saveRefusalTask?.cancel()
+    saveRefusalTask = nil
+    saveRefusedBy = holder
+    guard let holder else { return }
+    saveRefusalTask = Task { [weak self, gate] in
+      await gate.waitForRelease(of: holder)
+      // A new save or a dismissed notice supersedes this particular refusal.
+      guard !Task.isCancelled else { return }
+      self?.saveRefusedBy = nil
+    }
   }
 
   // MARK: - Operations (always inside the queue)
@@ -586,7 +601,7 @@ final class ArrangementCoordinator {
     let revision = rememberRequestRevision
     queue.enqueue {
       // Whatever refused the last save is stale once this one dequeues.
-      self.saveRefusedBy = nil
+      self.setSaveRefusal(nil)
       guard revision == self.rememberRequestRevision else { return }
       // Before the gate, so a save with the setting off is a clean no-op rather
       // than a report about work that would do nothing.
@@ -597,11 +612,11 @@ final class ArrangementCoordinator {
       // Both refusals publish `saveRefusedBy` and sync nothing, since the report
       // card's button would clear the notice this save exists to answer.
       guard await self.session.previewedArrangement == nil else {
-        self.saveRefusedBy = .arrangement
+        self.setSaveRefusal(.arrangement)
         return
       }
       if let holder = await self.gate.claim(.arrangement).refusedBy {
-        self.saveRefusedBy = holder
+        self.setSaveRefusal(holder)
         return
       }
       // Re-read, never whatever `arrangement` was holding: this saves what is on

--- a/CandelaAppTests/SavedLayoutConfirmationTests.swift
+++ b/CandelaAppTests/SavedLayoutConfirmationTests.swift
@@ -202,7 +202,8 @@ struct SavedLayoutConfirmationTests {
     }
   }
 
-  @Test func savingDuringAnOutstandingPreviewSavesNothingAndSaysWhoBlockedIt() async throws {
+  @Test(arguments: [true, false])
+  func savingDuringAnOutstandingPreviewSavesNothingAndSaysWhoBlockedIt(keeping: Bool) async throws {
     try await withCoordinator { coordinator, store, rig, gate in
       coordinator.setRestoringLayout(true)
       await coordinator.restoreSavedArrangement()
@@ -223,14 +224,21 @@ struct SavedLayoutConfirmationTests {
       #expect(coordinator.blockedBy == nil)
       // Not merely "no new record": the stored layout is the one saved before.
       #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == saved)
-      #expect(await rotation.revert(preview) == .reverted)
+      // Applying a rotation can notify before its confirmation is answered.
+      coordinator.displaysChanged()
+      await coordinator.restoreSavedArrangement()
+      #expect(coordinator.saveRefusedBy == .rotation)
+      let outcome = keeping ? await rotation.confirm(preview) : await rotation.revert(preview)
+      #expect(outcome == (keeping ? .committed : .reverted))
+      await expectSaveRefusalToClear(coordinator)
     }
   }
 
   /// The gate cannot cover this branch: a claim by the claimant already holding the
   /// gate is GRANTED, so an outstanding ARRANGEMENT preview gets past `gate.claim`
   /// and only the preview guard stops the save.
-  @Test func savingDuringAnOutstandingArrangementPreviewLeavesTheRecordAndThePreviewAlone() async throws {
+  @Test(arguments: [true, false])
+  func savingDuringAnOutstandingArrangementPreviewLeavesTheRecordAndThePreviewAlone(keeping: Bool) async throws {
     try await withCoordinator { coordinator, store, rig, gate in
       coordinator.setRestoringLayout(true)
       await coordinator.restoreSavedArrangement()
@@ -254,8 +262,39 @@ struct SavedLayoutConfirmationTests {
       // user nothing.
       #expect(coordinator.preview?.value == preview.value)
       #expect(await gate.holder == .arrangement)
-      #expect(await coordinator.revert(preview) == .reverted)
+      let outcome = keeping ? await coordinator.confirm(preview) : await coordinator.revert(preview)
+      #expect(outcome == (keeping ? .committed : .reverted))
+      await expectSaveRefusalToClear(coordinator)
     }
+  }
+
+  @Test(arguments: [ReconfigurationClaimant.rotation, .mirroring, .displayModes])
+  func endingTheBlockerClearsOnlyTheRefusalWithoutSaving(holder: ReconfigurationClaimant) async throws {
+    try await withCoordinator { coordinator, store, rig, gate in
+      coordinator.setRestoringLayout(true)
+      await coordinator.restoreSavedArrangement()
+      await reconnect(coordinator, rig, showing: Self.widening(rig.currentArrangement(), 2, by: 200))
+      let notice = try #require(coordinator.restoreNotice)
+      let saved = try #require(store.savedArrangement(for: TopologySignature(rig.currentArrangement())))
+      #expect(await gate.claim(holder) == .granted)
+      coordinator.saveCurrentLayout()
+      await coordinator.restoreSavedArrangement()
+      #expect(coordinator.saveRefusedBy == holder)
+
+      await gate.release(holder)
+      await expectSaveRefusalToClear(coordinator)
+      #expect(coordinator.restoreNotice == notice)
+      #expect(store.savedArrangement(for: TopologySignature(rig.currentArrangement())) == saved)
+    }
+  }
+
+  private func expectSaveRefusalToClear(_ coordinator: ArrangementCoordinator) async {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(1))
+    while coordinator.saveRefusedBy != nil, clock.now < deadline {
+      try? await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(coordinator.saveRefusedBy == nil)
   }
 
   /// A reconnect in the two steps the bookkeeping needs: a sample taken while the

--- a/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayReconfigurationGate.swift
+++ b/CandelaKit/Sources/CandelaKit/DisplayConfig/DisplayReconfigurationGate.swift
@@ -80,12 +80,26 @@ public enum ReconfigurationClaimOutcome: Sendable, Equatable {
 /// reconciles from is not main-actor-confined in the first place.
 public actor DisplayReconfigurationGate {
   private var claimant: ReconfigurationClaimant?
+  private var releaseWaiters: [UUID: AsyncStream<Void>.Continuation] = [:]
 
   public init() {}
 
   /// Who holds the gate. Exists for test assertions; the app names a holder from
   /// `ReconfigurationClaimOutcome.refusedBy` instead.
   public var holder: ReconfigurationClaimant? { claimant }
+
+  /// Waits until this holder releases the gate, or the waiting task is cancelled.
+  /// Returns immediately if the named holder has already finished. Display-change
+  /// notifications are not a substitute: they can arrive while a preview still
+  /// holds the gate, and keeping a preview need not post another notification.
+  public func waitForRelease(of claimant: ReconfigurationClaimant) async {
+    guard self.claimant == claimant, !Task.isCancelled else { return }
+    let id = UUID()
+    let (stream, continuation) = AsyncStream<Void>.makeStream()
+    releaseWaiters[id] = continuation
+    defer { releaseWaiters[id] = nil }
+    for await _ in stream {}
+  }
 
   /// Takes the gate for `claimant`, or refuses and names the holder.
   ///
@@ -106,5 +120,8 @@ public actor DisplayReconfigurationGate {
   public func release(_ claimant: ReconfigurationClaimant) {
     guard self.claimant == claimant else { return }
     self.claimant = nil
+    let waiters = releaseWaiters.values
+    releaseWaiters.removeAll()
+    for waiter in waiters { waiter.finish() }
   }
 }


### PR DESCRIPTION
## What

Clear the "Save This Layout" refusal caption when the display operation blocking it finishes. Keep the stale-layout notice and its Save button available, without automatically saving anything.

## Why

The caption previously stayed after answering a rotation or arrangement preview, until the next Save click. It now waits for the blocking operation to release the shared reconfiguration gate. Display-change notifications can arrive before a preview ends, and keeping a preview does not require another notification.

A new save or a dismissed notice cancels the previous wait, so an old refusal cannot clear a newer one.

Fixes #97.

## Hardware verification

This change only updates a settings caption's lifetime. Display configuration and monitor I/O are unchanged. `SavedLayoutConfirmationTests` exercises the real coordinators, preview sessions, and gate with scripted display I/O:

- Keep and Revert both clear the caption after rotation and arrangement previews.
- A display-change notification while a rotation preview remains open leaves the caption visible.
- Releasing rotation, mirroring, or display-mode operations clears the caption while preserving the stale-layout notice and saved record.

All seven regression cases failed against the previous code and pass with the fix. No additional physical-monitor check was needed for this change.

## Checks

- [x] `make check` passes: 2,632 engine tests and 764 app tests
- [x] `make markers` passes: Release build and debug-marker check
- [x] Tests cover the new logic
- [x] No ticket numbers in source comments, and no em dashes in user-visible text or new comments
