### PR TITLE
Add a guide to arranging displays

### DIFF
--- a/docs/guide/arrangement.md
+++ b/docs/guide/arrangement.md
@@ -1,0 +1,72 @@
+# Arrangement
+
+Arrange displays to match where they sit on your desk, so the pointer crosses
+between the edges you expect. Candela previews each change before saving it.
+
+Open **Settings → Arrangement**, under **Controls** in the sidebar.
+
+## The map
+
+Each tile represents a display in the current desktop layout. Its shape follows
+that display's current size and orientation. Tiles show the display name and
+logical dimensions when there is room; hover over a small tile to read them.
+The strip along the top marks the main display.
+
+Drag a tile toward a neighbour to move it. Tiles snap to nearby edges. Displays
+must touch along an edge and cannot overlap; a refused move returns the tile to
+its previous position and explains why. You can also Tab to a display and use
+the arrow keys to move it.
+
+You need at least two independent desktop tiles to arrange them. Mirrored
+displays share one tile, so two physical displays showing the same desktop do
+not provide two tiles to arrange. With one tile, the map asks you to connect
+another display. An extended virtual display also counts.
+
+## Main Display
+
+Select a tile, then choose **Use as Main Display**. This changes which display
+macOS treats as primary without changing the displays' positions relative to
+one another. The map's menu-bar strip moves to the chosen display.
+
+Main-display selection affects macOS's menu-bar placement. It does not move
+all your existing windows to that display or override each app's window
+placement. See Apple's [guide to arranging multiple displays](https://support.apple.com/guide/mac-help/mchlb5f905a1/mac)
+for the related macOS settings.
+
+The button's caption explains when the selected display is already main or a
+change cannot be made. The section appears when at least two independent desktop tiles are
+available.
+
+## Keep or revert
+
+A move or main-display change opens a confirmation with a countdown. Choose
+**Keep** to accept it or **Revert** to put the displays back. If you cannot reach
+the confirmation, let the countdown run out: Candela attempts to restore the
+previous arrangement automatically.
+
+If macOS could not apply or restore the layout, the confirmation reports what
+happened. Finish an outstanding resolution, rotation, mirroring, or arrangement
+preview before starting another display change.
+
+## Remembering the setup
+
+The **Saved Display Setups** section contains **Remember display rotations and
+positions**. It records a setup for the connected display set and restores it
+at launch or when that set reconnects. Keeping an arrangement or rotation in
+Candela updates the saved setup while remembering is enabled.
+
+Turning remembering off preserves the saved records and stops automatic
+restoration. It does not undo the arrangement currently on screen. See
+[Remembering a display setup](display-setups.md) for the first-use choice,
+identity matching, rotation restoration, and stale-layout notices.
+
+When a display is disconnected, the map follows the displays still present.
+Its return can trigger saved-setup restoration if remembering is enabled.
+Changes made in System Settings while the displays stay connected are left
+alone until a later restore.
+
+## Safe Mode
+
+Hold Shift while launching Candela to enter Safe Mode for that session.
+Arrangement reports that no arrangement will be restored, and your saved
+records are kept. Relaunch without Shift to leave Safe Mode.

--- a/docs/guide/display-setups.md
+++ b/docs/guide/display-setups.md
@@ -1,7 +1,8 @@
 # Remembering a display setup
 
 Candela can remember the positions and rotations of a set of displays and
-restore them when that set reconnects or Candela starts.
+restore them when that set reconnects or Candela starts. For moving displays on
+the map or choosing the main display, see [Arrangement](arrangement.md).
 
 When you first arrange displays in Candela and choose **Keep**, **Remember this
 display setup** is selected in the confirmation. Uncheck it if you only want to

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -13,6 +13,8 @@ hatches for hardware that misbehaves.
 - [Resolutions](resolutions.md). The size list, the HiDPI sizes macOS does not
   list, the in-between sizes Candela renders, and what happens when a size
   fails.
+- [Arrangement](arrangement.md). Moving display tiles, choosing the main display,
+  confirming changes, and finding saved-setup controls.
 - [Saved display setups](display-setups.md). Remembering rotations and positions,
   what happens on reconnect, and when a saved setup cannot be restored.
 - [Diagnostics](diagnostics.md). What the per-display Diagnostics page reports


### PR DESCRIPTION
## What

Add an Arrangement guide covering the map, snapping, keyboard moves, main-display selection, preview confirmation, and Safe Mode. Explain why mirrored displays share one tile and link the saved-setup controls to the existing restoration guide.

Add the page to the guide index and link back from the saved-display-setup guide.

Fixes #6.

## Verification

Documentation only. Reviewed against the current pane and canvas behavior; checked relative links and rendered the guide through GitHub Markdown. No app or hardware behavior changes.
