### PR TITLE
Choose one survivor when Candela copies launch together

### DIFF
--- a/Candela/AppKitIslands/SingleInstanceGuard.swift
+++ b/Candela/AppKitIslands/SingleInstanceGuard.swift
@@ -30,11 +30,13 @@ enum SingleInstanceGuard {
       .filter { !$0.isTerminated }
       .map {
         SingleInstancePolicy.Instance(
-          processIdentifier: $0.processIdentifier, bundlePath: $0.bundleURL?.path
+          processIdentifier: $0.processIdentifier, bundlePath: $0.bundleURL?.path,
+          launchDate: $0.launchDate
         )
       }
     let decision = SingleInstancePolicy.decide(
-      running: running, ownProcessIdentifier: NSRunningApplication.current.processIdentifier
+      running: running, ownProcessIdentifier: NSRunningApplication.current.processIdentifier,
+      ownLaunchDate: NSRunningApplication.current.launchDate
     )
     guard case let .terminate(runningBundlePath) = decision else { return }
 

--- a/CandelaKit/Sources/CandelaKit/Support/SingleInstancePolicy.swift
+++ b/CandelaKit/Sources/CandelaKit/Support/SingleInstancePolicy.swift
@@ -14,10 +14,12 @@ public enum SingleInstancePolicy {
     /// Nil when the location cannot be read. That is not evidence of anything:
     /// it is still a running copy.
     public let bundlePath: String?
+    public let launchDate: Date?
 
-    public init(processIdentifier: Int32, bundlePath: String?) {
+    public init(processIdentifier: Int32, bundlePath: String?, launchDate: Date? = nil) {
       self.processIdentifier = processIdentifier
       self.bundlePath = bundlePath
+      self.launchDate = launchDate
     }
   }
 
@@ -31,9 +33,27 @@ public enum SingleInstancePolicy {
   /// An empty list proceeds, which is also what a failed enumeration looks like: a
   /// missed second copy costs interleaved DDC writes, while a false positive locks
   /// someone out of the app with no route back from the UI.
-  public static func decide(running: [Instance], ownProcessIdentifier: Int32) -> Decision {
+  public static func decide(
+    running: [Instance], ownProcessIdentifier: Int32, ownLaunchDate: Date? = nil
+  ) -> Decision {
     let others = running.filter { $0.processIdentifier != ownProcessIdentifier }
-    guard let first = others.first else { return .proceed }
-    return .terminate(runningBundlePath: first.bundlePath)
+    guard !others.isEmpty else { return .proceed }
+    // Include this process even if Launch Services has not listed it yet.
+    // Preserve a listed entry even when its date is nil: filling it in only for
+    // ourselves could make two copies choose different orderings for one snapshot.
+    let own = running.first { $0.processIdentifier == ownProcessIdentifier }
+      ?? Instance(processIdentifier: ownProcessIdentifier, bundlePath: nil, launchDate: ownLaunchDate)
+    let candidates = others + [own]
+    // Choose one ordering for the whole set. Mixing date and PID comparisons
+    // pair by pair when a date is missing can make the comparison non-transitive.
+    let datesAvailable = candidates.allSatisfy { $0.launchDate != nil }
+    let winner = candidates.min {
+      if datesAvailable, let lhs = $0.launchDate, let rhs = $1.launchDate, lhs != rhs {
+        return lhs < rhs
+      }
+      return $0.processIdentifier < $1.processIdentifier
+    }!
+    return winner.processIdentifier == ownProcessIdentifier
+      ? .proceed : .terminate(runningBundlePath: winner.bundlePath)
   }
 }

--- a/CandelaKit/Tests/CandelaKitTests/SingleInstancePolicyTests.swift
+++ b/CandelaKit/Tests/CandelaKitTests/SingleInstancePolicyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import CandelaKit
@@ -47,4 +48,69 @@ struct SingleInstancePolicyTests {
   @Test func ourOwnPidIsExcludedEvenWhenItAppearsTwice() {
     #expect(decide([own(), own(path: nil)]) == .proceed)
   }
+  @Test func simultaneousCopiesChooseTheSameSurvivor() {
+    let copies = [
+      SingleInstancePolicy.Instance(processIdentifier: 7, bundlePath: "/Applications/Candela.app"),
+      SingleInstancePolicy.Instance(processIdentifier: 42, bundlePath: "/tmp/Candela.app"),
+    ]
+    let decisions = copies.map { copy in
+      SingleInstancePolicy.decide(running: copies, ownProcessIdentifier: copy.processIdentifier)
+    }
+    #expect(decisions.filter { $0 == .proceed }.count == 1)
+    #expect(decisions[0] == .proceed)
+    #expect(decisions[1] == .terminate(runningBundlePath: "/Applications/Candela.app"))
+  }
+
+  @Test(arguments: [false, true])
+  func theEarlierLaunchSurvivesRegardlessOfListOrderOrPID(reverse: Bool) {
+    let older = SingleInstancePolicy.Instance(processIdentifier: 90, bundlePath: "/old/Candela.app",
+      launchDate: Date(timeIntervalSince1970: 100))
+    let newer = SingleInstancePolicy.Instance(processIdentifier: 7, bundlePath: "/new/Candela.app",
+      launchDate: Date(timeIntervalSince1970: 101))
+    let copies = reverse ? [newer, older] : [older, newer]
+    #expect(SingleInstancePolicy.decide(running: copies, ownProcessIdentifier: 90) == .proceed)
+    #expect(SingleInstancePolicy.decide(running: copies, ownProcessIdentifier: 7)
+      == .terminate(runningBundlePath: "/old/Candela.app"))
+  }
+
+  @Test(arguments: [true, false])
+  func equalOrMissingDatesUseOnePIDOrdering(equalDates: Bool) {
+    let date = Date(timeIntervalSince1970: 100)
+    let copies = [
+      SingleInstancePolicy.Instance(processIdentifier: 90, bundlePath: "/third/Candela.app", launchDate: date),
+      SingleInstancePolicy.Instance(processIdentifier: 7, bundlePath: "/first/Candela.app", launchDate: equalDates ? date : nil),
+      SingleInstancePolicy.Instance(processIdentifier: 42, bundlePath: "/second/Candela.app", launchDate: date),
+    ]
+    for order in [copies, Array(copies.reversed()), [copies[1], copies[2], copies[0]]] {
+      let survivors = order.filter {
+        SingleInstancePolicy.decide(running: order, ownProcessIdentifier: $0.processIdentifier) == .proceed
+      }
+      #expect(survivors.map(\.processIdentifier) == [7])
+    }
+  }
+
+  @Test func ownLaunchDateParticipatesEvenBeforeTheProcessIsListed() {
+    let other = SingleInstancePolicy.Instance(processIdentifier: 7, bundlePath: "/other/Candela.app",
+      launchDate: Date(timeIntervalSince1970: 101))
+    #expect(SingleInstancePolicy.decide(running: [other], ownProcessIdentifier: 90,
+      ownLaunchDate: Date(timeIntervalSince1970: 100)) == .proceed)
+    #expect(SingleInstancePolicy.decide(running: [other], ownProcessIdentifier: 90,
+      ownLaunchDate: Date(timeIntervalSince1970: 102)) == .terminate(runningBundlePath: "/other/Candela.app"))
+  }
+
+  @Test func eachCopyUsesTheSameSnapshotWhenItsOwnDateIsMissing() {
+    let snapshot = [
+      SingleInstancePolicy.Instance(processIdentifier: 90, bundlePath: "/old/Candela.app",
+        launchDate: Date(timeIntervalSince1970: 100)),
+      SingleInstancePolicy.Instance(processIdentifier: 7, bundlePath: "/new/Candela.app"),
+    ]
+    let decisions = [
+      SingleInstancePolicy.decide(running: snapshot, ownProcessIdentifier: 90,
+        ownLaunchDate: Date(timeIntervalSince1970: 100)),
+      SingleInstancePolicy.decide(running: snapshot, ownProcessIdentifier: 7,
+        ownLaunchDate: Date(timeIntervalSince1970: 101)),
+    ]
+    #expect(decisions.filter { $0 == .proceed }.count == 1)
+  }
+
 }


