### PR TITLE
Show paused OLED care in the Protection summary

### DIFF
--- a/Candela/Settings/ProtectionPane.swift
+++ b/Candela/Settings/ProtectionPane.swift
@@ -58,9 +58,9 @@ struct ProtectionPane: View {
   }
 
   /// Both values from one read, so the sighted and the spoken form cannot
-  /// answer different enrollment counts.
+  /// answer different care states.
   private var dimmingRowValues: (value: String, spokenValue: String) {
-    Self.dimmingRow(enrolledCount: enrolledExternalCount(), isSafeMode: model.isSafeMode)
+    Self.dimmingRow(enrolledStates: enrolledExternalStates(), isSafeMode: model.isSafeMode)
   }
 
   /// Verbatim rather than a key: the test bundle reads this string directly.
@@ -69,10 +69,8 @@ struct ProtectionPane: View {
     + "dimming, fading idle screens and static regions so they are not left lit at full "
     + "brightness for hours."
 
-  /// The count half only. Safe mode outranks it and that branch lives in
-  /// `dimmingRow`, so a view calling this one directly would claim dimming in a
-  /// session where the care loop is not running. "Off" is the Remembered Sizes
-  /// summary's word for the same shape of answer, so the two sections agree.
+  /// The enabled count when care is running. Pauses are reported separately by
+  /// `dimmingRow`, so suspended displays are never included in this count.
   static func dimmingRowValue(enrolledCount: Int) -> String {
     switch enrolledCount {
     case 0: "Off"
@@ -81,26 +79,33 @@ struct ProtectionPane: View {
     }
   }
 
-  /// What the row draws and what VoiceOver reads. Enrollment answers first, so
-  /// nothing enrolled reads "Off" in either kind of session. Safe mode then
-  /// outranks the count, since the care loop is not running: the display hub's
-  /// preview already says Paused for the same state, in these words.
+  /// Enrollment answers first, then Safe Mode, then the care coordinator's
+  /// published states. A partial pause keeps the active display count visible.
   static func dimmingRow(
-    enrolledCount: Int, isSafeMode: Bool
+    enrolledStates: [OledDimState?], isSafeMode: Bool
   ) -> (value: String, spokenValue: String) {
+    let enrolledCount = enrolledStates.count
     let counted = dimmingRowValue(enrolledCount: enrolledCount)
-    guard enrolledCount > 0, isSafeMode else { return (counted, counted) }
-    return ("Paused", "Paused for this session, Safe Mode")
+    guard enrolledCount > 0 else { return (counted, counted) }
+    if isSafeMode { return ("Paused", "Paused for this session, Safe Mode") }
+    let paused = enrolledStates.filter { $0 == .suspended }.count
+    guard paused > 0 else { return (counted, counted) }
+    if paused == enrolledCount {
+      let displays = paused == 1 ? "1 display" : "\(paused) displays"
+      return ("Paused", "Paused for \(displays)")
+    }
+    let mixed = "\(dimmingRowValue(enrolledCount: enrolledCount - paused)), \(paused) paused"
+    return (mixed, mixed)
   }
 
   /// Nothing publishes enrollment, so this is a live read per display. The
   /// `prefsRevision` read at the top of `body` is what refreshes the row when
   /// enrollment changes elsewhere in the window. `model.displays` is externals
   /// only, which is all OLED care enrolls.
-  private func enrolledExternalCount() -> Int {
+  private func enrolledExternalStates() -> [OledDimState?] {
     model.displays.filter {
       DisplayPrefs(persistenceKey: $0.display.persistenceKey).oledCareEnrolled
-    }.count
+    }.map { model.oledCare.dimStates[$0.display.persistenceKey] }
   }
 
   // MARK: - Startup

--- a/CandelaAppTests/ProtectionPaneTests.swift
+++ b/CandelaAppTests/ProtectionPaneTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CandelaKit
 import SwiftUI
 import Testing
@@ -76,14 +77,67 @@ struct ProtectionPaneTests {
   /// enrollment as if it were running. The words are the display hub preview's.
   /// Enrollment still answers first: nothing enrolled reads "Off" either way.
   @Test func theDimmingRowSaysPausedInASafeModeSession() {
-    let paused = ProtectionPane.dimmingRow(enrolledCount: 2, isSafeMode: true)
+    let paused = ProtectionPane.dimmingRow(enrolledStates: [.active, .active], isSafeMode: true)
     #expect(paused.value == "Paused")
     #expect(paused.spokenValue == "Paused for this session, Safe Mode")
-    #expect(ProtectionPane.dimmingRow(enrolledCount: 0, isSafeMode: true).value == "Off")
+    #expect(ProtectionPane.dimmingRow(enrolledStates: [], isSafeMode: true).value == "Off")
 
-    let running = ProtectionPane.dimmingRow(enrolledCount: 2, isSafeMode: false)
+    let running = ProtectionPane.dimmingRow(enrolledStates: [.active, .active], isSafeMode: false)
     #expect(running.value == "On for 2 displays")
     #expect(running.spokenValue == running.value)
+  }
+
+  @Test func theDimmingRowTracksSuspensionAndResumption() {
+    let paused = ProtectionPane.dimmingRow(enrolledStates: [.suspended], isSafeMode: false)
+    #expect(paused.value == "Paused")
+    #expect(paused.spokenValue == "Paused for 1 display")
+    let resumed = ProtectionPane.dimmingRow(enrolledStates: [.active], isSafeMode: false)
+    #expect(resumed.value == "On for 1 display")
+  }
+
+  @Test func aPartialPauseDoesNotHideTheDisplaysStillBeingProtected() {
+    let mixed = ProtectionPane.dimmingRow(enrolledStates: [.idleDim, .suspended, .suspended], isSafeMode: false)
+    #expect(mixed.value == "On for 1 display, 2 paused")
+    #expect(mixed.spokenValue == mixed.value)
+    let all = ProtectionPane.dimmingRow(enrolledStates: [.suspended, .suspended], isSafeMode: false)
+    #expect(all.value == "Paused")
+    #expect(all.spokenValue == "Paused for 2 displays")
+  }
+
+  @Test func ordinaryCareStatesAndStartupStillCountAsEnabled() {
+    let states: [OledDimState?] = [.active, .idleDim, .blackout, .lockDim, .unfocusedDim, nil]
+    for state in states {
+      #expect(ProtectionPane.dimmingRow(enrolledStates: [state], isSafeMode: false).value == "On for 1 display")
+    }
+  }
+
+  @Test func pausedRowsPublishTheirSpokenValue() {
+    _ = NSApplication.shared
+    (NSApp as NSObject).accessibilitySetValue(
+      true, forAttribute: NSAccessibility.Attribute(rawValue: "AXEnhancedUserInterface"))
+    for states: [OledDimState?] in [[.suspended], [.active, .suspended, .suspended]] {
+      let row = ProtectionPane.dimmingRow(enrolledStates: states, isSafeMode: false)
+      let host = NSHostingView(rootView: NavigationRow(
+        title: "OLED Care", value: row.value, spokenValue: row.spokenValue, action: {})
+        .frame(width: 480, height: 80))
+      host.frame = NSRect(x: 0, y: 0, width: 480, height: 80)
+      host.layoutSubtreeIfNeeded()
+      var values: [String] = []
+      func collect(_ element: Any, depth: Int = 0) {
+        guard depth < 24 else { return }
+        let object = element as AnyObject
+        if (object.accessibilityRole?() ?? nil) == .button,
+           let accessible = object as? NSObject,
+           let value = accessible.perform(NSSelectorFromString("accessibilityValue"))?.takeUnretainedValue() as? String {
+          values.append(value)
+        }
+        for child in (object.accessibilityChildren?() ?? nil) ?? [] {
+          collect(child, depth: depth + 1)
+        }
+      }
+      collect(host)
+      #expect(values == [row.spokenValue])
+    }
   }
 
   // MARK: - The startup caption


### PR DESCRIPTION
## What

Make the Protection page's OLED Care row reflect the care coordinator's published dimming states. It says "Paused" when all enrolled displays are suspended, including pauses outside Safe Mode. If some are still active, it shows the active count and the paused count.

## Why

The row previously counted enrollment alone, so it said care was on even when the display hub correctly showed it was paused. Enrollment still decides "Off", and Safe Mode retains its existing spoken explanation.

Fixes #96.

## Hardware verification

This changes a summary label only. The dimming engine and monitor I/O are unchanged. Automated cases cover suspension and resumption, partial and complete pauses, ordinary dimming states, startup, and Safe Mode. The native accessibility tree is checked for the row's spoken values. Live VoiceOver is omitted as agreed.

## Checks

- [x] Engine suite passes: 2,632 tests
- [x] App suite passes: 768 tests
- [x] Release build and debug-marker check pass
- [x] Tests cover the new logic
- [x] No ticket numbers in source comments, and no em dashes in user-visible text or new comments