### PR DESCRIPTION
## What

Choose one survivor when two visible copies of Candela launch together. The earlier launch continues; equal launch times use process ID. If the shared snapshot lacks any launch date, both copies use process ID for the whole set. Each copy preserves the snapshot's own entry so local date information cannot change its ordering.

## Why

Previously each copy treated the other as the existing app and both could quit. The pure policy now chooses one winner, and the AppKit guard supplies launch dates. Empty-enumeration behavior and filtering of terminated applications are unchanged.

Fixes #98.

## Hardware verification

Tested a signed Release build locally with the built-in display, Dell U2725QE, and MSI MAG connected:

- A single copy opened normally.
- With that copy settled, a second copy logged the correct existing-app path and entered the rejection alert before app initialization.
- Three pairs launched concurrently from two bundle locations. Each left one copy with a working Settings window, while the other logged rejection. Rejected copies were terminated for cleanup after recording the guard decision; the unchanged alert's Quit action was covered in the earlier single-instance verification.
- After both test processes exited, the installed copy relaunched normally. The temporary copy was removed.

The Sparkle delivery path is unchanged. Relaunch after the outgoing process exits was checked; no update package was published or installed through Sparkle for this change.

## Checks

- [x] `make check` passes: 2,637 engine tests and 768 app tests
- [x] Release build, debug-marker check, and signing verification pass
- [x] Regression tests cover both-visible copies, reversed enumeration, launch order versus PID order, equal and missing dates, and a missing own-process entry
- [x] The original two-survivor-decision test failed with zero survivors before the fix; the missing-date review case also failed before correction
- [x] No ticket numbers in source comments, and no em dashes in user-visible text or new comments
